### PR TITLE
feat: add metaphysical poetry wave

### DIFF
--- a/meta/andrew-marvell/to-his-coy-mistress.yml
+++ b/meta/andrew-marvell/to-his-coy-mistress.yml
@@ -1,0 +1,15 @@
+id: "andrew-marvell/to-his-coy-mistress"
+slug: "to-his-coy-mistress"
+author: "Andrew Marvell"
+author_slug: "andrew-marvell"
+title: "To His Coy Mistress"
+century: 17
+
+text_path: "poems/andrew-marvell/to-his-coy-mistress.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/To_his_Coy_Mistress"
+public_domain_rationale: "Public domain in the United States: Marvell died 1678 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography preserved from the 1681 text on Wikisource."

--- a/meta/george-herbert/love-iii.yml
+++ b/meta/george-herbert/love-iii.yml
@@ -1,0 +1,15 @@
+id: "george-herbert/love-iii"
+slug: "love-iii"
+author: "George Herbert"
+author_slug: "george-herbert"
+title: "Love (III)"
+century: 17
+
+text_path: "poems/george-herbert/love-iii.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Love_(III)"
+public_domain_rationale: "Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography preserved from the 1633 text on Wikisource."

--- a/meta/george-herbert/the-pulley.yml
+++ b/meta/george-herbert/the-pulley.yml
@@ -1,0 +1,15 @@
+id: "george-herbert/the-pulley"
+slug: "the-pulley"
+author: "George Herbert"
+author_slug: "george-herbert"
+title: "The Pulley"
+century: 17
+
+text_path: "poems/george-herbert/the-pulley.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/The_Pulley"
+public_domain_rationale: "Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography preserved from the 1633 text on Wikisource."

--- a/meta/john-donne/a-valediction-forbidding-mourning.yml
+++ b/meta/john-donne/a-valediction-forbidding-mourning.yml
@@ -1,0 +1,15 @@
+id: "john-donne/a-valediction-forbidding-mourning"
+slug: "a-valediction-forbidding-mourning"
+author: "John Donne"
+author_slug: "john-donne"
+title: "A Valediction: Forbidding Mourning"
+century: 17
+
+text_path: "poems/john-donne/a-valediction-forbidding-mourning.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/A_Valediction:_Forbidding_Mourning"
+public_domain_rationale: "Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography preserved from Wikisource."

--- a/meta/john-donne/holy-sonnet-10.yml
+++ b/meta/john-donne/holy-sonnet-10.yml
@@ -1,0 +1,15 @@
+id: "john-donne/holy-sonnet-10"
+slug: "holy-sonnet-10"
+author: "John Donne"
+author_slug: "john-donne"
+title: "Holy Sonnet 10"
+century: 17
+
+text_path: "poems/john-donne/holy-sonnet-10.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Holy_Sonnets/Holy_Sonnet_X"
+public_domain_rationale: "Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source."
+
+notes: "Often known by its opening line, 'Death be not proud'."

