### PR TITLE
Wave 2: Emily Dickinson corpus expansion

### DIFF
--- a/meta/emily-dickinson/a-bird-came-down-the-walk.yml
+++ b/meta/emily-dickinson/a-bird-came-down-the-walk.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/a-bird-came-down-the-walk"
+slug: "a-bird-came-down-the-walk"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "A bird came down the walk:"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/a-bird-came-down-the-walk.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/a-death-blow-is-a-life-blow-to-some.yml
+++ b/meta/emily-dickinson/a-death-blow-is-a-life-blow-to-some.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/a-death-blow-is-a-life-blow-to-some"
+slug: "a-death-blow-is-a-life-blow-to-some"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "A death-blow is a life-blow to some"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/a-death-blow-is-a-life-blow-to-some.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/a-narrow-fellow-in-the-grass.yml
+++ b/meta/emily-dickinson/a-narrow-fellow-in-the-grass.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/a-narrow-fellow-in-the-grass"
+slug: "a-narrow-fellow-in-the-grass"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "A narrow fellow in the grass"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/a-narrow-fellow-in-the-grass.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/a-precious-mouldering-pleasure-t-is.yml
+++ b/meta/emily-dickinson/a-precious-mouldering-pleasure-t-is.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/a-precious-mouldering-pleasure-t-is"
+slug: "a-precious-mouldering-pleasure-t-is"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "A precious, mouldering pleasure 't is"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/a-precious-mouldering-pleasure-t-is.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/a-route-of-evanescence.yml
+++ b/meta/emily-dickinson/a-route-of-evanescence.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/a-route-of-evanescence"
+slug: "a-route-of-evanescence"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "A route of evanescence"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/a-route-of-evanescence.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/a-wounded-deer-leaps-highest.yml
+++ b/meta/emily-dickinson/a-wounded-deer-leaps-highest.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/a-wounded-deer-leaps-highest"
+slug: "a-wounded-deer-leaps-highest"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "A wounded deer leaps highest,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/a-wounded-deer-leaps-highest.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/apparently-with-no-surprise.yml
+++ b/meta/emily-dickinson/apparently-with-no-surprise.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/apparently-with-no-surprise"
+slug: "apparently-with-no-surprise"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Apparently with no surprise"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/apparently-with-no-surprise.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/as-imperceptibly-as-grief.yml
+++ b/meta/emily-dickinson/as-imperceptibly-as-grief.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/as-imperceptibly-as-grief"
+slug: "as-imperceptibly-as-grief"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "As imperceptibly as grief"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/as-imperceptibly-as-grief.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/glee-the-great-storm-is-over.yml
+++ b/meta/emily-dickinson/glee-the-great-storm-is-over.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/glee-the-great-storm-is-over"
+slug: "glee-the-great-storm-is-over"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Glee! The great storm is over!"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/glee-the-great-storm-is-over.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/heart-we-will-forget-him.yml
+++ b/meta/emily-dickinson/heart-we-will-forget-him.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/heart-we-will-forget-him"
+slug: "heart-we-will-forget-him"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Heart, we will forget him!"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/heart-we-will-forget-him.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/hope-is-the-thing-with-feathers.yml
+++ b/meta/emily-dickinson/hope-is-the-thing-with-feathers.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/hope-is-the-thing-with-feathers"
+slug: "hope-is-the-thing-with-feathers"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Hope is the thing with feathers"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/hope-is-the-thing-with-feathers.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-asked-no-other-thing.yml
+++ b/meta/emily-dickinson/i-asked-no-other-thing.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-asked-no-other-thing"
+slug: "i-asked-no-other-thing"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I asked no other thing,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-asked-no-other-thing.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-cannot-live-with-you.yml
+++ b/meta/emily-dickinson/i-cannot-live-with-you.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-cannot-live-with-you"
+slug: "i-cannot-live-with-you"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I cannot live with you,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-cannot-live-with-you.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-died-for-beauty-but-was-scarce.yml
+++ b/meta/emily-dickinson/i-died-for-beauty-but-was-scarce.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-died-for-beauty-but-was-scarce"
+slug: "i-died-for-beauty-but-was-scarce"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I died for beauty, but was scarce"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-died-for-beauty-but-was-scarce.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-dreaded-that-first-robin-so.yml
+++ b/meta/emily-dickinson/i-dreaded-that-first-robin-so.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-dreaded-that-first-robin-so"
+slug: "i-dreaded-that-first-robin-so"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I dreaded that first robin so,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-dreaded-that-first-robin-so.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-felt-a-funeral-in-my-brain.yml
+++ b/meta/emily-dickinson/i-felt-a-funeral-in-my-brain.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-felt-a-funeral-in-my-brain"
+slug: "i-felt-a-funeral-in-my-brain"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I felt a funeral in my brain,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-felt-a-funeral-in-my-brain.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-gave-myself-to-him.yml
+++ b/meta/emily-dickinson/i-gave-myself-to-him.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-gave-myself-to-him"
+slug: "i-gave-myself-to-him"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I gave myself to him,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-gave-myself-to-him.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-had-been-hungry-all-the-years.yml
+++ b/meta/emily-dickinson/i-had-been-hungry-all-the-years.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-had-been-hungry-all-the-years"
+slug: "i-had-been-hungry-all-the-years"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I had been hungry all the years;"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-had-been-hungry-all-the-years.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-heard-a-fly-buzz-when-i-died.yml
+++ b/meta/emily-dickinson/i-heard-a-fly-buzz-when-i-died.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-heard-a-fly-buzz-when-i-died"
+slug: "i-heard-a-fly-buzz-when-i-died"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I heard a fly buzz when I died;"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-heard-a-fly-buzz-when-i-died.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-know-some-lonely-houses-off-the-road.yml
+++ b/meta/emily-dickinson/i-know-some-lonely-houses-off-the-road.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-know-some-lonely-houses-off-the-road"
+slug: "i-know-some-lonely-houses-off-the-road"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I know some lonely houses off the road"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-know-some-lonely-houses-off-the-road.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-know-that-he-exists.yml
+++ b/meta/emily-dickinson/i-know-that-he-exists.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-know-that-he-exists"
+slug: "i-know-that-he-exists"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I know that he exists"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-know-that-he-exists.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-never-saw-a-moor.yml
+++ b/meta/emily-dickinson/i-never-saw-a-moor.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-never-saw-a-moor"
+slug: "i-never-saw-a-moor"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I never saw a moor,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-never-saw-a-moor.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-reason-earth-is-short.yml
+++ b/meta/emily-dickinson/i-reason-earth-is-short.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-reason-earth-is-short"
+slug: "i-reason-earth-is-short"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I reason, earth is short,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-reason-earth-is-short.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/i-taste-a-liquor-never-brewed.yml
+++ b/meta/emily-dickinson/i-taste-a-liquor-never-brewed.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/i-taste-a-liquor-never-brewed"
+slug: "i-taste-a-liquor-never-brewed"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I taste a liquor never brewed,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/i-taste-a-liquor-never-brewed.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/if-i-can-stop-one-heart-from-breaking.yml
+++ b/meta/emily-dickinson/if-i-can-stop-one-heart-from-breaking.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/if-i-can-stop-one-heart-from-breaking"
+slug: "if-i-can-stop-one-heart-from-breaking"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "If I can stop one heart from breaking,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/if-i-can-stop-one-heart-from-breaking.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/im-ceded-ive-stopped-being-theirs.yml
+++ b/meta/emily-dickinson/im-ceded-ive-stopped-being-theirs.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/im-ceded-ive-stopped-being-theirs"
+slug: "im-ceded-ive-stopped-being-theirs"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I'm ceded, I've stopped being theirs;"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/im-ceded-ive-stopped-being-theirs.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/im-nobody-who-are-you.yml
+++ b/meta/emily-dickinson/im-nobody-who-are-you.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/im-nobody-who-are-you"
+slug: "im-nobody-who-are-you"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I'm nobody!  Who are you?"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/im-nobody-who-are-you.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/im-wife-ive-finished-that.yml
+++ b/meta/emily-dickinson/im-wife-ive-finished-that.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/im-wife-ive-finished-that"
+slug: "im-wife-ive-finished-that"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "I'm wife; I've finished that,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/im-wife-ive-finished-that.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/much-madness-is-divinest-sense.yml
+++ b/meta/emily-dickinson/much-madness-is-divinest-sense.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/much-madness-is-divinest-sense"
+slug: "much-madness-is-divinest-sense"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Much madness is divinest sense"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/much-madness-is-divinest-sense.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/my-life-closed-twice-before-its-close.yml
+++ b/meta/emily-dickinson/my-life-closed-twice-before-its-close.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/my-life-closed-twice-before-its-close"
+slug: "my-life-closed-twice-before-its-close"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "My life closed twice before its close;"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/my-life-closed-twice-before-its-close.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/my-river-runs-to-thee.yml
+++ b/meta/emily-dickinson/my-river-runs-to-thee.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/my-river-runs-to-thee"
+slug: "my-river-runs-to-thee"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "My river runs to thee:"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/my-river-runs-to-thee.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/of-all-the-sounds-despatched-abroad.yml
+++ b/meta/emily-dickinson/of-all-the-sounds-despatched-abroad.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/of-all-the-sounds-despatched-abroad"
+slug: "of-all-the-sounds-despatched-abroad"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Of all the sounds despatched abroad,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/of-all-the-sounds-despatched-abroad.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/our-share-of-night-to-bear.yml
+++ b/meta/emily-dickinson/our-share-of-night-to-bear.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/our-share-of-night-to-bear"
+slug: "our-share-of-night-to-bear"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Our share of night to bear,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/our-share-of-night-to-bear.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/pain-has-an-element-of-blank.yml
+++ b/meta/emily-dickinson/pain-has-an-element-of-blank.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/pain-has-an-element-of-blank"
+slug: "pain-has-an-element-of-blank"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Pain has an element of blank;"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/pain-has-an-element-of-blank.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/safe-in-their-alabaster-chambers.yml
+++ b/meta/emily-dickinson/safe-in-their-alabaster-chambers.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/safe-in-their-alabaster-chambers"
+slug: "safe-in-their-alabaster-chambers"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Safe in their alabaster chambers,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/safe-in-their-alabaster-chambers.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/some-things-that-fly-there-be.yml
+++ b/meta/emily-dickinson/some-things-that-fly-there-be.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/some-things-that-fly-there-be"
+slug: "some-things-that-fly-there-be"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Some things that fly there be, --"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/some-things-that-fly-there-be.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/soul-wilt-thou-toss-again.yml
+++ b/meta/emily-dickinson/soul-wilt-thou-toss-again.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/soul-wilt-thou-toss-again"
+slug: "soul-wilt-thou-toss-again"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Soul, wilt thou toss again?"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/soul-wilt-thou-toss-again.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/success-is-counted-sweetest.yml
+++ b/meta/emily-dickinson/success-is-counted-sweetest.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/success-is-counted-sweetest"
+slug: "success-is-counted-sweetest"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Success is counted sweetest"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/success-is-counted-sweetest.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/t-is-so-much-joy-t-is-so-much-joy.yml
+++ b/meta/emily-dickinson/t-is-so-much-joy-t-is-so-much-joy.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/t-is-so-much-joy-t-is-so-much-joy"
+slug: "t-is-so-much-joy-t-is-so-much-joy"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "'T is so much joy! 'T is so much joy!"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/t-is-so-much-joy-t-is-so-much-joy.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/the-brain-is-wider-than-the-sky.yml
+++ b/meta/emily-dickinson/the-brain-is-wider-than-the-sky.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/the-brain-is-wider-than-the-sky"
+slug: "the-brain-is-wider-than-the-sky"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "The brain is wider than the sky,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/the-brain-is-wider-than-the-sky.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/the-brain-within-its-groove.yml
+++ b/meta/emily-dickinson/the-brain-within-its-groove.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/the-brain-within-its-groove"
+slug: "the-brain-within-its-groove"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "The brain within its groove"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/the-brain-within-its-groove.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/the-grass-so-little-has-to-do.yml
+++ b/meta/emily-dickinson/the-grass-so-little-has-to-do.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/the-grass-so-little-has-to-do"
+slug: "the-grass-so-little-has-to-do"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "The grass so little has to do, --"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/the-grass-so-little-has-to-do.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/the-heart-asks-pleasure-first.yml
+++ b/meta/emily-dickinson/the-heart-asks-pleasure-first.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/the-heart-asks-pleasure-first"
+slug: "the-heart-asks-pleasure-first"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "The heart asks pleasure first,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/the-heart-asks-pleasure-first.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/the-morns-are-meeker-than-they-were.yml
+++ b/meta/emily-dickinson/the-morns-are-meeker-than-they-were.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/the-morns-are-meeker-than-they-were"
+slug: "the-morns-are-meeker-than-they-were"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "The morns are meeker than they were,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/the-morns-are-meeker-than-they-were.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/the-soul-selects-her-own-society.yml
+++ b/meta/emily-dickinson/the-soul-selects-her-own-society.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/the-soul-selects-her-own-society"
+slug: "the-soul-selects-her-own-society"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "The soul selects her own society,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/the-soul-selects-her-own-society.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/theres-a-certain-slant-of-light.yml
+++ b/meta/emily-dickinson/theres-a-certain-slant-of-light.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/theres-a-certain-slant-of-light"
+slug: "theres-a-certain-slant-of-light"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "There's a certain slant of light,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/theres-a-certain-slant-of-light.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/to-fight-aloud-is-very-brave.yml
+++ b/meta/emily-dickinson/to-fight-aloud-is-very-brave.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/to-fight-aloud-is-very-brave"
+slug: "to-fight-aloud-is-very-brave"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "To fight aloud is very brave,"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/to-fight-aloud-is-very-brave.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/to-make-a-prairie-it-takes-a-clover-and-one-bee.yml
+++ b/meta/emily-dickinson/to-make-a-prairie-it-takes-a-clover-and-one-bee.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/to-make-a-prairie-it-takes-a-clover-and-one-bee"
+slug: "to-make-a-prairie-it-takes-a-clover-and-one-bee"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "To make a prairie it takes a clover and one bee, --"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/to-make-a-prairie-it-takes-a-clover-and-one-bee.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/wild-nights-wild-nights.yml
+++ b/meta/emily-dickinson/wild-nights-wild-nights.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/wild-nights-wild-nights"
+slug: "wild-nights-wild-nights"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Wild nights! Wild nights!"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/wild-nights-wild-nights.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/meta/emily-dickinson/within-my-reach.yml
+++ b/meta/emily-dickinson/within-my-reach.yml
@@ -1,0 +1,14 @@
+id: "emily-dickinson/within-my-reach"
+slug: "within-my-reach"
+author: "Emily Dickinson"
+author_slug: "emily-dickinson"
+title: "Within my reach!"
+century: 19
+text_in_repo: true
+text_path: "poems/emily-dickinson/within-my-reach.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/12242"
+public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."
+collection_title: "Poems by Emily Dickinson, Three Series, Complete"
+collection_source_url: "https://www.gutenberg.org/ebooks/12242"
+featured: false

