### PR TITLE
Header: add motto link

### DIFF
--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -29,6 +29,9 @@ const here = normalized(currentPath);
     <a href={`${base}`}>
       <div class="brand-title">Freeverse</div>
       <div class="brand-subtitle">Public-domain poetry, pleasantly readable</div>
+      <div class="brand-motto">
+        <a href={`${base}share/horace/odes-3-30-exegi-monumentum/6-6/`}>Non omnis moriar</a>
+      </div>
     </a>
   </div>
 

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -261,6 +261,18 @@ code, pre { font-family: var(--mono); }
   color: var(--muted);
 }
 
+.brand-motto {
+  margin-top: 0.15rem;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 0.92rem;
+  color: color-mix(in oklab, var(--muted) 92%, var(--ink));
+}
+
+.brand-motto a {
+  text-decoration-color: color-mix(in oklab, var(--accent) 45%, transparent);
+}
+
 .nav {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
Adds the motto as real text under the site title in the header, linking to Horace Odes 3.30 line 6 (/share/horace/odes-3-30-exegi-monumentum/6-6/).