### PR TITLE
Add /authors index and enriched author pages

### DIFF
--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -11,6 +11,7 @@ const base = import.meta.env.BASE_URL.endsWith("/")
 const nav = [
   { href: `${base}`, label: "Home", key: "/" },
   { href: `${base}browse/`, label: "Explore poems", key: "/browse" },
+  { href: `${base}authors/`, label: "Authors", key: "/authors" },
   { href: `${base}search/`, label: "Search", key: "/search" },
 ];
 

--- a/site/src/lib/authors.ts
+++ b/site/src/lib/authors.ts
@@ -1,0 +1,150 @@
+export type AuthorInfo = {
+  birth_year: number;
+  death_year: number;
+  bio: string;
+  source_label: string;
+  source_url: string;
+};
+
+export const AUTHOR_INFO: Record<string, AuthorInfo> = {
+  "alfred-tennyson": {
+    birth_year: 1809,
+    death_year: 1892,
+    bio: "English poet and Poet Laureate of Great Britain, known for Victorian narrative and lyric poems including 'Ulysses' and 'The Charge of the Light Brigade'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Alfred,_Lord_Tennyson",
+  },
+  "christina-rossetti": {
+    birth_year: 1830,
+    death_year: 1894,
+    bio: "English poet associated with the Pre-Raphaelites, widely read for devotional lyrics and poems such as 'Goblin Market' and 'Remember'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Christina_Rossetti",
+  },
+  "edgar-allan-poe": {
+    birth_year: 1809,
+    death_year: 1849,
+    bio: "American poet, critic, and fiction writer, famous for Gothic and musical verse including 'The Raven' and 'Annabel Lee'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Edgar_Allan_Poe",
+  },
+  "elizabeth-barrett-browning": {
+    birth_year: 1806,
+    death_year: 1861,
+    bio: "English poet of the Victorian era best known for 'Sonnets from the Portuguese', including Sonnet 43 ('How do I love thee?').",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Elizabeth_Barrett_Browning",
+  },
+  "emily-dickinson": {
+    birth_year: 1830,
+    death_year: 1886,
+    bio: "American lyric poet whose compressed, innovative style and posthumous influence made her one of the central figures of American poetry.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Emily_Dickinson",
+  },
+  "emma-lazarus": {
+    birth_year: 1849,
+    death_year: 1887,
+    bio: "American poet and essayist known for the sonnet 'The New Colossus', later associated with the Statue of Liberty.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Emma_Lazarus",
+  },
+  "george-gordon-byron": {
+    birth_year: 1788,
+    death_year: 1824,
+    bio: "English Romantic poet whose works include satirical and lyrical poems such as 'She Walks in Beauty' and 'Don Juan'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Lord_Byron",
+  },
+  "gerard-manley-hopkins": {
+    birth_year: 1844,
+    death_year: 1889,
+    bio: "English poet and Jesuit priest known for sprung rhythm and intensely patterned devotional language.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Gerard_Manley_Hopkins",
+  },
+  horace: {
+    birth_year: -65,
+    death_year: -8,
+    bio: "Roman lyric poet of the Augustan age, celebrated for the Odes and enduring maxims including 'non omnis moriar'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Horace",
+  },
+  "john-keats": {
+    birth_year: 1795,
+    death_year: 1821,
+    bio: "English Romantic poet whose odes and sonnets, including 'To Autumn' and 'Ode to a Nightingale', are central to English lyric poetry.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/John_Keats",
+  },
+  "john-milton": {
+    birth_year: 1608,
+    death_year: 1674,
+    bio: "English poet and polemicist, author of 'Paradise Lost' and major works of early modern English literature.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/John_Milton",
+  },
+  "percy-bysshe-shelley": {
+    birth_year: 1792,
+    death_year: 1822,
+    bio: "English Romantic poet known for visionary political and lyric poems such as 'Ozymandias' and 'Ode to the West Wind'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Percy_Bysshe_Shelley",
+  },
+  "ralph-waldo-emerson": {
+    birth_year: 1803,
+    death_year: 1882,
+    bio: "American essayist and poet, a leading voice in Transcendentalism whose writings shaped nineteenth-century American thought.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Ralph_Waldo_Emerson",
+  },
+  "robert-browning": {
+    birth_year: 1812,
+    death_year: 1889,
+    bio: "English poet and playwright known for dramatic monologue and psychological intensity in Victorian verse.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Robert_Browning",
+  },
+  "samuel-taylor-coleridge": {
+    birth_year: 1772,
+    death_year: 1834,
+    bio: "English poet and critic of the Romantic movement, known for 'The Rime of the Ancient Mariner' and collaboration with Wordsworth.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Samuel_Taylor_Coleridge",
+  },
+  "walt-whitman": {
+    birth_year: 1819,
+    death_year: 1892,
+    bio: "American poet of free verse and expansive democratic style, best known for 'Leaves of Grass'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Walt_Whitman",
+  },
+  "william-blake": {
+    birth_year: 1757,
+    death_year: 1827,
+    bio: "English poet and artist whose visionary collections 'Songs of Innocence and of Experience' include 'The Lamb' and 'The Tyger'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/William_Blake",
+  },
+  "william-ernest-henley": {
+    birth_year: 1849,
+    death_year: 1903,
+    bio: "English poet and editor remembered for stoic Victorian verse, especially 'Invictus'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/William_Ernest_Henley",
+  },
+  "william-shakespeare": {
+    birth_year: 1564,
+    death_year: 1616,
+    bio: "English playwright and poet whose sonnets and dramatic works are foundational in world literature.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/William_Shakespeare",
+  },
+  "william-wordsworth": {
+    birth_year: 1770,
+    death_year: 1850,
+    bio: "English Romantic poet, co-founder of Lyrical Ballads, known for meditative nature poetry such as 'Tintern Abbey'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/William_Wordsworth",
+  },
+};