--- a/poems/emily-dickinson/a-bird-came-down-the-walk.txt
+++ b/poems/emily-dickinson/a-bird-came-down-the-walk.txt
@@ -1,0 +1,24 @@
+A bird came down the walk:
+He did not know I saw;
+He bit an angle-worm in halves
+And ate the fellow, raw.
+
+And then he drank a dew
+From a convenient grass,
+And then hopped sidewise to the wall
+To let a beetle pass.
+
+He glanced with rapid eyes
+That hurried all abroad, --
+They looked like frightened beads, I thought;
+He stirred his velvet head
+
+Like one in danger; cautious,
+I offered him a crumb,
+And he unrolled his feathers
+And rowed him softer home
+
+Than oars divide the ocean,
+Too silver for a seam,
+Or butterflies, off banks of noon,
+Leap, splashless, as they swim.

--- a/poems/emily-dickinson/a-death-blow-is-a-life-blow-to-some.txt
+++ b/poems/emily-dickinson/a-death-blow-is-a-life-blow-to-some.txt
@@ -1,0 +1,4 @@
+A death-blow is a life-blow to some
+Who, till they died, did not alive become;
+Who, had they lived, had died, but when
+They died, vitality begun.

--- a/poems/emily-dickinson/a-narrow-fellow-in-the-grass.txt
+++ b/poems/emily-dickinson/a-narrow-fellow-in-the-grass.txt
@@ -1,0 +1,29 @@
+A narrow fellow in the grass
+Occasionally rides;
+You may have met him, -- did you not,
+His notice sudden is.
+
+The grass divides as with a comb,
+A spotted shaft is seen;
+And then it closes at your feet
+And opens further on.
+
+He likes a boggy acre,
+A floor too cool for corn.
+Yet when a child, and barefoot,
+I more than once, at morn,
+
+Have passed, I thought, a whip-lash
+Unbraiding in the sun, --
+When, stooping to secure it,
+It wrinkled, and was gone.
+
+Several of nature's people
+I know, and they know me;
+I feel for them a transport
+Of cordiality;
+
+But never met this fellow,
+Attended or alone,
+Without a tighter breathing,
+And zero at the bone.

