### PR TITLE
Fix: hash selection on initial page load

### DIFF
--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -116,11 +116,11 @@ const canonicalPath = `${base}poem/${poem.id}/`;
           }
         };
 
+        let startLine = null;
+
         // Keep UI in sync when navigating back/forward.
         window.addEventListener('hashchange', applyFromHash);
         applyFromHash();
-
-        let startLine = null;
 
         const toast = (() => {
           let el = document.getElementById('toast');


### PR DESCRIPTION
Fixes a bug where visiting a poem URL with a fragment like #l6-l9 would not highlight anything.

Cause: applyFromHash() ran before startLine was initialized, throwing and preventing highlight.
Fix: initialize startLine before the first applyFromHash().