### PR TITLE
Add Wave 5 American poetry ingest batch

### DIFF
--- a/meta/henry-wadsworth-longfellow/a-psalm-of-life.yml
+++ b/meta/henry-wadsworth-longfellow/a-psalm-of-life.yml
@@ -1,0 +1,14 @@
+id: "henry-wadsworth-longfellow/a-psalm-of-life"
+slug: "a-psalm-of-life"
+author: "Henry Wadsworth Longfellow"
+author_slug: "henry-wadsworth-longfellow"
+title: "A Psalm of Life"
+century: 19
+text_in_repo: true
+text_path: "poems/henry-wadsworth-longfellow/a-psalm-of-life.txt"
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Voices_of_the_Night/A_Psalm_of_Life"
+public_domain_rationale: "Public domain (author died 1882; source provides a public-domain edition)."
+collection_title: "Voices of the Night"
+collection_source_url: "https://en.wikisource.org/wiki/Voices_of_the_Night"
+featured: false

--- a/meta/henry-wadsworth-longfellow/paul-reveres-ride.yml
+++ b/meta/henry-wadsworth-longfellow/paul-reveres-ride.yml
@@ -1,0 +1,14 @@
+id: "henry-wadsworth-longfellow/paul-reveres-ride"
+slug: "paul-reveres-ride"
+author: "Henry Wadsworth Longfellow"
+author_slug: "henry-wadsworth-longfellow"
+title: "Paul Revere's Ride"
+century: 19
+text_in_repo: true
+text_path: "poems/henry-wadsworth-longfellow/paul-reveres-ride.txt"
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Tales_of_a_Wayside_Inn/Part_First/The_Landlord%27s_Tale/Paul_Revere%27s_Ride"
+public_domain_rationale: "Public domain (author died 1882; source provides a public-domain edition)."
+collection_title: "Tales of a Wayside Inn"
+collection_source_url: "https://en.wikisource.org/wiki/Tales_of_a_Wayside_Inn"
+featured: false

--- a/meta/oliver-wendell-holmes-sr/old-ironsides.yml
+++ b/meta/oliver-wendell-holmes-sr/old-ironsides.yml
@@ -1,0 +1,15 @@
+id: "oliver-wendell-holmes-sr/old-ironsides"
+slug: "old-ironsides"
+author: "Oliver Wendell Holmes Sr."
+author_slug: "oliver-wendell-holmes-sr"
+title: "Old Ironsides"
+century: 19
+text_in_repo: true
+text_path: "poems/oliver-wendell-holmes-sr/old-ironsides.txt"
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Poems_That_Every_Child_Should_Know/Old_Ironsides"
+public_domain_rationale: "Public domain (author died 1894; source provides a public-domain edition)."
+collection_title: "Poems That Every Child Should Know"
+collection_source_url: "https://en.wikisource.org/wiki/Poems_That_Every_Child_Should_Know"
+featured: false
+notes: "Anthology editor commentary and trailing author credit omitted from the in-repo text."

--- a/meta/oliver-wendell-holmes-sr/the-chambered-nautilus.yml
+++ b/meta/oliver-wendell-holmes-sr/the-chambered-nautilus.yml
@@ -1,0 +1,15 @@
+id: "oliver-wendell-holmes-sr/the-chambered-nautilus"
+slug: "the-chambered-nautilus"
+author: "Oliver Wendell Holmes Sr."
+author_slug: "oliver-wendell-holmes-sr"
+title: "The Chambered Nautilus"
+century: 19
+text_in_repo: true
+text_path: "poems/oliver-wendell-holmes-sr/the-chambered-nautilus.txt"
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Poems_That_Every_Child_Should_Know/The_Chambered_Nautilus"
+public_domain_rationale: "Public domain (author died 1894; source provides a public-domain edition)."
+collection_title: "Poems That Every Child Should Know"
+collection_source_url: "https://en.wikisource.org/wiki/Poems_That_Every_Child_Should_Know"
+featured: false
+notes: "Anthology editor commentary and trailing author credit omitted from the in-repo text."