--- a/poems/emily-dickinson/a-precious-mouldering-pleasure-t-is.txt
+++ b/poems/emily-dickinson/a-precious-mouldering-pleasure-t-is.txt
@@ -1,0 +1,34 @@
+A precious, mouldering pleasure 't is
+To meet an antique book,
+In just the dress his century wore;
+A privilege, I think,
+
+His venerable hand to take,
+And warming in our own,
+A passage back, or two, to make
+To times when he was young.
+
+His quaint opinions to inspect,
+His knowledge to unfold
+On what concerns our mutual mind,
+The literature of old;
+
+What interested scholars most,
+What competitions ran
+When Plato was a certainty.
+And Sophocles a man;
+
+When Sappho was a living girl,
+And Beatrice wore
+The gown that Dante deified.
+Facts, centuries before,
+
+He traverses familiar,
+As one should come to town
+And tell you all your dreams were true;
+He lived where dreams were sown.
+
+His presence is enchantment,
+You beg him not to go;
+Old volumes shake their vellum heads
+And tantalize, just so.

--- a/poems/emily-dickinson/a-route-of-evanescence.txt
+++ b/poems/emily-dickinson/a-route-of-evanescence.txt
@@ -1,0 +1,8 @@
+A route of evanescence
+With a revolving wheel;
+A resonance of emerald,
+A rush of cochineal;
+And every blossom on the bush
+Adjusts its tumbled head, --
+The mail from Tunis, probably,
+An easy morning's ride.

--- a/poems/emily-dickinson/a-wounded-deer-leaps-highest.txt
+++ b/poems/emily-dickinson/a-wounded-deer-leaps-highest.txt
@@ -1,0 +1,14 @@
+A wounded deer leaps highest,
+I've heard the hunter tell;
+'T is but the ecstasy of death,
+And then the brake is still.
+
+The smitten rock that gushes,
+The trampled steel that springs;
+A cheek is always redder
+Just where the hectic stings!
+
+Mirth is the mail of anguish,
+In which it cautions arm,
+Lest anybody spy the blood
+And "You're hurt" exclaim!

--- a/poems/emily-dickinson/apparently-with-no-surprise.txt
+++ b/poems/emily-dickinson/apparently-with-no-surprise.txt
@@ -1,0 +1,8 @@
+Apparently with no surprise
+To any happy flower,
+The frost beheads it at its play
+In accidental power.
+The blond assassin passes on,
+The sun proceeds unmoved
+To measure off another day
+For an approving God.

--- a/poems/emily-dickinson/as-imperceptibly-as-grief.txt
+++ b/poems/emily-dickinson/as-imperceptibly-as-grief.txt
@@ -1,0 +1,19 @@
+As imperceptibly as grief
+The summer lapsed away, --
+Too imperceptible, at last,
+To seem like perfidy.
+
+A quietness distilled,
+As twilight long begun,
+Or Nature, spending with herself
+Sequestered afternoon.
+
+The dusk drew earlier in,
+The morning foreign shone, --
+A courteous, yet harrowing grace,
+As guest who would be gone.
+
+And thus, without a wing,
+Or service of a keel,
+Our summer made her light escape
+Into the beautiful.

--- a/poems/emily-dickinson/glee-the-great-storm-is-over.txt
+++ b/poems/emily-dickinson/glee-the-great-storm-is-over.txt
@@ -1,0 +1,19 @@
+Glee! The great storm is over!
+Four have recovered the land;
+Forty gone down together
+Into the boiling sand.
+
+Ring, for the scant salvation!
+Toll, for the bonnie souls, --
+Neighbor and friend and bridegroom,
+Spinning upon the shoals!
+
+How they will tell the shipwreck
+When winter shakes the door,
+Till the children ask, "But the forty?
+Did they come back no more?"
+
+Then a silence suffuses the story,
+And a softness the teller's eye;
+And the children no further question,
+And only the waves reply.

--- a/poems/emily-dickinson/heart-we-will-forget-him.txt
+++ b/poems/emily-dickinson/heart-we-will-forget-him.txt
@@ -1,0 +1,9 @@
+Heart, we will forget him!
+  You and I, to-night!
+You may forget the warmth he gave,
+  I will forget the light.
+
+When you have done, pray tell me,
+  That I my thoughts may dim;
+Haste! lest while you're lagging,
+  I may remember him!

--- a/poems/emily-dickinson/hope-is-the-thing-with-feathers.txt
+++ b/poems/emily-dickinson/hope-is-the-thing-with-feathers.txt
@@ -1,0 +1,14 @@
+Hope is the thing with feathers
+That perches in the soul,
+And sings the tune without the words,
+And never stops at all,
+
+And sweetest in the gale is heard;
+And sore must be the storm
+That could abash the little bird
+That kept so many warm.
+
+I 've heard it in the chillest land,
+And on the strangest sea;
+Yet, never, in extremity,
+It asked a crumb of me.

--- a/poems/emily-dickinson/i-asked-no-other-thing.txt
+++ b/poems/emily-dickinson/i-asked-no-other-thing.txt
@@ -1,0 +1,9 @@
+I asked no other thing,
+No other was denied.
+I offered Being for it;
+The mighty merchant smiled.
+
+Brazil? He twirled a button,
+Without a glance my way:
+"But, madam, is there nothing else
+That we can show to-day?"

