### PR TITLE
fix: scroll first highlighted line into view on deep-link load

### DIFF
--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -190,7 +190,7 @@ const canonicalPath = `${base}poem/${poem.id}/`;
         const setHash = async (start, end) => {
           const fragment = start === end ? `#l${start}` : `#l${start}-l${end}`;
           history.replaceState(null, '', fragment);
-          applyFromHash();
+          applyFromHash(false);
           await copyUrl(start, end);
         };
 


### PR DESCRIPTION
When a poem URL contains a line hash (e.g. `#l42` or `#l12-l17`), the page now scrolls the first highlighted line to the center of the viewport after applying the highlight.

**Behaviour:**
- Page load with a hash in the URL → scroll to highlighted line (center)
- Browser back/forward triggering a `hashchange` → scroll to highlighted line (center)
- Clicking a line to create a selection → no scroll (user is already looking at the right place)

**Implementation:** `applyFromHash` now accepts a `scroll` boolean. The initial call and the `hashchange` listener pass `true`; the `setHash` click handler passes `false`.

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents unwanted page jumps when selecting or copying lines: updating the URL fragment for line selection no longer moves the viewport.
  * Preserves automatic scrolling when navigating via direct links or using back/forward, ensuring referenced lines still come into view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->