--- a/poems/henry-wadsworth-longfellow/a-psalm-of-life.txt
+++ b/poems/henry-wadsworth-longfellow/a-psalm-of-life.txt
@@ -1,0 +1,44 @@
+Tell me not, in mournful numbers,
+     Life is but an empty dream!—
+For the soul is dead that slumbers,
+     And things are not what they seem.
+
+Life is real! Life is earnest!
+     And the grave is not its goal;
+Dust thou art, to dust returnest,
+     Was not spoken of the soul.
+
+Not enjoyment, and not sorrow,
+     Is our destined end or way;
+But to act, that each to-morrow
+     Find us farther than to-day.
+
+Art is long, and Time is fleeting,
+     And our hearts, though stout and brave,
+Still, like muffled drums, are beating
+     Funeral marches to the grave.
+
+In the world's broad field of battle,
+     In the bivouac of Life,
+Be not like dumb, driven cattle!
+     Be a hero in the strife!
+
+Trust no Future, howe'er pleasant!
+     Let the dead Past bury its dead!
+Act,—act in the living Present!
+     Heart within, and God o'erhead!
+
+Lives of great men all remind us
+     We can make our lives sublime,
+And, departing, leave behind us
+     Footprints on the sands of time;
+
+Footprints, that perhaps another,
+     Sailing o'er life's solemn main,
+A forlorn and shipwrecked brother,
+     Seeing, shall take heart again.
+
+Let us, then, be up and doing,
+     With a heart for any fate;
+Still achieving, still pursuing,
+     Learn to labor and to wait.