--- a/poems/andrew-marvell/to-his-coy-mistress.txt
+++ b/poems/andrew-marvell/to-his-coy-mistress.txt
@@ -1,0 +1,46 @@
+Had we but World enough, and Time,
+This coyness Lady were no crime.
+We would sit down, and think which way
+To walk, and pass our long Loves Day.
+Thou by the Indian Ganges side
+Should'st Rubies find; I by the Tide
+Of Humber would complain. I would
+Love you ten years before the Flood:
+And you should if you please refuse
+Till the Conversion of the Jews.
+My vegetable Love should grow
+Vaster then Empires, and more slow.
+An hundred years should go to praise
+Thine Eyes, and on thy Forehead Gaze.
+Two hundred to adore each Breast:
+But thirty thousand to the rest.
+An Age at least to every part,
+And the last Age should show your Heart.
+For Lady you deserve this State;
+Nor would I love at lower rate.
+But at my back I alwaies hear
+Times winged Charriot hurrying near:
+And yonder all before us lye
+Desarts of vast Eternity.
+Thy Beauty shall no more be found,
+Nor, in thy marble Vault, shall sound
+My ecchoing Song: then Worms shall try
+That long preserv'd Virginity:
+And your quaint Honour turn to dust;
+And into ashes all my Lust.
+The Grave's a fine and private place,
+But none I think do there embrace.
+Now therefore, while the youthful hew
+Sits on thy skin like morning glew,
+And while thy willing Soul transpires
+At every pore with instant Fires,
+Now let us sport us while we may;
+And now, like am'rous birds of prey,
+Rather at once our Time devour,
+Than languish in his slow-chapt pow'r.
+Let us roll all our Strength, and all
+Our sweetness, up into one Ball:
+And tear our Pleasures with rough strife,
+Thorough the Iron gates of Life.
+Thus, though we cannot make our Sun
+Stand still, yet we will make him run.

--- a/poems/george-herbert/love-iii.txt
+++ b/poems/george-herbert/love-iii.txt
@@ -1,0 +1,20 @@
+Love bade me welcome: yet my soul drew back,
+Guiltie of dust and sinne.
+But quick-ey'd Love, observing me grow slack
+From my first entrance in,
+Drew nearer to me, sweetly questioning,
+If I lack'd any thing.
+
+A guest, I answer'd, worthy to be here:
+Love said, you shall be he.
+I the unkinde, ungratefull? Ah my deare,
+I cannot look on thee.
+Love took my hand, and smiling did reply,
+Who made the eyes but I?
+
+Truth Lord, but I have marr'd them: let my shame
+Go where it doth deserve.
+And know you not, sayes Love, who bore the blame?
+My deare, then I will serve.
+You must sit down, sayes Love, and taste my meat:
+So I did sit and eat.

--- a/poems/george-herbert/the-pulley.txt
+++ b/poems/george-herbert/the-pulley.txt
@@ -1,0 +1,23 @@
+When God at first made man,
+Having a glasse of blessings standing by;
+Let us (said he) poure on him all we can:
+Let the worlds riches, which dispersed lie,
+Contract into a span.
+
+So strength first made a way;
+Then beautie flow'd, then wisdome, honour, pleasure:
+When almost all was out, God made a stay,
+Perceiving that alone of all his treasure
+Rest in the bottome lay.
+
+For if I should (said he)
+Bestow this jewell also on my creature,
+He would adore my gifts in stead of me,
+And rest in Nature, not the God of Nature,
+So both should losers be.
+
+Yet let him keep the rest,
+But keep them with repining restlesnesse:
+Let him be rich and wearie, that at least,
+If goodnesse leade him not, yet wearinesse
+May tosse him to my breast.

--- a/poems/john-donne/a-valediction-forbidding-mourning.txt
+++ b/poems/john-donne/a-valediction-forbidding-mourning.txt
@@ -1,0 +1,44 @@
+As virtuous men pass mildly away,
+And whisper to their souls to go,
+Whilst some of their sad friends do say,
+"Now his breath goes," and some say, "No."
+
+So let us melt, and make no noise,
+No tear-floods, nor sigh-tempests move;
+'Twere profanation of our joys
+To tell the laity our love.
+
+Moving of th' earth brings harms and fears;
+Men reckon what it did, and meant;
+But trepidation of the spheres,
+Though greater far, is innocent.
+
+Dull sublunary lovers' love
+—Whose soul is sense—cannot admit
+Of absence, 'cause it doth remove
+The thing which elemented it.
+
+But we by a love so much refined,
+That ourselves know not what it is,
+Inter-assurèd of the mind,
+Care less, eyes, lips and hands to miss.
+
+Our two souls therefore, which are one,
+Though I must go, endure not yet
+A breach, but an expansion,
+Like gold to aery thinness beat.
+
+If they be two, they are two so
+As stiff twin compasses are two;
+Thy soul, the fix'd foot, makes no show
+To move, but doth, if th' other do.
+
+And though it in the centre sit,
+Yet, when the other far doth roam,
+It leans, and hearkens after it,
+And grows erect, as that comes home.
+
+Such wilt thou be to me, who must,
+Like th' other foot, obliquely run;
+Thy firmness makes my circle just
+And makes me end where I begun.

