### PR TITLE
feat: add reader mode toggle

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -32,6 +32,17 @@ const ogImageUrl = site ? new URL(`${base}og.png`, site).toString() : undefined;
         } catch {}
       })();
     </script>
+    <script is:inline>
+      (() => {
+        const STORAGE_KEY = 'freeverse-reader-mode';
+        try {
+          const mode = localStorage.getItem(STORAGE_KEY);
+          if (mode === 'clean' || mode === 'scholar') {
+            document.documentElement.dataset.readerMode = mode;
+          }
+        } catch {}
+      })();
+    </script>
     <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
     <link rel="icon" href={`${base}favicon.ico`} />
     <meta name="viewport" content="width=device-width" />

--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -33,17 +33,27 @@ const canonicalPath = `${base}poem/${poem.id}/`;
     <header class="reader-head">
       <div class="reader-head-row">
         <h1 class="reader-title">{poem.title}</h1>
-        <button
-          class="star-btn"
-          type="button"
-          aria-label="Add to favorites"
-          aria-pressed="false"
-          data-poem-id={poem.id}
-        >
-          <svg class="star-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="22" height="22">
-            <path d="M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 21 12 17.77 5.82 21 7 14.14 2 9.27l6.91-1.01L12 2z"/>
-          </svg>
-        </button>
+        <div class="reader-actions">
+          <div class="reader-mode-toggle" role="group" aria-label="Reader mode">
+            <button type="button" class="reader-mode-btn" data-reader-mode-value="clean" aria-pressed="false">
+              Clean page
+            </button>
+            <button type="button" class="reader-mode-btn" data-reader-mode-value="scholar" aria-pressed="false">
+              Scholar mode
+            </button>
+          </div>
+          <button
+            class="star-btn"
+            type="button"
+            aria-label="Add to favorites"
+            aria-pressed="false"
+            data-poem-id={poem.id}
+          >
+            <svg class="star-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false" width="22" height="22">
+              <path d="M12 2l3.09 6.26L22 9.27l-5 4.87L18.18 21 12 17.77 5.82 21 7 14.14 2 9.27l6.91-1.01L12 2z"/>
+            </svg>
+          </button>
+        </div>
       </div>
       <p class="reader-byline">
         <span class="muted">by</span>{' '}
@@ -63,7 +73,7 @@ const canonicalPath = `${base}poem/${poem.id}/`;
           const isBlank = line === "";
           return (
             <li id={id} data-line={n} class={isBlank ? "is-blank" : ""} aria-label={isBlank ? "Stanza break" : undefined}>
-              <span class="line-anchor" aria-hidden="true"></span>
+              <span class="line-anchor" aria-hidden="true" data-line={n}></span>
               <span class="line-text">{isBlank ? "\u00A0" : line}</span>
             </li>
           );
@@ -93,8 +103,28 @@ const canonicalPath = `${base}poem/${poem.id}/`;
       // This inline script intentionally keeps its own lightweight parsing/building
       // to avoid bundling surprises in the static output.
       (() => {
+        const READER_MODE_STORAGE_KEY = 'freeverse-reader-mode';
         const lines = Array.from(document.querySelectorAll('.poem-lines li'));
         if (!lines.length) return;
+        const readerModeButtons = Array.from(document.querySelectorAll('.reader-mode-btn'));
+
+        const applyReaderMode = (mode) => {
+          const nextMode = mode === 'scholar' ? 'scholar' : 'clean';
+          document.documentElement.dataset.readerMode = nextMode;
+          readerModeButtons.forEach((button) => {
+            const active = button.dataset.readerModeValue === nextMode;
+            button.setAttribute('aria-pressed', String(active));
+          });
+          try {
+            localStorage.setItem(READER_MODE_STORAGE_KEY, nextMode);
+          } catch {}
+        };
+
+        readerModeButtons.forEach((button) => {
+          button.addEventListener('click', () => applyReaderMode(button.dataset.readerModeValue));
+        });
+
+        applyReaderMode(document.documentElement.dataset.readerMode);
 
         const clear = () => {
           lines.forEach((li) => li.classList.remove('is-selected'));

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -736,6 +736,39 @@ main {
   margin: 0.25rem 0 1.4rem;
 }
 
+.reader-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.reader-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.2rem;
+  border: 1px solid color-mix(in oklab, var(--border) 70%, transparent);
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--paper) 82%, transparent);
+}
+
+.reader-mode-btn {
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 0.45rem 0.75rem;
+  font: inherit;
+  font-family: var(--sans);
+  font-size: 0.86rem;
+  cursor: pointer;
+}
+
+.reader-mode-btn[aria-pressed="true"] {
+  background: color-mix(in oklab, var(--accent) 18%, var(--paper));
+  color: var(--ink);
+}
+
 .reader-title {
   margin: 0;
   font-size: clamp(2.05rem, 1.65rem + 1.7vw, 2.75rem);
@@ -766,6 +799,11 @@ main {
   padding: 0.22rem 0;
 }
 
+:root[data-reader-mode="scholar"] .poem-lines li {
+  grid-template-columns: 2.75rem 1fr;
+  gap: 0.8rem;
+}
+
 .poem-lines li:not(.is-blank) {
   cursor: pointer;
 }
@@ -790,6 +828,19 @@ main {
   width: 1.2rem;
 }
 
+:root[data-reader-mode="scholar"] .line-anchor {
+  width: 2.4rem;
+  text-align: right;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: color-mix(in oklab, var(--muted) 82%, transparent);
+  user-select: none;
+}
+
+:root[data-reader-mode="scholar"] .line-anchor::before {
+  content: attr(data-line);
+}
+
 .line-text {
   white-space: pre-wrap;
   font-size: clamp(1.05rem, 1.01rem + 0.35vw, 1.18rem);
@@ -799,9 +850,32 @@ main {
 
 /* De-emphasize the empty gutter on small screens */
 @media (max-width: 480px) {
+  .reader-head-row {
+    align-items: flex-start;
+  }
+
+  .reader-actions {
+    flex-direction: column-reverse;
+    align-items: flex-end;
+    gap: 0.5rem;
+  }
+
+  .reader-mode-toggle {
+    align-self: stretch;
+  }
+
+  .reader-mode-btn {
+    padding-inline: 0.65rem;
+  }
+
   .poem-lines li {
     grid-template-columns: 1.1rem 1fr;
     gap: 0.5rem;
+  }
+
+  :root[data-reader-mode="scholar"] .poem-lines li {
+    grid-template-columns: 2.2rem 1fr;
+    gap: 0.55rem;
   }
 }
 


### PR DESCRIPTION
Closes #76

## Summary
Add a persistent poem-reader mode toggle with two views:
- `Clean page` keeps the current low-chrome reading experience
- `Scholar mode` reveals explicit line numbers in the gutter for citation-friendly reading

## What changed
- persist reader mode in localStorage via `freeverse-reader-mode`
- initialize the mode in the base layout to avoid flash on navigation
- add clean/scholar mode controls to poem pages
- reveal numeric line gutter in scholar mode while preserving existing line-range linking
- adjust mobile reader layout so the mode controls and favorites button still fit

## Verification
- `cd site && npm run build`

## Notes
Current behavior is effectively the clean-page mode. Scholar mode adds explicit line-number affordances without changing the share/hash model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added reader mode selector with "Clean" and "Scholar" viewing options for poems
* Scholar mode displays line numbers for enhanced reading reference
* Reader mode preference is saved and persists across browsing sessions
* Optimized reader controls layout for mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->