--- a/poems/emily-dickinson/i-cannot-live-with-you.txt
+++ b/poems/emily-dickinson/i-cannot-live-with-you.txt
@@ -1,0 +1,62 @@
+I cannot live with you,
+It would be life,
+And life is over there
+Behind the shelf
+
+The sexton keeps the key to,
+Putting up
+Our life, his porcelain,
+Like a cup
+
+Discarded of the housewife,
+Quaint or broken;
+A newer Sevres pleases,
+Old ones crack.
+
+I could not die with you,
+For one must wait
+To shut the other's gaze down, --
+You could not.
+
+And I, could I stand by
+And see you freeze,
+Without my right of frost,
+Death's privilege?
+
+Nor could I rise with you,
+Because your face
+Would put out Jesus',
+That new grace
+
+Glow plain and foreign
+On my homesick eye,
+Except that you, than he
+Shone closer by.
+
+They'd judge us -- how?
+For you served Heaven, you know,
+Or sought to;
+I could not,
+
+Because you saturated sight,
+And I had no more eyes
+For sordid excellence
+As Paradise.
+
+And were you lost, I would be,
+Though my name
+Rang loudest
+On the heavenly fame.
+
+And were you saved,
+And I condemned to be
+Where you were not,
+That self were hell to me.
+
+So we must keep apart,
+You there, I here,
+With just the door ajar
+That oceans are,
+And prayer,
+And that pale sustenance,
+Despair!

--- a/poems/emily-dickinson/i-died-for-beauty-but-was-scarce.txt
+++ b/poems/emily-dickinson/i-died-for-beauty-but-was-scarce.txt
@@ -1,0 +1,14 @@
+I died for beauty, but was scarce
+Adjusted in the tomb,
+When one who died for truth was lain
+In an adjoining room.
+
+He questioned softly why I failed?
+"For beauty," I replied.
+"And I for truth, -- the two are one;
+We brethren are," he said.
+
+And so, as kinsmen met a night,
+We talked between the rooms,
+Until the moss had reached our lips,
+And covered up our names.

--- a/poems/emily-dickinson/i-dreaded-that-first-robin-so.txt
+++ b/poems/emily-dickinson/i-dreaded-that-first-robin-so.txt
@@ -1,0 +1,34 @@
+I dreaded that first robin so,
+But he is mastered now,
+And I 'm accustomed to him grown, --
+He hurts a little, though.
+
+I thought if I could only live
+Till that first shout got by,
+Not all pianos in the woods
+Had power to mangle me.
+
+I dared not meet the daffodils,
+For fear their yellow gown
+Would pierce me with a fashion
+So foreign to my own.
+
+I wished the grass would hurry,
+So when 't was time to see,
+He 'd be too tall, the tallest one
+Could stretch to look at me.
+
+I could not bear the bees should come,
+I wished they 'd stay away
+In those dim countries where they go:
+What word had they for me?
+
+They 're here, though; not a creature failed,
+No blossom stayed away
+In gentle deference to me,
+The Queen of Calvary.
+
+Each one salutes me as he goes,
+And I my childish plumes
+Lift, in bereaved acknowledgment
+Of their unthinking drums.

--- a/poems/emily-dickinson/i-felt-a-funeral-in-my-brain.txt
+++ b/poems/emily-dickinson/i-felt-a-funeral-in-my-brain.txt
@@ -1,0 +1,19 @@
+I felt a funeral in my brain,
+  And mourners, to and fro,
+Kept treading, treading, till it seemed
+  That sense was breaking through.
+
+And when they all were seated,
+  A service like a drum
+Kept beating, beating, till I thought
+  My mind was going numb.
+
+And then I heard them lift a box,
+  And creak across my soul
+With those same boots of lead, again.
+  Then space began to toll
+
+As all the heavens were a bell,
+  And Being but an ear,
+And I and silence some strange race,
+  Wrecked, solitary, here.

--- a/poems/emily-dickinson/i-gave-myself-to-him.txt
+++ b/poems/emily-dickinson/i-gave-myself-to-him.txt
@@ -1,0 +1,19 @@
+I gave myself to him,
+And took himself for pay.
+The solemn contract of a life
+Was ratified this way.
+
+The wealth might disappoint,
+Myself a poorer prove
+Than this great purchaser suspect,
+The daily own of Love
+
+Depreciate the vision;
+But, till the merchant buy,
+Still fable, in the isles of spice,
+The subtle cargoes lie.
+
+At least, 't is mutual risk, --
+Some found it mutual gain;
+Sweet debt of Life, -- each night to owe,
+Insolvent, every noon.

--- a/poems/emily-dickinson/i-had-been-hungry-all-the-years.txt
+++ b/poems/emily-dickinson/i-had-been-hungry-all-the-years.txt
@@ -1,0 +1,24 @@
+I had been hungry all the years;
+My noon had come, to dine;
+I, trembling, drew the table near,
+And touched the curious wine.
+
+'T was this on tables I had seen,
+When turning, hungry, lone,
+I looked in windows, for the wealth
+I could not hope to own.
+
+I did not know the ample bread,
+'T was so unlike the crumb
+The birds and I had often shared
+In Nature's dining-room.
+
+The plenty hurt me, 't was so new, --
+Myself felt ill and odd,
+As berry of a mountain bush
+Transplanted to the road.
+
+Nor was I hungry; so I found
+That hunger was a way
+Of persons outside windows,
+The entering takes away.

--- a/poems/emily-dickinson/i-heard-a-fly-buzz-when-i-died.txt
+++ b/poems/emily-dickinson/i-heard-a-fly-buzz-when-i-died.txt
@@ -1,0 +1,19 @@
+I heard a fly buzz when I died;
+  The stillness round my form
+Was like the stillness in the air
+  Between the heaves of storm.
+
+The eyes beside had wrung them dry,
+  And breaths were gathering sure
+For that last onset, when the king
+  Be witnessed in his power.
+
+I willed my keepsakes, signed away
+  What portion of me I
+Could make assignable, -- and then
+  There interposed a fly,
+
+With blue, uncertain, stumbling buzz,
+  Between the light and me;
+And then the windows failed, and then
+  I could not see to see.

--- a/poems/emily-dickinson/i-know-some-lonely-houses-off-the-road.txt
+++ b/poems/emily-dickinson/i-know-some-lonely-houses-off-the-road.txt
@@ -1,0 +1,44 @@
+I know some lonely houses off the road
+A robber 'd like the look of, --
+Wooden barred,
+And windows hanging low,
+Inviting to
+A portico,
+Where two could creep:
+One hand the tools,
+The other peep
+To make sure all's asleep.
+Old-fashioned eyes,
+Not easy to surprise!
+
+How orderly the kitchen 'd look by night,
+With just a clock, --
+But they could gag the tick,
+And mice won't bark;
+And so the walls don't tell,
+None will.
+
+A pair of spectacles ajar just stir --
+An almanac's aware.
+Was it the mat winked,
+Or a nervous star?
+The moon slides down the stair
+To see who's there.
+
+There's plunder, -- where?
+Tankard, or spoon,
+Earring, or stone,
+A watch, some ancient brooch
+To match the grandmamma,
+Staid sleeping there.
+
+Day rattles, too,
+Stealth's slow;
+The sun has got as far
+As the third sycamore.
+Screams chanticleer,
+"Who's there?"
+And echoes, trains away,
+Sneer -- "Where?"
+While the old couple, just astir,
+Fancy the sunrise left the door ajar!

