### PR TITLE
Header: motto links to poem

### DIFF
--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -30,7 +30,7 @@ const here = normalized(currentPath);
       <div class="brand-title">Freeverse</div>
       <div class="brand-subtitle">Public-domain poetry, pleasantly readable</div>
       <div class="brand-motto">
-        <a href={`${base}share/horace/odes-3-30-exegi-monumentum/6-6/`}>Non omnis moriar</a>
+        <a href={`${base}poem/horace/odes-3-30-exegi-monumentum/#l6-l6`}>Non omnis moriar</a>
       </div>
     </a>
   </div>


### PR DESCRIPTION
Change the header motto link to the poem page (highlight line 6) instead of the share URL.