--- a/site/src/pages/author/[slug].astro
+++ b/site/src/pages/author/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { loadPoemMetas, type PoemMeta } from "../../lib/poems";
+import { AUTHOR_INFO } from "../../lib/authors";
 
 type AuthorPageProps = {
   author: string;
@@ -39,6 +40,7 @@ export async function getStaticPaths() {
 }
 
 const { author, poems } = Astro.props as AuthorPageProps;
+const info = AUTHOR_INFO[(Astro.props as AuthorPageProps).authorSlug];
 const title = `${author} · Freeverse`;
 const description = `Read public-domain poems by ${author}.`;
 ---
@@ -49,6 +51,19 @@ const description = `Read public-domain poems by ${author}.`;
     <p class="lede">
       {poems.length} poem{poems.length === 1 ? "" : "s"} in the collection.
     </p>
+    {info ? (
+      <p class="muted" style="margin: 0.55rem 0 0.25rem;">
+        {info.birth_year}–{info.death_year}
+      </p>
+    ) : null}
+    {info ? (
+      <p style="max-width: 72ch; margin: 0.2rem 0 0;">
+        {info.bio}{" "}
+        <a class="muted" href={info.source_url}>
+          Source: {info.source_label}
+        </a>
+      </p>
+    ) : null}
   </section>
 
   <div class="card">
@@ -72,6 +87,7 @@ const description = `Read public-domain poems by ${author}.`;
 
     <div class="actions" style="margin-top:1rem;">
       <a class="action" href={`${base}browse/`}>Back to Browse</a>
+      <a class="action" href={`${base}authors/`}>All authors</a>
       <a class="action" href={`${base}search/`}>Search</a>
     </div>
   </div>

--- a/site/src/pages/authors/index.astro
+++ b/site/src/pages/authors/index.astro
@@ -1,0 +1,55 @@
+---
+import BaseLayout from "../../layouts/BaseLayout.astro";
+import { loadPoemMetas } from "../../lib/poems";
+import { authorPath } from "../../lib/url";
+import { AUTHOR_INFO } from "../../lib/authors";
+
+const base = import.meta.env.BASE_URL.endsWith("/")
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+
+const poems = await loadPoemMetas();
+const authors = Array.from(
+  poems.reduce((acc, poem) => {
+    const existing = acc.get(poem.author_slug);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      acc.set(poem.author_slug, { slug: poem.author_slug, name: poem.author, count: 1 });
+    }
+    return acc;
+  }, new Map<string, { slug: string; name: string; count: number }>()),
+).map(([, v]) => v);
+
+authors.sort((a, b) => a.name.localeCompare(b.name));
+---
+
+<BaseLayout title="Authors · Freeverse" description="Browse poets in the Freeverse collection." currentPath={""}>
+  <section class="hero">
+    <h1>Authors</h1>
+    <p class="lede">Alphabetical index of poets in Freeverse.</p>
+  </section>
+
+  <div class="card">
+    <div class="kicker">
+      <h2>Poets</h2>
+      <span class="pill">{authors.length} total</span>
+    </div>
+
+    <ul class="list">
+      {authors.map((a) => {
+        const info = AUTHOR_INFO[a.slug];
+        return (
+          <li>
+            <a class="list-title" href={authorPath(base, a.slug)}>
+              <strong>{a.name}</strong>
+            </a>
+            <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">
+              {info ? `${info.birth_year}–${info.death_year}` : "Dates unavailable"} · {a.count} poem{a.count === 1 ? "" : "s"}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
Closes #37

## Summary
- add new author facts module (`site/src/lib/authors.ts`) with short bio, birth/death years, and source link per author slug
- enhance `/author/[slug]/` to display years, brief sourced bio, poem count, and link back to all authors
- add `/authors/` index page listing all poets alphabetically with poem counts and lifespan
- add `Authors` to top navigation

## Spec coverage
- route `/author/<slug>/`: includes bio, birth/death, poem count, poem list with links
- poem pages: author links were already clickable and remain so
- route `/authors/`: added alphabetical author index

## Verification
- static build command still fails in this environment (`astro: command not found`) due missing dependencies
