### PR TITLE
Add local favorites for poems

### DIFF
--- a/site/src/lib/favorites.ts
+++ b/site/src/lib/favorites.ts
@@ -1,0 +1,53 @@
+const FAVORITES_KEY = "freeverse-favorites";
+
+function hasLocalStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function parseFavoriteIds(value: string | null): string[] {
+  if (!value) return [];
+
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+
+    const ids = parsed
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+
+    return Array.from(new Set(ids));
+  } catch {
+    return [];
+  }
+}
+
+export function readFavorites(): string[] {
+  if (!hasLocalStorage()) return [];
+  return parseFavoriteIds(window.localStorage.getItem(FAVORITES_KEY));
+}
+
+export function isFavorite(poemId: string): boolean {
+  return readFavorites().includes(poemId);
+}
+
+export function writeFavorites(ids: string[]): void {
+  if (!hasLocalStorage()) return;
+
+  const clean = Array.from(new Set(ids.map((id) => id.trim()).filter(Boolean)));
+  window.localStorage.setItem(FAVORITES_KEY, JSON.stringify(clean));
+}
+
+export function toggleFavorite(poemId: string): boolean {
+  const id = poemId.trim();
+  if (!id) return false;
+
+  const favorites = readFavorites();
+  if (favorites.includes(id)) {
+    writeFavorites(favorites.filter((entry) => entry !== id));
+    return false;
+  }
+
+  writeFavorites([...favorites, id]);
+  return true;
+}