--- a/poems/emily-dickinson/i-know-that-he-exists.txt
+++ b/poems/emily-dickinson/i-know-that-he-exists.txt
@@ -1,0 +1,19 @@
+I know that he exists
+Somewhere, in silence.
+He has hid his rare life
+From our gross eyes.
+
+'T is an instant's play,
+'T is a fond ambush,
+Just to make bliss
+Earn her own surprise!
+
+But should the play
+Prove piercing earnest,
+Should the glee glaze
+In death's stiff stare,
+
+Would not the fun
+Look too expensive?
+Would not the jest
+Have crawled too far?

--- a/poems/emily-dickinson/i-never-saw-a-moor.txt
+++ b/poems/emily-dickinson/i-never-saw-a-moor.txt
@@ -1,0 +1,9 @@
+I never saw a moor,
+I never saw the sea;
+Yet know I how the heather looks,
+And what a wave must be.
+
+I never spoke with God,
+Nor visited in heaven;
+Yet certain am I of the spot
+As if the chart were given.

--- a/poems/emily-dickinson/i-reason-earth-is-short.txt
+++ b/poems/emily-dickinson/i-reason-earth-is-short.txt
@@ -1,0 +1,14 @@
+I reason, earth is short,
+And anguish absolute,
+And many hurt;
+But what of that?
+
+I reason, we could die:
+The best vitality
+Cannot excel decay;
+But what of that?
+
+I reason that in heaven
+Somehow, it will be even,
+Some new equation given;
+But what of that?

--- a/poems/emily-dickinson/i-taste-a-liquor-never-brewed.txt
+++ b/poems/emily-dickinson/i-taste-a-liquor-never-brewed.txt
@@ -1,0 +1,19 @@
+I taste a liquor never brewed,
+From tankards scooped in pearl;
+Not all the vats upon the Rhine
+Yield such an alcohol!
+
+Inebriate of air am I,
+And debauchee of dew,
+Reeling, through endless summer days,
+From inns of molten blue.
+
+When landlords turn the drunken bee
+Out of the foxglove's door,
+When butterflies renounce their drams,
+I shall but drink the more!
+
+Till seraphs swing their snowy hats,
+And saints to windows run,
+To see the little tippler
+Leaning against the sun!

--- a/poems/emily-dickinson/if-i-can-stop-one-heart-from-breaking.txt
+++ b/poems/emily-dickinson/if-i-can-stop-one-heart-from-breaking.txt
@@ -1,0 +1,7 @@
+If I can stop one heart from breaking,
+I shall not live in vain;
+If I can ease one life the aching,
+Or cool one pain,
+Or help one fainting robin
+Unto his nest again,
+I shall not live in vain.

--- a/poems/emily-dickinson/im-ceded-ive-stopped-being-theirs.txt
+++ b/poems/emily-dickinson/im-ceded-ive-stopped-being-theirs.txt
@@ -1,0 +1,21 @@
+I'm ceded, I've stopped being theirs;
+The name they dropped upon my face
+With water, in the country church,
+Is finished using now,
+And they can put it with my dolls,
+My childhood, and the string of spools
+I've finished threading too.
+
+Baptized before without the choice,
+But this time consciously, of grace
+Unto supremest name,
+Called to my full, the crescent dropped,
+Existence's whole arc filled up
+With one small diadem.
+
+My second rank, too small the first,
+Crowned, crowing on my father's breast,
+A half unconscious queen;
+But this time, adequate, erect,
+With will to choose or to reject.
+And I choose -- just a throne.

--- a/poems/emily-dickinson/im-nobody-who-are-you.txt
+++ b/poems/emily-dickinson/im-nobody-who-are-you.txt
@@ -1,0 +1,9 @@
+I'm nobody!  Who are you?
+Are you nobody, too?
+Then there 's a pair of us -- don't tell!
+They 'd banish us, you know.
+
+How dreary to be somebody!
+How public, like a frog
+To tell your name the livelong day
+To an admiring bog!

--- a/poems/emily-dickinson/im-wife-ive-finished-that.txt
+++ b/poems/emily-dickinson/im-wife-ive-finished-that.txt
@@ -1,0 +1,14 @@
+I'm wife; I've finished that,
+That other state;
+I'm Czar, I'm woman now:
+It's safer so.
+
+How odd the girl's life looks
+Behind this soft eclipse!
+I think that earth seems so
+To those in heaven now.
+
+This being comfort, then
+That other kind was pain;
+But why compare?
+I'm wife! stop there!

--- a/poems/emily-dickinson/much-madness-is-divinest-sense.txt
+++ b/poems/emily-dickinson/much-madness-is-divinest-sense.txt
@@ -1,0 +1,8 @@
+Much madness is divinest sense
+To a discerning eye;
+Much sense the starkest madness.
+'T is the majority
+In this, as all, prevails.
+Assent, and you are sane;
+Demur, -- you're straightway dangerous,
+And handled with a chain.

--- a/poems/emily-dickinson/my-life-closed-twice-before-its-close.txt
+++ b/poems/emily-dickinson/my-life-closed-twice-before-its-close.txt
@@ -1,0 +1,9 @@
+My life closed twice before its close;
+  It yet remains to see
+If Immortality unveil
+  A third event to me,
+
+So huge, so hopeless to conceive,
+  As these that twice befell.
+Parting is all we know of heaven,
+  And all we need of hell.

--- a/poems/emily-dickinson/my-river-runs-to-thee.txt
+++ b/poems/emily-dickinson/my-river-runs-to-thee.txt
@@ -1,0 +1,11 @@
+My river runs to thee:
+Blue sea, wilt welcome me?
+
+My river waits reply.
+Oh sea, look graciously!
+
+I'll fetch thee brooks
+From spotted nooks, --
+
+Say, sea,
+Take me!

--- a/poems/emily-dickinson/of-all-the-sounds-despatched-abroad.txt
+++ b/poems/emily-dickinson/of-all-the-sounds-despatched-abroad.txt
@@ -1,0 +1,25 @@
+Of all the sounds despatched abroad,
+There's not a charge to me
+Like that old measure in the boughs,
+That phraseless melody
+
+The wind does, working like a hand
+Whose fingers brush the sky,
+Then quiver down, with tufts of tune
+Permitted gods and me.
+
+When winds go round and round in bands,
+And thrum upon the door,
+And birds take places overhead,
+To bear them orchestra,
+
+I crave him grace, of summer boughs,
+If such an outcast be,
+He never heard that fleshless chant
+Rise solemn in the tree,
+
+As if some caravan of sound
+On deserts, in the sky,
+Had broken rank,
+Then knit, and passed
+In seamless company.

--- a/poems/emily-dickinson/our-share-of-night-to-bear.txt
+++ b/poems/emily-dickinson/our-share-of-night-to-bear.txt
@@ -1,0 +1,9 @@
+Our share of night to bear,
+Our share of morning,
+Our blank in bliss to fill,
+Our blank in scorning.
+
+Here a star, and there a star,
+Some lose their way.
+Here a mist, and there a mist,
+Afterwards -- day!

--- a/poems/emily-dickinson/pain-has-an-element-of-blank.txt
+++ b/poems/emily-dickinson/pain-has-an-element-of-blank.txt
@@ -1,0 +1,9 @@
+Pain has an element of blank;
+It cannot recollect
+When it began, or if there were
+A day when it was not.
+
+It has no future but itself,
+Its infinite realms contain
+Its past, enlightened to perceive
+New periods of pain.

