### PR TITLE
feat: add related poem suggestions

### DIFF
--- a/site/src/lib/collections.ts
+++ b/site/src/lib/collections.ts
@@ -12,6 +12,11 @@ export type CollectionWithPoems = CollectionRecord & {
   poems: PoemMeta[];
 };
 
+export type RelatedPoem = {
+  poem: PoemMeta;
+  reason: string;
+};
+
 const collectionRecords: CollectionRecord[] = [
   {
     slug: 'grief-and-mortality',
@@ -79,4 +84,41 @@ export async function loadCollections(): Promise<CollectionWithPoems[]> {
 export async function loadCollectionBySlug(slug: string): Promise<CollectionWithPoems | undefined> {
   const collections = await loadCollections();
   return collections.find((collection) => collection.slug === slug);
+}
+
+export async function loadRelatedPoems(poemId: string, limit = 4): Promise<RelatedPoem[]> {
+  const poems = await loadPoemMetas();
+  const targetPoem = poems.find((poem) => poem.id === poemId);
+  if (!targetPoem) return [];
+
+  const collections = await loadCollections();
+  const suggestions = new Map<string, RelatedPoem>();
+
+  for (const collection of collections) {
+    if (!collection.poemIds.includes(poemId)) continue;
+
+    for (const poem of collection.poems) {
+      if (poem.id === poemId || suggestions.has(poem.id)) continue;
+      suggestions.set(poem.id, {
+        poem,
+        reason: `Also in ${collection.title}`,
+      });
+      if (suggestions.size >= limit) return Array.from(suggestions.values());
+    }
+  }
+
+  const sameAuthorPoems = poems
+    .filter((poem) => poem.id !== poemId && poem.author_slug === targetPoem.author_slug)
+    .sort((a, b) => a.title.localeCompare(b.title));
+
+  for (const poem of sameAuthorPoems) {
+    if (suggestions.has(poem.id)) continue;
+    suggestions.set(poem.id, {
+      poem,
+      reason: `More by ${targetPoem.author}`,
+    });
+    if (suggestions.size >= limit) break;
+  }
+
+  return Array.from(suggestions.values());
 }

--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { loadRelatedPoems } from "../../lib/collections";
 import { loadPoemMetas, loadPoemText, type PoemMeta } from "../../lib/poems";
 import { authorPath } from "../../lib/url";
 // (tests) line-link hash logic is unit-tested separately in src/lib/lineLinks.ts
@@ -18,6 +19,7 @@ type Props = { poem: PoemMeta };
 const { poem } = Astro.props;
 const raw = await loadPoemText(poem);
 const lines = raw ? raw.split(/\r?\n/) : [];
+const relatedPoems = await loadRelatedPoems(poem.id);
 
 const title = `${poem.author} — ${poem.title} · Freeverse`;
 const description = `Read ${poem.title} by ${poem.author}.`;
@@ -103,6 +105,31 @@ const canonicalPath = `${base}poem/${poem.id}/`;
         Tip: click a line to share it — or shift-click another line to share a range.
       </p>
     </footer>
+
+    {relatedPoems.length > 0 ? (
+      <section class="card related-readings" aria-labelledby="related-readings-title">
+        <div class="kicker">
+          <h2 id="related-readings-title">Related readings</h2>
+          <span class="pill">{relatedPoems.length} suggestion{relatedPoems.length === 1 ? "" : "s"}</span>
+        </div>
+        <ul class="list related-readings-list">
+          {relatedPoems.map(({ poem: relatedPoem, reason }) => (
+            <li>
+              <p style="margin: 0;">
+                <a class="list-title" href={`${base}poem/${relatedPoem.id}/`}>
+                  <strong>{relatedPoem.title}</strong>
+                </a>
+              </p>
+              <p class="muted related-reading-meta">
+                <a href={authorPath(base, relatedPoem.author_slug)}>{relatedPoem.author}</a>
+                <span class="related-reading-dot">·</span>
+                <span>{reason}</span>
+              </p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    ) : null}
 
     <section class="quote-card-tools" data-quote-card-tools hidden aria-live="polite">
       <div>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1085,6 +1085,35 @@ body.quote-card-open {
   overflow: hidden;
 }
 
+.related-readings {
+  margin-top: 1.5rem;
+}
+
+.related-readings-list {
+  margin-top: 0.65rem;
+}
+
+.related-reading-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  margin-top: 0.3rem;
+}
+
+.related-reading-meta a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.related-reading-meta a:hover {
+  text-decoration: underline;
+}
+
+.related-reading-dot {
+  color: color-mix(in oklab, var(--muted) 82%, transparent);
+}
+
 @media (prefers-reduced-motion: reduce) {
   * { scroll-behavior: auto !important; }
   .toast { transition: none; }


### PR DESCRIPTION
Closes #79

## Summary
Add deterministic related-poem suggestions on poem pages.

## What changed
- add a related-poems helper that prefers shared editorial collections
- fall back to same-author suggestions when a poem is not in a collection
- render a Related readings section on poem pages with an explicit reason label for each suggestion

## Verification
- cd site && npm run build
- checked built poem pages for both collection-backed and same-author fallback suggestions

## Notes
This is intentionally deterministic and repo-backed. It avoids opaque semantic ranking in the first iteration while still improving poem-to-poem discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Poem pages now include a "Related readings" section that intelligently recommends related poems based on shared collections and additional works by the same author, with contextual labels explaining the connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->