### PR TITLE
fix: scroll deep-linked poem selections into view

### DIFF
--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -136,7 +136,6 @@ const canonicalPath = `${base}poem/${poem.id}/`;
       (() => {
         const lines = Array.from(document.querySelectorAll('.poem-lines li'));
         if (!lines.length) return;
-        let hasAutoScrolledFromInitialHash = false;
 
         const clear = () => {
           lines.forEach((li) => li.classList.remove('is-selected'));
@@ -158,7 +157,16 @@ const canonicalPath = `${base}poem/${poem.id}/`;
           return { start, end };
         };
 
-        const applyFromHash = () => {
+        const scrollSelectionIntoView = (range) => {
+          const firstSelected = document.getElementById(`l${range.start}`);
+          if (!firstSelected) return;
+
+          requestAnimationFrame(() => {
+            firstSelected.scrollIntoView({ block: 'center', behavior: 'auto' });
+          });
+        };
+
+        const applyFromHash = ({ scroll = false } = {}) => {
           clear();
           const r = parseHash();
           if (!r) return;
@@ -171,20 +179,16 @@ const canonicalPath = `${base}poem/${poem.id}/`;
             if (el) el.classList.add('is-selected');
           }
 
-          if (!hasAutoScrolledFromInitialHash) {
-            const first = document.getElementById(`l${r.start}`);
-            if (first) {
-              first.scrollIntoView({ block: 'center', inline: 'nearest' });
-            }
-            hasAutoScrolledFromInitialHash = true;
+          if (scroll) {
+            scrollSelectionIntoView(r);
           }
         };
 
         let startLine = null;
 
-        // Keep UI in sync when navigating back/forward.
-        window.addEventListener('hashchange', applyFromHash);
-        applyFromHash();
+        // Keep UI in sync when navigating back/forward and reveal deep links on load.
+        window.addEventListener('hashchange', () => applyFromHash({ scroll: true }));
+        applyFromHash({ scroll: true });
 
         const toast = (() => {
           let el = document.getElementById('toast');


### PR DESCRIPTION
## Summary
- add a small helper that scrolls the first selected line into view
- call the hash-application logic with scrolling on initial page load and browser hash navigation
- keep in-page share clicks using the existing non-scrolling path to avoid unnecessary viewport jumps

## Validation
- reviewed the updated poem page script on branch `codex/48-deeplink-autoscroll`
- did not run Astro locally because this repo is not checked out in the current sandboxed worktree

Closes #48