### PR TITLE
Deep-link auto-scroll highlighted poem lines on load

### DIFF
--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -82,6 +82,7 @@ const canonicalPath = `${base}poem/${poem.id}/`;
       (() => {
         const lines = Array.from(document.querySelectorAll('.poem-lines li'));
         if (!lines.length) return;
+        let hasAutoScrolledFromInitialHash = false;
 
         const clear = () => {
           lines.forEach((li) => li.classList.remove('is-selected'));
@@ -114,6 +115,14 @@ const canonicalPath = `${base}poem/${poem.id}/`;
           for (let n = r.start; n <= r.end; n++) {
             const el = document.getElementById(`l${n}`);
             if (el) el.classList.add('is-selected');
+          }
+
+          if (!hasAutoScrolledFromInitialHash) {
+            const first = document.getElementById(`l${r.start}`);
+            if (first) {
+              first.scrollIntoView({ block: 'center', inline: 'nearest' });
+            }
+            hasAutoScrolledFromInitialHash = true;
           }
         };
 


### PR DESCRIPTION
Closes #48

Changes:
- keeps existing line-range hash highlighting behavior
- scrolls the first highlighted line into view on initial page load
- uses a one-time auto-scroll guard so later hash changes do not keep recentring the page

Files:
- `site/src/pages/poem/[...id].astro`

Build verification:
- Not run in this environment. The workspace sandbox is read-only, so `npm run build` cannot write output here.
