### PR TITLE
[infra] GitHub-native issue workflow baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+---
+name: Bug
+about: Report a defect
+title: "[bug] "
+labels: ["bug"]
+assignees: []
+---
+
+## Description
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+## Environment

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,15 @@
+---
+name: Feature
+about: Propose a new feature
+title: "[feature] "
+labels: ["feature"]
+assignees: []
+---
+
+## Summary
+
+## Why
+
+## Acceptance Criteria
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/infra.md
+++ b/.github/ISSUE_TEMPLATE/infra.md
@@ -1,0 +1,15 @@
+---
+name: Infra
+about: Infrastructure and tooling work
+title: "[infra] "
+labels: ["infra"]
+assignees: []
+---
+
+## Summary
+
+## Impact
+
+## Rollout / Verification
+
+- [ ]

--- a/.github/ISSUE_TEMPLATE/research.md
+++ b/.github/ISSUE_TEMPLATE/research.md
@@ -1,0 +1,13 @@
+---
+name: Research
+about: Explore and document findings
+title: "[research] "
+labels: ["research"]
+assignees: []
+---
+
+## Question
+
+## Scope
+
+## Deliverable

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,12 @@
 - [ ] Metadata updated (`meta/*.yml`) as needed
 - [ ] `npm run build` (in `site/`) passes
 - [ ] GitHub Pages preview looks sane
+
+## Linked Issue
+
+Closes #
+
+## Execution Lane
+
+- [ ] Rowan-den
+- [ ] BLD


### PR DESCRIPTION
Closes #31\n\nAdds issue templates (feature/research/infra/bug), disables blank issues, and updates PR template with execution lane checkboxes.