--- a/poems/henry-wadsworth-longfellow/paul-reveres-ride.txt
+++ b/poems/henry-wadsworth-longfellow/paul-reveres-ride.txt
@@ -1,0 +1,143 @@
+Listen my children and you shall hear:
+Of the midnight ride of Paul Revere,
+On the eighteenth of April, in Seventy-five;
+Hardly a man is now alive
+Who remembers that famous day and year.
+
+He said to his friend, "If the British march
+By land or sea from the town to-night,
+Hang a lantern aloft in the belfry arch
+Of the North Church tower as a signal light,—
+One if by land, and two if by sea;
+And I on the opposite shore will be,
+Ready to ride and spread the alarm
+Through every Middlesex village and farm,
+For the country folk to be up and to arm."
+
+Then he said "Good-night!" and with muffled oar
+Silently rowed to the Charlestown shore,
+Just as the moon rose over the bay,
+Where swinging wide at her moorings lay
+The Somerset, British man-of-war;
+A phantom ship, with each mast and spar
+Across the moon like a prison bar,
+And a huge black hulk, that was magnified
+By its own reflection in the tide.
+
+Meanwhile, his friend through alley and street
+Wanders and watches, with eager ears,
+Till in the silence around him he hears
+The muster of men at the barrack door,
+The sound of arms, and the tramp of feet,
+And the measured tread of the grenadiers,
+Marching down to their boats on the shore.
+
+Then he climbed the tower of the Old North Church,
+By the wooden stairs, with stealthy tread,
+To the belfry chamber overhead,
+And startled the pigeons from their perch
+On the sombre rafters, that round him made
+Masses and moving shapes of shade,—
+By the trembling ladder, steep and tall,
+To the highest window in the wall,
+Where he paused to listen and look down
+A moment on the roofs of the town
+And the moonlight flowing over all.
+
+Beneath, in the churchyard, lay the dead,
+In their night encampment on the hill,
+Wrapped in silence so deep and still
+That he could hear, like a sentinel's tread,
+The watchful night-wind, as it went
+Creeping along from tent to tent,
+And seeming to whisper, "All is well!"
+A moment only he feels the spell
+Of the place and the hour, and the secret dread
+Of the lonely belfry and the dead;
+For suddenly all his thoughts are bent
+On a shadowy something far away,
+Where the river widens to meet the bay,—
+A line of black that bends and floats
+On the rising tide like a bridge of boats.
+
+Meanwhile, impatient to mount and ride,
+Booted and spurred, with a heavy stride
+On the opposite shore walked Paul Revere.
+Now he patted his horse's side,
+Now he gazed at the landscape far and near,
+Then, impetuous, stamped the earth,
+And turned and tightened his saddle girth;
+But mostly he watched with eager search
+The belfry tower of the Old North Church,
+As it rose above the graves on the hill,
+Lonely and spectral and sombre and still.
+And lo! as he looks, on the belfry's height
+A glimmer, and then a gleam of light!
+He springs to the saddle, the bridle he turns,
+But lingers and gazes, till full on his sight
+A second lamp in the belfry burns.
+
+A hurry of hoofs in a village street,
+A shape in the moonlight, a bulk in the dark,
+And beneath, from the pebbles, in passing, a spark
+Struck out by a steed flying fearless and fleet;
+That was all! And yet, through the gloom and the light,
+The fate of a nation was riding that night;
+And the spark struck out by that steed, in his flight,
+Kindled the land into flame with its heat.
+
+He has left the village and mounted the steep,
+And beneath him, tranquil and broad and deep,
+Is the Mystic, meeting the ocean tides;
+And under the alders that skirt its edge,
+Now soft on the sand, now loud on the ledge,
+Is heard the tramp of his steed as he rides.
+
+It was twelve by the village clock
+When he crossed the bridge into Medford town.
+He heard the crowing of the cock,
+And the barking of the farmer's dog,
+And felt the damp of the river fog,
+That rises after the sun goes down.
+
+It was one by the village clock,
+When he galloped into Lexington.
+He saw the gilded weathercock
+Swim in the moonlight as he passed,
+And the meeting-house windows, black and bare,
+Gaze at him with a spectral glare,
+As if they already stood aghast
+At the bloody work they would look upon.
+
+It was two by the village clock,
+When he came to the bridge in Concord town.
+He heard the bleating of the flock,
+And the twitter of birds among the trees,
+And felt the breath of the morning breeze
+Blowing over the meadow brown.
+And one was safe and asleep in his bed
+Who at the bridge would be first to fall,
+Who that day would be lying dead,
+Pierced by a British musket ball.
+
+You know the rest. In the books you have read
+How the British Regulars fired and fled,—
+How the farmers gave them ball for ball,
+From behind each fence and farmyard wall,
+Chasing the redcoats down the lane,
+Then crossing the fields to emerge again
+Under the trees at the turn of the road,
+And only pausing to fire and load.
+
+So through the night rode Paul Revere;
+And so through the night went his cry of alarm
+To every Middlesex village and farm,—
+A cry of defiance, and not of fear,
+A voice in the darkness, a knock at the door,
+And a word that shall echo for evermore!
+For, borne on the night-wind of the Past,
+Through all our history, to the last,
+In the hour of darkness and peril and need,
+The people will waken and listen to hear
+The hurrying hoof-beats of that steed,
+And the midnight message of Paul Revere.

--- a/poems/oliver-wendell-holmes-sr/old-ironsides.txt
+++ b/poems/oliver-wendell-holmes-sr/old-ironsides.txt
@@ -1,0 +1,26 @@
+Ay, tear her tattered ensign down!
+Long has it waved on high,
+And many an eye has danced to see
+That banner in the sky;
+Beneath it rung the battle shout,
+And burst the cannon's roar;—
+The meteor of the ocean air
+Shall sweep the clouds no more.
+
+Her deck, once red with heroes' blood,
+Where knelt the vanquished foe,
+When winds were hurrying o'er the flood
+And waves were white below.
+No more shall feel the victor's tread,
+Or know the conquered knee;
+The harpies of the shore shall pluck
+The eagle of the sea!
+
+O, better that her shattered hulk
+Should sink beneath the wave;
+Her thunders shook the mighty deep,
+And there should be her grave;
+Nail to the mast her holy flag,
+Set every threadbare sail,
+And give her to the god of storms,
+The lightning and the gale!