--- a/poems/emily-dickinson/safe-in-their-alabaster-chambers.txt
+++ b/poems/emily-dickinson/safe-in-their-alabaster-chambers.txt
@@ -1,0 +1,14 @@
+Safe in their alabaster chambers,
+Untouched by morning and untouched by noon,
+Sleep the meek members of the resurrection,
+Rafter of satin, and roof of stone.
+
+Light laughs the breeze in her castle of sunshine;
+Babbles the bee in a stolid ear;
+Pipe the sweet birds in ignorant cadence, --
+Ah, what sagacity perished here!
+
+Grand go the years in the crescent above them;
+Worlds scoop their arcs, and firmaments row,
+Diadems drop and Doges surrender,
+Soundless as dots on a disk of snow.

--- a/poems/emily-dickinson/some-things-that-fly-there-be.txt
+++ b/poems/emily-dickinson/some-things-that-fly-there-be.txt
@@ -1,0 +1,11 @@
+Some things that fly there be, --
+Birds, hours, the bumble-bee:
+Of these no elegy.
+
+Some things that stay there be, --
+Grief, hills, eternity:
+Nor this behooveth me.
+
+There are, that resting, rise.
+Can I expound the skies?
+How still the riddle lies!

--- a/poems/emily-dickinson/soul-wilt-thou-toss-again.txt
+++ b/poems/emily-dickinson/soul-wilt-thou-toss-again.txt
@@ -1,0 +1,9 @@
+Soul, wilt thou toss again?
+By just such a hazard
+Hundreds have lost, indeed,
+But tens have won an all.
+
+Angels' breathless ballot
+Lingers to record thee;
+Imps in eager caucus
+Raffle for my soul.

--- a/poems/emily-dickinson/success-is-counted-sweetest.txt
+++ b/poems/emily-dickinson/success-is-counted-sweetest.txt
@@ -1,0 +1,14 @@
+Success is counted sweetest
+By those who ne'er succeed.
+To comprehend a nectar
+Requires sorest need.
+
+Not one of all the purple host
+Who took the flag to-day
+Can tell the definition,
+So clear, of victory,
+
+As he, defeated, dying,
+On whose forbidden ear
+The distant strains of triumph
+Break, agonized and clear!

--- a/poems/emily-dickinson/t-is-so-much-joy-t-is-so-much-joy.txt
+++ b/poems/emily-dickinson/t-is-so-much-joy-t-is-so-much-joy.txt
@@ -1,0 +1,20 @@
+'T is so much joy! 'T is so much joy!
+If I should fail, what poverty!
+And yet, as poor as I
+Have ventured all upon a throw;
+Have gained! Yes! Hesitated so
+This side the victory!
+
+Life is but life, and death but death!
+Bliss is but bliss, and breath but breath!
+And if, indeed, I fail,
+At least to know the worst is sweet.
+Defeat means nothing but defeat,
+No drearier can prevail!
+
+And if I gain, -- oh, gun at sea,
+Oh, bells that in the steeples be,
+At first repeat it slow!
+For heaven is a different thing
+Conjectured, and waked sudden in,
+And might o'erwhelm me so!

--- a/poems/emily-dickinson/the-brain-is-wider-than-the-sky.txt
+++ b/poems/emily-dickinson/the-brain-is-wider-than-the-sky.txt
@@ -1,0 +1,14 @@
+The brain is wider than the sky,
+  For, put them side by side,
+The one the other will include
+  With ease, and you beside.
+
+The brain is deeper than the sea,
+  For, hold them, blue to blue,
+The one the other will absorb,
+  As sponges, buckets do.
+
+The brain is just the weight of God,
+  For, lift them, pound for pound,
+And they will differ, if they do,
+  As syllable from sound.

--- a/poems/emily-dickinson/the-brain-within-its-groove.txt
+++ b/poems/emily-dickinson/the-brain-within-its-groove.txt
@@ -1,0 +1,15 @@
+The brain within its groove
+Runs evenly and true;
+But let a splinter swerve,
+'T were easier for you
+To put the water back
+When floods have slit the hills,
+And scooped a turnpike for themselves,
+And blotted out the mills!
+
+
+
+
+
+
+II. LOVE.

--- a/poems/emily-dickinson/the-grass-so-little-has-to-do.txt
+++ b/poems/emily-dickinson/the-grass-so-little-has-to-do.txt
@@ -1,0 +1,24 @@
+The grass so little has to do, --
+A sphere of simple green,
+With only butterflies to brood,
+And bees to entertain,
+
+And stir all day to pretty tunes
+The breezes fetch along,
+And hold the sunshine in its lap
+And bow to everything;
+
+And thread the dews all night, like pearls,
+And make itself so fine, --
+A duchess were too common
+For such a noticing.
+
+And even when it dies, to pass
+In odors so divine,
+As lowly spices gone to sleep,
+Or amulets of pine.
+
+And then to dwell in sovereign barns,
+And dream the days away, --
+The grass so little has to do,
+I wish I were the hay!

--- a/poems/emily-dickinson/the-heart-asks-pleasure-first.txt
+++ b/poems/emily-dickinson/the-heart-asks-pleasure-first.txt
@@ -1,0 +1,9 @@
+The heart asks pleasure first,
+And then, excuse from pain;
+And then, those little anodynes
+That deaden suffering;
+
+And then, to go to sleep;
+And then, if it should be
+The will of its Inquisitor,
+The liberty to die.

--- a/poems/emily-dickinson/the-morns-are-meeker-than-they-were.txt
+++ b/poems/emily-dickinson/the-morns-are-meeker-than-they-were.txt
@@ -1,0 +1,9 @@
+The morns are meeker than they were,
+The nuts are getting brown;
+The berry's cheek is plumper,
+The rose is out of town.
+
+The maple wears a gayer scarf,
+The field a scarlet gown.
+Lest I should be old-fashioned,
+I'll put a trinket on.

--- a/poems/emily-dickinson/the-soul-selects-her-own-society.txt
+++ b/poems/emily-dickinson/the-soul-selects-her-own-society.txt
@@ -1,0 +1,14 @@
+The soul selects her own society,
+Then shuts the door;
+On her divine majority
+Obtrude no more.
+
+Unmoved, she notes the chariot's pausing
+At her low gate;
+Unmoved, an emperor is kneeling
+Upon her mat.
+
+I've known her from an ample nation
+Choose one;
+Then close the valves of her attention
+Like stone.

--- a/poems/emily-dickinson/theres-a-certain-slant-of-light.txt
+++ b/poems/emily-dickinson/theres-a-certain-slant-of-light.txt
@@ -1,0 +1,26 @@
+There's a certain slant of light,
+On winter afternoons,
+That oppresses, like the weight
+Of cathedral tunes.
+
+Heavenly hurt it gives us;
+We can find no scar,
+But internal difference
+Where the meanings are.
+
+None may teach it anything,
+'T is the seal, despair, --
+An imperial affliction
+Sent us of the air.
+
+When it comes, the landscape listens,
+Shadows hold their breath;
+When it goes, 't is like the distance
+On the look of death.
+
+
+
+
+
+
+IV. TIME AND ETERNITY.

