### PR TITLE
fix: build timeout guard and page-count warning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/site/scripts/build-poem-index.mjs
+++ b/site/scripts/build-poem-index.mjs
@@ -20,6 +20,8 @@ const metaRoot = path.join(repoRoot, "meta");
 const outputPath = path.join(process.cwd(), "src", "data", "poem-index.json");
 const dedupeReportPath = path.join(process.cwd(), "src", "data", "dedupe-report.json");
 
+const STATIC_PAGE_LIMIT = 5000;
+
 function parseScalar(raw) {
   const t = raw.trim();
   if (t === "true") return true;
@@ -224,6 +226,14 @@ async function main() {
     `${JSON.stringify({ duplicate_clusters, near_variant_candidates }, null, 2)}\n`,
     "utf8",
   );
+
+  const staticPageCount = metas.length;
+  if (staticPageCount > STATIC_PAGE_LIMIT) {
+    process.stderr.write(
+      `WARNING: static page count (${staticPageCount}) exceeds the ${STATIC_PAGE_LIMIT}-page limit. ` +
+      `This may cause slow builds or bloated deploy artifacts.\n`,
+    );
+  }
 
   console.log(
     `Wrote poem index (${metas.length} poems), duplicate clusters: ${duplicate_clusters.length}, near-variant candidates: ${near_variant_candidates.length}`,


### PR DESCRIPTION
Add `timeout-minutes: 10` to the build job in `.github/workflows/deploy.yml` to prevent runaway builds from blocking the deploy queue.

In `site/scripts/build-poem-index.mjs`, add a page-count guard: if the total number of static poem pages exceeds 5,000, emit a warning to stderr. This provides early notice of route explosion before it causes slow builds or oversized deploy artifacts.

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 10-minute timeout limit to the build job in the deployment workflow.
  * Added a warning system during the build process when generated content exceeds the static page limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->