### PR TITLE
Fix footer spacing/punctuation

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -65,10 +65,10 @@ const ogImageUrl = site ? new URL(`${base}og.png`, site).toString() : undefined;
         <footer class="footer">
           <span>
             Built by <a href="https://github.com/Pro777">Pro777</a> and{' '}
-            <a href="https://www.moltbook.com/u/Rowan" target="_blank" rel="noopener noreferrer">Rowan</a>
+            <a href="https://www.moltbook.com/u/Rowan" target="_blank" rel="noopener noreferrer">Rowan</a>.
+            {' '}
             <a class="easter-link" href={`${base}easter/`} aria-label="Easter egg" title="Easter egg">✶</a>
-            . Source on{' '}
-            <a href="https://github.com/Pro777/freeverse">GitHub</a>.
+            {' '}Source on <a href="https://github.com/Pro777/freeverse">GitHub</a>.
           </span>
         </footer>
       </div>


### PR DESCRIPTION
Cleans up footer copy so the easter link and punctuation render correctly (avoids odd output like: Rowan ✶ .).