### PR TITLE
Easter page: image frames + profile links

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -65,9 +65,7 @@ const ogImageUrl = site ? new URL(`${base}og.png`, site).toString() : undefined;
         <footer class="footer">
           <span>
             Built by <a href="https://github.com/Pro777">Pro777</a> and{' '}
-            <a href="https://www.moltbook.com/u/Rowan" target="_blank" rel="noopener noreferrer">Rowan</a>.
-            {' '}
-            <a class="easter-link" href={`${base}easter/`} aria-label="Easter egg" title="Easter egg">✶</a>
+            <a href="https://www.moltbook.com/u/Rowan" target="_blank" rel="noopener noreferrer">Rowan</a><a class="easter-link" href={`${base}easter/`} aria-label="Easter egg" title="Easter egg">.</a>
             {' '}Source on <a href="https://github.com/Pro777/freeverse">GitHub</a>.
           </span>
         </footer>

--- a/site/src/pages/easter.astro
+++ b/site/src/pages/easter.astro
@@ -11,14 +11,27 @@ const base = import.meta.env.BASE_URL.endsWith("/")
     <h2 style="margin-bottom: 0.6rem;">Easter egg</h2>
     <p class="muted">If you found this, you’re officially allowed to have an opinion.</p>
 
-    <div style="display:flex; gap: 1rem; flex-wrap: wrap; align-items: center; margin-top: 1rem;">
-      <div style="flex: 0 1 220px;">
-        <p class="muted" style="margin: 0 0 0.4rem;">Pro777</p>
-        <img src={`${base}easter/john.jpg`} alt="Pro777" style="width: 220px; max-width: 100%; border-radius: 14px; border: 1px solid var(--card-border);" />
+    <div class="easter-grid" style="margin-top: 1rem;">
+      <div class="easter-profile">
+        <p class="muted" style="margin: 0 0 0.4rem;">
+          <a href="https://github.com/Pro777" target="_blank" rel="noopener noreferrer">Pro777</a>
+          <span class="muted"> · </span>
+          <a href="https://www.moltbook.com/u/Pro777" target="_blank" rel="noopener noreferrer">Moltbook</a>
+        </p>
+        <div class="easter-avatar-frame">
+          <img class="easter-avatar" src={`${base}easter/john.jpg`} alt="Pro777" loading="lazy" />
+        </div>
       </div>
-      <div style="flex: 0 1 220px;">
-        <p class="muted" style="margin: 0 0 0.4rem;">Rowan</p>
-        <img src={`${base}easter/rowan.svg`} alt="Rowan" style="width: 220px; max-width: 100%; border-radius: 14px; border: 1px solid var(--card-border); background: var(--paper);" />
+
+      <div class="easter-profile">
+        <p class="muted" style="margin: 0 0 0.4rem;">
+          <a href="https://github.com/Pro777/rowan" target="_blank" rel="noopener noreferrer">Rowan</a>
+          <span class="muted"> · </span>
+          <a href="https://www.moltbook.com/u/Rowan" target="_blank" rel="noopener noreferrer">Moltbook</a>
+        </p>
+        <div class="easter-avatar-frame easter-avatar-frame--art">
+          <img class="easter-avatar" src={`${base}easter/rowan.svg`} alt="Rowan" loading="lazy" />
+        </div>
       </div>
     </div>
 

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -444,17 +444,17 @@ main {
 
 /* Subtle “curiosity” link to /easter (keep it an easter egg, not a nav item). */
 .easter-link {
-  display: inline-block;
-  margin: 0 0.25rem;
-  padding: 0 0.1rem;
-  opacity: 0.45;
+  display: inline;
+  margin: 0;
+  padding: 0;
+  opacity: 0.25;
   text-decoration: none;
   text-decoration-color: transparent;
   text-underline-offset: 0.2em;
 }
 
 .easter-link:hover {
-  opacity: 0.95;
+  opacity: 0.9;
   text-decoration: underline;
   text-decoration-color: color-mix(in oklab, var(--accent) 45%, transparent);
 }
@@ -464,6 +464,39 @@ main {
   outline: 2px solid color-mix(in oklab, var(--accent) 55%, transparent);
   outline-offset: 3px;
   border-radius: 6px;
+}
+
+/* Easter page */
+.easter-grid {
+  display: flex;
+  gap: 1.2rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.easter-profile {
+  flex: 0 1 320px;
+}
+
+.easter-avatar-frame {
+  background: color-mix(in oklab, var(--paper) 88%, transparent);
+  border: 1px solid var(--card-border);
+  border-radius: calc(var(--radius) + 4px);
+  padding: 0.65rem;
+  box-shadow: var(--shadow);
+}
+
+.easter-avatar-frame--art {
+  background: color-mix(in oklab, var(--preview-bg) 65%, var(--paper));
+}
+
+.easter-avatar {
+  display: block;
+  width: 100%;
+  max-width: 320px;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: calc(var(--radius) + 2px);
 }
 
 .list-title {


### PR DESCRIPTION
- Style Easter images as framed cards (like the mock)
- Link names to GitHub + Moltbook profiles
- Hide the easter link as a subtle punctuation mark in the footer