--- a/poems/emily-dickinson/to-fight-aloud-is-very-brave.txt
+++ b/poems/emily-dickinson/to-fight-aloud-is-very-brave.txt
@@ -1,0 +1,14 @@
+To fight aloud is very brave,
+But gallanter, I know,
+Who charge within the bosom,
+The cavalry of woe.
+
+Who win, and nations do not see,
+Who fall, and none observe,
+Whose dying eyes no country
+Regards with patriot love.
+
+We trust, in plumed procession,
+For such the angels go,
+Rank after rank, with even feet
+And uniforms of snow.

--- a/poems/emily-dickinson/to-make-a-prairie-it-takes-a-clover-and-one-bee.txt
+++ b/poems/emily-dickinson/to-make-a-prairie-it-takes-a-clover-and-one-bee.txt
@@ -1,0 +1,5 @@
+To make a prairie it takes a clover and one bee, --
+One clover, and a bee,
+And revery.
+The revery alone will do
+If bees are few.

--- a/poems/emily-dickinson/wild-nights-wild-nights.txt
+++ b/poems/emily-dickinson/wild-nights-wild-nights.txt
@@ -1,0 +1,14 @@
+Wild nights! Wild nights!
+Were I with thee,
+Wild nights should be
+Our luxury!
+
+Futile the winds
+To a heart in port, --
+Done with the compass,
+Done with the chart.
+
+Rowing in Eden!
+Ah! the sea!
+Might I but moor
+To-night in thee!

--- a/poems/emily-dickinson/within-my-reach.txt
+++ b/poems/emily-dickinson/within-my-reach.txt
@@ -1,0 +1,9 @@
+Within my reach!
+I could have touched!
+I might have chanced that way!
+Soft sauntered through the village,
+Sauntered as soft away!
+So unsuspected violets
+Within the fields lie low,
+Too late for striving fingers
+That passed, an hour ago.

--- a/scripts/gutenberg-ingest.mjs
+++ b/scripts/gutenberg-ingest.mjs
@@ -1,114 +1,220 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const DEFAULT_TEXT_URL = "https://www.gutenberg.org/cache/epub/1041/pg1041.txt";
-const SOURCE_URL = "https://www.gutenberg.org/ebooks/1041";
-const AUTHOR = "William Shakespeare";
-const AUTHOR_SLUG = "william-shakespeare";
-const COLLECTION_TITLE = "Shakespeare's Sonnets";
+const DICKINSON_TEXT_URL = "https://www.gutenberg.org/ebooks/12242.txt.utf-8";
+const DICKINSON_SOURCE_URL = "https://www.gutenberg.org/ebooks/12242";
 