--- a/poems/john-donne/holy-sonnet-10.txt
+++ b/poems/john-donne/holy-sonnet-10.txt
@@ -1,0 +1,14 @@
+Death be not proud, though some have callèd thee
+Mighty and dreadfull, for, thou art not so,
+For, those, whom thou think'st, thou dost overthrow,
+Die not, poore death, nor yet canst thou kill me.
+From rest and sleepe, which but thy pictures bee,
+Much pleasure, then from thee, much more must flow,
+And soonest our best men with thee doe goe,
+Rest of their bones, and soules deliverie.
+Thou art slave to Fate, Chance, kings, and desperate men,
+And dost with poyson, warre, and sicknesse dwell,
+And poppie, or charmes can make us sleepe as well,
+And better than thy stroake; why swell'st thou then;
+One short sleepe past, wee wake eternally,
+And death shall be no more, death, thou shalt die.

--- a/site/src/lib/authors.ts
+++ b/site/src/lib/authors.ts
@@ -77,6 +77,13 @@ export const AUTHOR_INFO: Record<string, AuthorInfo> = {
     source_label: "Wikipedia",
     source_url: "https://en.wikipedia.org/wiki/John_Keats",
   },
+  "john-donne": {
+    birth_year: 1572,
+    death_year: 1631,
+    bio: "English poet, preacher, and leading metaphysical writer, known for intellectually charged lyrics such as 'A Valediction: Forbidding Mourning' and the Holy Sonnets.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/John_Donne",
+  },
   "john-milton": {
     birth_year: 1608,
     death_year: 1674,
@@ -111,6 +118,20 @@ export const AUTHOR_INFO: Record<string, AuthorInfo> = {
     bio: "English poet and critic of the Romantic movement, known for 'The Rime of the Ancient Mariner' and collaboration with Wordsworth.",
     source_label: "Wikipedia",
     source_url: "https://en.wikipedia.org/wiki/Samuel_Taylor_Coleridge",
+  },
+  "george-herbert": {
+    birth_year: 1593,
+    death_year: 1633,
+    bio: "English poet and priest whose devotional lyrics in 'The Temple' combine metaphysical wit with compressed spiritual reflection.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/George_Herbert",
+  },
+  "andrew-marvell": {
+    birth_year: 1621,
+    death_year: 1678,
+    bio: "English poet and statesman associated with metaphysical and political verse, remembered for 'To His Coy Mistress' and other agile, argument-driven lyrics.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Andrew_Marvell",
   },
   "walt-whitman": {
     birth_year: 1819,


### PR DESCRIPTION
Closes #80

## Summary
Add a first metaphysical poets corpus wave to Freeverse.

## What changed
- add John Donne, George Herbert, and Andrew Marvell to the author registry
- add five poems with matching metadata sidecars
- use approved public-domain sources from Wikisource

## Included poems
- John Donne: A Valediction: Forbidding Mourning
- John Donne: Holy Sonnet 10
- George Herbert: Love (III)
- George Herbert: The Pulley
- Andrew Marvell: To His Coy Mistress

## Verification
- cd site && npm run build

## Notes
This is a small first wave rather than a full anthology. Text lineation and early-modern spelling were preserved from the source transcriptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five classic 17th-century poems to the collection: Andrew Marvell's "To His Coy Mistress," George Herbert's "Love (III)" and "The Pulley," and John Donne's "A Valediction: Forbidding Mourning" and "Holy Sonnet 10." Each poem includes author information, source attribution, and public domain documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->