### PR TITLE
UX: nicer title wrap + author filter links

### DIFF
--- a/site/src/lib/url.ts
+++ b/site/src/lib/url.ts
@@ -1,0 +1,3 @@
+export function q(s: string): string {
+  return encodeURIComponent(s);
+}

--- a/site/src/pages/browse/index.astro
+++ b/site/src/pages/browse/index.astro
@@ -6,13 +6,18 @@ const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
 
-const poems = await loadPoemMetas();
+const poemsAll = await loadPoemMetas();
 
-poems.sort((a, b) => {
+poemsAll.sort((a, b) => {
   const author = a.author.localeCompare(b.author);
   if (author !== 0) return author;
   return a.title.localeCompare(b.title);
 });
+
+const authorFilter = Astro.url.searchParams.get('author');
+const poems = authorFilter
+  ? poemsAll.filter((p) => p.author === authorFilter)
+  : poemsAll;
 ---
 
 <BaseLayout title="Explore poems · Freeverse" description="Explore public-domain poems." currentPath="/browse">
@@ -20,6 +25,12 @@ poems.sort((a, b) => {
     <h1>Explore poems</h1>
     <p class="lede">
       A growing library of public-domain poetry. Click any title to read.
+      {authorFilter ? (
+        <>
+          {' '}Showing only <strong>{authorFilter}</strong>.{' '}
+          <a class="muted" href={`${base}browse/`}>Clear filter</a>.
+        </>
+      ) : null}
     </p>
   </section>
 
@@ -36,7 +47,12 @@ poems.sort((a, b) => {
             <a class="list-title" href={`${base}poem/${p.id}/`}>
               <strong>{p.title}</strong>
             </a>
-            <span class="muted">— {p.author}</span>
+            <span class="muted">
+              —{' '}
+              <a class="muted" href={`${base}browse/?author=${encodeURIComponent(p.author)}`}>
+                {p.author}
+              </a>
+            </span>
           </div>
           <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">
             {p.century}th century

--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -32,7 +32,10 @@ const canonicalPath = `${base}poem/${poem.id}/`;
     <header class="reader-head">
       <h1 class="reader-title">{poem.title}</h1>
       <p class="reader-byline">
-        <span class="muted">by</span> <strong>{poem.author}</strong>
+        <span class="muted">by</span>{' '}
+        <a href={`${base}browse/?author=${encodeURIComponent(poem.author)}`}>
+          <strong>{poem.author}</strong>
+        </a>
         <span class="muted" style="margin: 0 0.35rem;">·</span>
         <a class="muted" href={`${base}browse/`}>Explore poems</a>
       </p>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -474,6 +474,8 @@ main {
 .reader-title {
   margin: 0;
   font-size: clamp(2.05rem, 1.65rem + 1.7vw, 2.75rem);
+  text-wrap: balance;
+  hyphens: auto;
 }
 
 .reader-byline {


### PR DESCRIPTION
- Improve poem title wrapping with text-wrap: balance (prettier line breaks)
- Make author name clickable on poem page → /browse/?author=<name>
- Add simple author filter support to /browse (query param) + author links in catalog
