### PR TITLE
Add deploy timeout and static page count guard

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/site/src/pages/share/[...id]/[range].astro
+++ b/site/src/pages/share/[...id]/[range].astro
@@ -26,6 +26,7 @@ function excerptLines(lines: string[], start: number, end: number) {
 
 export async function getStaticPaths() {
   const MAX_RANGE_LEN = 12;
+  const MAX_EXPECTED_STATIC_PAGES = 5000;
   const poems = await loadPoemMetas();
 
   const paths = [] as Array<{ params: { id: string; range: string }; props: { poem: PoemMeta; start: number; end: number } }>;
@@ -44,6 +45,13 @@ export async function getStaticPaths() {
         });
       }
     }
+  }
+
+  if (paths.length > MAX_EXPECTED_STATIC_PAGES) {
+    console.warn(
+      `[share-routes] High static page count: ${paths.length}. ` +
+      `Expected <= ${MAX_EXPECTED_STATIC_PAGES}. Check for combinatorial explosion.`
+    );
   }
 
   return paths;


### PR DESCRIPTION
Closes #47

Changes:
- adds `timeout-minutes: 10` to the GitHub Pages build job
- adds a warning when share route static page generation exceeds 5,000 pages

Files:
- `.github/workflows/deploy.yml`
- `site/src/pages/share/[...id]/[range].astro`

Note:
- `scripts/build-poem-index.mjs` is not present on `develop`, so the page-count guard was applied in the share route generator where static pages are actually enumerated in this branch.

Build verification:
- Not run in this environment. The workspace sandbox is read-only, so `npm run build` cannot write output here.