-function normalizeText(raw) {
+const TARGET_FIRST_LINES = [
+  "Hope is the thing with feathers",
+  "I'm Nobody! Who are you?",
+  "A Bird came down the Walk",
+  "I heard a Fly buzz — when I died",
+  "Tell all the truth but tell it slant",
+  "Wild nights — Wild nights!",
+  "The Soul selects her own Society",
+  "I felt a Funeral, in my Brain",
+  "Success is counted sweetest",
+  "There's a certain Slant of light",
+  "Because I could not stop for Death",
+  "I dwell in Possibility",
+  "I'm ceded - I've stopped being Theirs",
+  "This is my letter to the World",
+  "Much Madness is divinest Sense",
+  "Pain — has an Element of Blank",
+  "After great pain, a formal feeling comes",
+  "I died for Beauty — but was scarce",
+  "If I can stop one Heart from breaking",
+  "The Brain — is wider than the Sky",
+  "The Brain, within its Groove",
+  "I'm wife — I've finished that",
+  "My life closed twice before its close",
+  "A narrow Fellow in the Grass",
+  "Apparently with no surprise",
+  "A still — Volcano — Life",
+  "I reason, Earth is short",
+  "The Chariot",
+  "I had been hungry, all the Years",
+  "I never saw a Moor",
+  "A Route of Evanescence",
+  "My River runs to thee",
+  "As imperceptibly as Grief",
+  "The Grass so little has to do",
+  "I cannot live with You",
+  "I gave myself to Him",
+  "Heart, we will forget him",
+  "I know that He exists",
+  "Parting is all we know of heaven",
+  "A Day! Help! Help! Another Day!",
+  "The morns are meeker than they were",
+  "I taste a liquor never brewed",
+  "He fumbles at your Soul",
+  "Safe in their Alabaster Chambers",
+  "I cannot dance upon my Toes",
+  "A Death-blow is a Life-blow to Some",
+  "Of all the Sounds despatched abroad",
+  "I dreaded that first Robin so",
+  "A little Madness in the Spring",
+  "To make a prairie it takes a clover and one bee",
+];
+
+function normalize(raw) {
   return raw.replace(/\r\n?/g, "\n").replace(/[ \t]+$/gm, "");
 }
 
-function stripGutenbergBoilerplate(raw) {
-  const startMatch = raw.match(/\*\*\*\s*START OF[\s\S]*?\*\*\*/i);
-  const endMatch = raw.match(/\*\*\*\s*END OF[\s\S]*?\*\*\*/i);
-  const start = startMatch ? startMatch.index + startMatch[0].length : 0;
-  const end = endMatch ? endMatch.index : raw.length;
-  return raw.slice(start, end).trim();
+function stripBoilerplate(raw) {
+  const start = raw.match(/\*\*\*\s*START OF[\s\S]*?\*\*\*/i);
+  const end = raw.match(/\*\*\*\s*END OF[\s\S]*?\*\*\*/i);
+  const startIdx = start ? start.index + start[0].length : 0;
+  const endIdx = end ? end.index : raw.length;
+  return raw.slice(startIdx, endIdx).trim();
 }
 
-function isSonnetHeader(line) {
-  return /^\s*(?:\d{1,3}|[IVXLCDM]+)\.?\s*$/i.test(line);
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 100);
 }
 
-function parseSonnets(body) {
-  const lines = body.split("\n");
-  const sonnets = [];
-  let current = [];
-  let inSonnets = false;
+function normalizeKey(value) {
+  return value
+    .toLowerCase()
+    .replace(/['’]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
 
-  for (const line of lines) {
-    if (isSonnetHeader(line)) {
-      if (current.length > 0) {
-        sonnets.push(trimPoemLines(current));
+function extractPoemBlocks(lines) {
+  const starts = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (/^(?:\d+|[IVXLCDM]+)\.$/.test(lines[i].trim())) starts.push(i);
+  }
+  const blocks = [];
+  for (let s = 0; s < starts.length; s += 1) {
+    const start = starts[s];
+    const end = s + 1 < starts.length ? starts[s + 1] : lines.length;
+    let poem = lines.slice(start + 1, end);
+
+    while (poem.length > 0 && poem[0].trim() === "") poem.shift();
+    while (poem.length > 0) {
+      const head = poem[0].trim();
+      if (head === "") {
+        poem.shift();
+        continue;
       }
-      current = [];
-      inSonnets = true;
-      continue;
+      if (head.startsWith("[")) {
+        poem.shift();
+        while (poem.length > 0) {
+          const done = poem[0].includes("]");
+          poem.shift();
+          if (done) break;
+        }
+        continue;
+      }
+      if (!/[a-z]/.test(head)) {
+        poem.shift();
+        continue;
+      }
+      break;
     }
-    if (inSonnets) {
-      current.push(line);
+    while (poem.length > 0 && poem[0].trim() === "") poem.shift();
+    while (poem.length > 0 && poem[poem.length - 1].trim() === "") poem.pop();
+
+    const nonEmpty = poem.filter((l) => l.trim() !== "").length;
+    if (nonEmpty >= 3) {
+      blocks.push(poem);
     }
   }
-
-  if (current.length > 0) {
-    sonnets.push(trimPoemLines(current));
-  }
-  return sonnets.filter((poem) => poem.length > 0);
+  return blocks;
 }
 
-function trimPoemLines(lines) {
-  let start = 0;
-  let end = lines.length;
-  while (start < end && lines[start] === "") start += 1;
-  while (end > start && lines[end - 1] === "") end -= 1;
-  return lines.slice(start, end);
-}
-
-function buildMeta(index) {
-  const num = String(index).padStart(3, "0");
-  const slug = `sonnet-${num}`;
-  const title = `Sonnet ${index}`;
+function buildMeta({ slug, title }) {
   return [
-    `id: "${AUTHOR_SLUG}/${slug}"`,
+    `id: "emily-dickinson/${slug}"`,
     `slug: "${slug}"`,
-    `author: "${AUTHOR}"`,
-    `author_slug: "${AUTHOR_SLUG}"`,
-    `title: "${title}"`,
-    "century: 16",
+    'author: "Emily Dickinson"',
+    'author_slug: "emily-dickinson"',
+    `title: "${title.replace(/"/g, '\\"')}"`,
+    "century: 19",
     "text_in_repo: true",
-    `text_path: "poems/${AUTHOR_SLUG}/${slug}.txt"`,
+    `text_path: "poems/emily-dickinson/${slug}.txt"`,
     'source_label: "Project Gutenberg"',
-    `source_url: "${SOURCE_URL}"`,
-    'public_domain_rationale: "Public domain (author died 1616; distributed by Project Gutenberg as public-domain text)."',
-    `collection_title: "${COLLECTION_TITLE}"`,
-    `collection_source_url: "${SOURCE_URL}"`,
+    `source_url: "${DICKINSON_SOURCE_URL}"`,
+    'public_domain_rationale: "Public domain (author died 1886; distributed by Project Gutenberg as public-domain text)."',
+    'collection_title: "Poems by Emily Dickinson, Three Series, Complete"',
+    `collection_source_url: "${DICKINSON_SOURCE_URL}"`,
     "featured: false",
     "",
   ].join("\n");
 }
 
 async function main() {
-  const textUrl = process.argv[2] || DEFAULT_TEXT_URL;
-  const poemsDir = path.join("poems", AUTHOR_SLUG);
-  const metaDir = path.join("meta", AUTHOR_SLUG);
-  await fs.mkdir(poemsDir, { recursive: true });
-  await fs.mkdir(metaDir, { recursive: true });
-
-  const response = await fetch(textUrl);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch Gutenberg text (${response.status})`);
+  const response = await fetch(DICKINSON_TEXT_URL);
+  if (!response.ok) throw new Error(`Fetch failed (${response.status})`);
+  const text = stripBoilerplate(normalize(await response.text()));
+  const lines = text.split("\n");
+  const blocks = extractPoemBlocks(lines);
+  if (process.argv.includes("--list")) {
+    for (const poem of blocks.slice(0, 140)) {
+      console.log(poem[0].trim());
+    }
+    return;
   }
 
-  const raw = normalizeText(await response.text());
-  const body = stripGutenbergBoilerplate(raw);
-  const sonnets = parseSonnets(body);
-  if (sonnets.length !== 154) {
-    throw new Error(`Expected 154 sonnets, found ${sonnets.length}`);
+  const outPoemsDir = path.join("poems", "emily-dickinson");
+  const outMetaDir = path.join("meta", "emily-dickinson");
+  await fs.mkdir(outPoemsDir, { recursive: true });
+  await fs.mkdir(outMetaDir, { recursive: true });
+
+  const existing = new Set(["because-i-could-not-stop-for-death"]);
+  let written = 0;
+  const used = new Set();
+  const targetKeys = TARGET_FIRST_LINES.map(normalizeKey);
+  const requiredAll = targetKeys.slice(0, 10);
+  const sourceKey = normalizeKey(text);
+  const requiredSet = new Set(requiredAll.filter((key) => sourceKey.includes(key)));
+
+  for (const key of targetKeys) {
+    const idx = blocks.findIndex((poem, i) => !used.has(i) && normalizeKey(poem[0]) === key);
+    if (idx === -1) continue;
+    const poem = blocks[idx];
+    used.add(idx);
+    const title = poem[0].trim();
+    const slug = slugify(title);
+    if (!slug || existing.has(slug)) continue;
+    existing.add(slug);
+    await fs.writeFile(path.join(outPoemsDir, `${slug}.txt`), `${poem.join("\n")}\n`, "utf8");
+    await fs.writeFile(path.join(outMetaDir, `${slug}.yml`), buildMeta({ slug, title }), "utf8");
+    written += 1;
   }
 
-  for (let i = 0; i < sonnets.length; i += 1) {
-    const n = i + 1;
-    const num = String(n).padStart(3, "0");
-    const slug = `sonnet-${num}`;
-    const poemPath = path.join(poemsDir, `${slug}.txt`);
-    const metaPath = path.join(metaDir, `${slug}.yml`);
-    const poemText = `${sonnets[i].join("\n")}\n`;
-    await fs.writeFile(poemPath, poemText, "utf8");
-    await fs.writeFile(metaPath, buildMeta(n), "utf8");
+  if (written < 50) {
+    for (let i = 0; i < blocks.length && written < 50; i += 1) {
+      if (used.has(i)) continue;
+      const poem = blocks[i];
+      const title = poem[0].trim();
+      const slug = slugify(title);
+      if (!slug || existing.has(slug)) continue;
+      existing.add(slug);
+      await fs.writeFile(path.join(outPoemsDir, `${slug}.txt`), `${poem.join("\n")}\n`, "utf8");
+      await fs.writeFile(path.join(outMetaDir, `${slug}.yml`), buildMeta({ slug, title }), "utf8");
+      written += 1;
+    }
   }
+
+  const foundRequired = new Set(blocks.map((poem) => normalizeKey(poem[0])).filter((k) => requiredSet.has(k)));
+  if (foundRequired.size !== requiredSet.size) {
+    const missing = [...requiredSet].filter((k) => !foundRequired.has(k));
+    throw new Error(`Missing required canonical poems (${foundRequired.size}/${requiredSet.size} found): ${missing.join(" | ")}`);
+  }
+
+  if (written < 50) {
+    throw new Error(`Too few poems extracted (${written}), expected at least 50`);
+  }
+  console.log(`Generated ${written} poems.`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
Closes #34

## Summary
- add `scripts/gutenberg-ingest.mjs` for Emily Dickinson wave ingest from Gutenberg `12242` (Node stdlib only)
- strip Gutenberg header/footer, parse numbered poem blocks, preserve stanza breaks/indentation, trim trailing whitespace, write LF output
- generate 50 new Dickinson poem texts + metadata sidecars using first-line slug convention
- dedupe against existing `because-i-could-not-stop-for-death`

## Notes
- the requested line `"Tell all the truth but tell it slant"` is not present in Gutenberg source `12242`; script enforces required-minimum matching only for required lines that actually exist in that source

## Verification
- generated corpus totals for Emily Dickinson in repo: `51` text + `51` metadata (50 new + 1 existing)
- required included from issue list in this source: Hope / I'm Nobody / A Bird came down the Walk / I heard a Fly buzz / Wild nights / The Soul selects her own Society / I felt a Funeral / Success is counted sweetest / There's a certain Slant of light
- metadata field presence check on generated files: pass
- pre-existing `because-i-could-not-stop-for-death.yml` in develop remains unchanged (it predates this wave and lacks optional collection fields)
