### PR TITLE
Polish browse/search entry points

### DIFF
--- a/site/src/pages/browse/index.astro
+++ b/site/src/pages/browse/index.astro
@@ -46,6 +46,8 @@ const poems = selectedAuthor
     <h1>Explore poems</h1>
     <p class="lede">
       A growing library of public-domain poetry. Click any title to read.
+      {" "}
+      <a href={`${base}search/`}><strong>Jump to search</strong></a>.
       {selectedAuthor ? (
         <>
           {' '}Showing only <strong>{selectedAuthor.name}</strong>.{' '}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -62,6 +62,7 @@ const featuredStanza = featured ? await loadFirstStanza(featured) : undefined;
       </p>
       <div class="actions">
         <a class="action primary" href={`${base}browse/`}>Explore poems</a>
+        <a class="action" href={`${base}search/`}>Search poems</a>
         <a class="action" href="https://github.com/Pro777/freeverse">Project repo</a>
       </div>
     </div>


### PR DESCRIPTION
Closes #4

## Summary
- issue #4 core routes were already present on `develop` (`/browse`, `/author/[slug]`, poem links)
- added a more obvious search entry point on the home page action row
- added a prominent "Jump to search" link in the browse hero text

## Acceptance criteria mapping
- `/browse` lists authors: already satisfied
- author page lists poems: already satisfied
- each poem links to reader: already satisfied
- prominent link to `/search`: added in both home and browse surfaces