--- a/site/src/pages/browse/index.astro
+++ b/site/src/pages/browse/index.astro
@@ -119,6 +119,13 @@ const browseDocs = groupedAuthors.flatMap((author) =>
                   <a class="list-title" href={`${base}poem/${poem.id}/`}>
                     <strong>{poem.title}</strong>
                   </a>
+                  <span
+                    data-poem-id={poem.id}
+                    aria-hidden="true"
+                    title="Favorite"
+                    hidden
+                    style="color:var(--accent); font-size:0.95rem; line-height:1; transform:translateY(-0.03rem);"
+                  >★</span>
                 </div>
                 <div class="muted poem-meta">{poem.century}th century</div>
               </li>
@@ -218,6 +225,18 @@ const browseDocs = groupedAuthors.flatMap((author) =>
 
     filterInput.addEventListener("input", runFilter);
     runFilter();
+  </script>
+
+  <script type="module">
+    import { readFavorites } from "../../lib/favorites";
+
+    const favoriteIds = new Set(readFavorites());
+    document.querySelectorAll("[data-poem-id]").forEach((el) => {
+      const id = el.getAttribute("data-poem-id");
+      if (id && favoriteIds.has(id)) {
+        el.hidden = false;
+      }
+    });
   </script>
 
   <style>

--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -31,7 +31,21 @@ const canonicalPath = `${base}poem/${poem.id}/`;
 <BaseLayout title={title} description={description} currentPath={""}>
   <article class="reader">
     <header class="reader-head">
-      <h1 class="reader-title">{poem.title}</h1>
+      <div style="display:flex; align-items:flex-start; justify-content:space-between; gap:0.75rem;">
+        <h1 class="reader-title">{poem.title}</h1>
+        <button
+          type="button"
+          id="favorite-toggle"
+          data-poem-id={poem.id}
+          aria-pressed="false"
+          aria-label="Add to favorites"
+          title="Add to favorites"
+          style="border:1px solid var(--card-border); border-radius:999px; background:color-mix(in oklab, var(--paper) 86%, transparent); color:var(--ink); font-family:var(--sans); font-size:0.85rem; padding:0.35rem 0.6rem; display:inline-flex; align-items:center; gap:0.3rem; cursor:pointer; white-space:nowrap;"
+        >
+          <span aria-hidden="true">☆</span>
+          <span>Favorite</span>
+        </button>
+      </div>
       <p class="reader-byline">
         <span class="muted">by</span>{' '}
         <a href={authorPath(base, poem.author_slug)}>
@@ -82,6 +96,38 @@ const canonicalPath = `${base}poem/${poem.id}/`;
         Tip: click a line to share it — or shift-click another line to share a range.
       </p>
     </footer>
+
+    <script type="module" define:vars={{ poemId: poem.id }}>
+      import { isFavorite, toggleFavorite } from "../../lib/favorites";
+
+      const favoriteButton = document.getElementById("favorite-toggle");
+      const currentPoemId = favoriteButton?.dataset.poemId || poemId || "";
+
+      const updateFavoriteUi = (active) => {
+        if (!favoriteButton) return;
+
+        favoriteButton.setAttribute("aria-pressed", active ? "true" : "false");
+        favoriteButton.setAttribute("aria-label", active ? "Remove from favorites" : "Add to favorites");
+        favoriteButton.setAttribute("title", active ? "Remove from favorites" : "Add to favorites");
+        favoriteButton.style.borderColor = active
+          ? "color-mix(in oklab, var(--accent) 60%, transparent)"
+          : "var(--card-border)";
+        favoriteButton.style.background = active
+          ? "color-mix(in oklab, var(--accent) 14%, var(--paper))"
+          : "color-mix(in oklab, var(--paper) 86%, transparent)";
+
+        const icon = favoriteButton.querySelector("span[aria-hidden='true']");
+        if (icon) icon.textContent = active ? "★" : "☆";
+      };
+
+      if (favoriteButton && currentPoemId) {
+        updateFavoriteUi(isFavorite(currentPoemId));
+        favoriteButton.addEventListener("click", () => {
+          const active = toggleFavorite(currentPoemId);
+          updateFavoriteUi(active);
+        });
+      }
+    </script>
 
     <script is:inline>
       // NOTE: URL fragment helpers are unit-tested in site/src/lib/lineLinks.ts.

--- a/site/src/pages/search.astro
+++ b/site/src/pages/search.astro
@@ -43,6 +43,7 @@ const docs = poems.map((p) => ({
 
   <script type="module">
     import MiniSearch from 'minisearch';
+    import { readFavorites } from "../lib/favorites";
 
     const docs = JSON.parse(document.getElementById('search-data').textContent);
 
@@ -60,6 +61,7 @@ const docs = poems.map((p) => ({
     const input = document.getElementById('q');
     const resultsEl = document.getElementById('results');
     const countEl = document.getElementById('count');
+    const favoriteIds = new Set(readFavorites());
 
     let selectedIndex = -1;
 
@@ -81,9 +83,11 @@ const docs = poems.map((p) => ({
         li.role = 'option';
         li.tabIndex = -1;
         li.setAttribute('aria-label', `${r.title} by ${r.author}`);
+        const hiddenAttr = favoriteIds.has(r.id) ? '' : 'hidden';
         li.innerHTML = `
           <div style="display:flex; gap:0.5rem; flex-wrap:wrap; align-items:baseline;">
             <a class="list-title" href="${r.url}"><strong>${r.title}</strong></a>
+            <span aria-hidden="true" title="Favorite" ${hiddenAttr} style="color:var(--accent); font-size:0.95rem; line-height:1; transform:translateY(-0.03rem);">★</span>
             <span class="muted">— <a class="muted" href="${r.authorUrl}">${r.author}</a></span>
           </div>
           <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">


### PR DESCRIPTION
Closes #50

Changes:
- adds localStorage-backed favorites helpers under `site/src/lib/favorites.ts`
- adds a favorite toggle to poem pages using the `freeverse-favorites` key
- shows star indicators in browse and search results for favorited poems

Files:
- `site/src/lib/favorites.ts`
- `site/src/pages/poem/[...id].astro`
- `site/src/pages/browse/index.astro`
- `site/src/pages/search.astro`

Build verification:
- Not run in this environment. The workspace sandbox is read-only, so `npm run build` cannot write output here.

Note:
- This branch overlaps `site/src/pages/browse/index.astro` and `site/src/pages/poem/[...id].astro` with other open PRs, so it may need a rebase after they merge.