--- a/poems/oliver-wendell-holmes-sr/the-chambered-nautilus.txt
+++ b/poems/oliver-wendell-holmes-sr/the-chambered-nautilus.txt
@@ -1,0 +1,39 @@
+This is the ship of pearl, which, poets feign,
+Sailed the unshadowed main,—
+The venturous bark that flings
+On the sweet summer wind its purpled wings
+In gulfs enchanted, where the Siren sings,
+And coral reefs lie bare,
+Where the cold sea-maids rise to sun their streaming hair.
+
+Its webs of living gauze no more unfurl;
+Wrecked is the ship of pearl!
+And every chambered cell,
+Where its dim dreaming life was wont to dwell,
+As the frail tenant shaped his growing shell,
+Before thee lies revealed,—
+Its irised ceiling rent, its sunless crypt unsealed!
+
+Year after year beheld the silent toil
+That spread his lustrous coil;
+Still, as the spiral grew,
+He left the past year's dwelling for the new,
+Stole with soft step its shining archway through,
+Built up its idle door,
+Stretched in his last-found home, and knew the old no more.
+
+Thanks for the heavenly message brought by thee,
+Child of the wandering sea,
+Cast from her lap, forlorn!
+From thy dead lips a clearer note is born
+Than ever Triton blew from wreathèd horn!
+While on mine ear it rings,
+Through the deep caves of thought I hear a voice that sings:—
+
+Build thee more stately mansions, O my soul,
+As the swift seasons roll!
+Leave thy low-vaulted past!
+Let each new temple, nobler than the last,
+Shut thee from heaven with a dome more vast,
+Till thou at length art free,
+Leaving thine outgrown shell by life's unresting sea!

--- a/site/src/lib/authors.ts
+++ b/site/src/lib/authors.ts
@@ -84,6 +84,20 @@ export const AUTHOR_INFO: Record<string, AuthorInfo> = {
     source_label: "Wikipedia",
     source_url: "https://en.wikipedia.org/wiki/John_Milton",
   },
+  "henry-wadsworth-longfellow": {
+    birth_year: 1807,
+    death_year: 1882,
+    bio: "American poet and educator known for widely read narrative and lyric works including 'Paul Revere's Ride' and 'A Psalm of Life'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Henry_Wadsworth_Longfellow",
+  },
+  "oliver-wendell-holmes-sr": {
+    birth_year: 1809,
+    death_year: 1894,
+    bio: "American poet, essayist, and physician remembered for civic and reflective poems including 'Old Ironsides' and 'The Chambered Nautilus'.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Oliver_Wendell_Holmes_Sr.",
+  },
   "percy-bysshe-shelley": {
     birth_year: 1792,
     death_year: 1822,


### PR DESCRIPTION
Closes #49

Batch contents:
- Henry Wadsworth Longfellow
  - `A Psalm of Life`
  - `Paul Revere's Ride`
- Oliver Wendell Holmes Sr.
  - `Old Ironsides`
  - `The Chambered Nautilus`

Changes:
- registers Longfellow and Holmes in `site/src/lib/authors.ts`
- adds poem texts under `poems/`
- adds matching metadata under `meta/` with explicit provenance and public-domain rationale
- uses canonical Wikisource pages for all four poems

Files:
- `site/src/lib/authors.ts`
- `poems/henry-wadsworth-longfellow/*`
- `meta/henry-wadsworth-longfellow/*`
- `poems/oliver-wendell-holmes-sr/*`
- `meta/oliver-wendell-holmes-sr/*`

Build verification:
- Not run in this environment. The workspace sandbox is read-only, so `npm run build` cannot write output here.
