### PR TITLE
feat: add romantic odes wave

### DIFF
--- a/meta/john-keats/bright-star.yml
+++ b/meta/john-keats/bright-star.yml
@@ -1,0 +1,15 @@
+id: "john-keats/bright-star"
+slug: "bright-star"
+author: "John Keats"
+author_slug: "john-keats"
+title: "Bright star, would I were stedfast as thou art"
+century: 19
+
+text_path: "poems/john-keats/bright-star.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Hundred_Best_Poems_(lyrical)_in_the_English_language_-_second_series/Bright_star,_would_I_were_stedfast_as_thou_art"
+public_domain_rationale: "Public domain in the United States: Keats died 1821; text from a 1904 Wikisource transcription of a public-domain anthology."
+
+notes: "Title follows the opening line on Wikisource; original spelling and punctuation preserved from the source transcription."

--- a/meta/samuel-taylor-coleridge/dejection-an-ode.yml
+++ b/meta/samuel-taylor-coleridge/dejection-an-ode.yml
@@ -1,0 +1,15 @@
+id: "samuel-taylor-coleridge/dejection-an-ode"
+slug: "dejection-an-ode"
+author: "Samuel Taylor Coleridge"
+author_slug: "samuel-taylor-coleridge"
+title: "Dejection: an Ode"
+century: 19
+
+text_path: "poems/samuel-taylor-coleridge/dejection-an-ode.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Sibylline_Leaves_(Coleridge)/Dejection:_an_Ode"
+public_domain_rationale: "Public domain in the United States: Coleridge died 1834; text from an 1817 Wikisource transcription of Sibylline Leaves."
+
+notes: "Keeps the source epigraph and stanza numbering; Wikisource errata notes and glossary footnotes were omitted from the poem text."

--- a/meta/william-wordsworth/tintern-abbey.yml
+++ b/meta/william-wordsworth/tintern-abbey.yml
@@ -1,0 +1,15 @@
+id: "william-wordsworth/tintern-abbey"
+slug: "tintern-abbey"
+author: "William Wordsworth"
+author_slug: "william-wordsworth"
+title: "Lines Composed a few Miles above Tintern Abbey"
+century: 19
+
+text_path: "poems/william-wordsworth/tintern-abbey.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Poems_(Wordsworth,_1815)/Volume_2/Tintern_Abbey"
+public_domain_rationale: "Public domain in the United States: published in an 1815 volume on Wikisource (pre-1929); Wordsworth died 1850."
+
+notes: "Running title shortened to the common form 'Tintern Abbey' for the slug; poem text omits Wikisource page notes and references."

--- a/poems/john-keats/bright-star.txt
+++ b/poems/john-keats/bright-star.txt
@@ -1,0 +1,14 @@
+BRIGHT star, would I were stedfast as thou art-
+Not in lone splendour hung aloft the night
+And watching, with eternal lids apart,
+Like nature's patient, sleepless Eremite,
+The moving waters at their priestlike task
+Of pure ablution round earth's human shores,
+Or gazing on the new soft-fallen mask
+Of snow upon the mountains and the moors
+No yet still stedfast, still unchangeable,
+Pillow'd upon my fair love's ripening breast,
+To feel for ever its soft fall and swell,
+Awake for ever in a sweet unrest,
+Still, still to hear her tender-taken breath,
+And so live ever or else swoon to death.

--- a/poems/samuel-taylor-coleridge/dejection-an-ode.txt
+++ b/poems/samuel-taylor-coleridge/dejection-an-ode.txt
@@ -1,0 +1,169 @@
+Late, late yestreen I saw the new Moon,
+With the old Moon in her arms;
+And I fear, I fear, my Master dear!
+We shall have a deadly storm.
+Ballad of Sir PATRICK SPENCE.
+
+I.
+
+Well! If the Bard was weather-wise, who made
+The grand old ballad of Sir Patrick Spence,
+This night, so tranquil now, will not go hence
+Unrous'd by winds, that ply a busier trade
+Than those which mould yon clouds in lazy flakes,
+Or the dull sobbing draft, that moans and rakes
+Upon the strings of this AEolian lute,
+Which better far were mute.
+For lo! the New-moon winter-bright!
+And overspread with phantom-light,
+(With swimming phantom-light o'erspread
+But rimm'd and circled by a silver thread)
+I see the old Moon in her lap, foretelling
+The coming on of rain and squally blast.
+And oh! that even now the gust were swelling,
+And the slant night-shower driving loud and fast!
+Those sounds which oft have raised me, whilst they awed,
+And sent my soul abroad,
+Might now perhaps their wonted impulse give,
+Might startle this dull pain, and make it move and live!
+
+II.
+
+A grief without a pang, void, dark, and drear,
+A stifled, drowsy, unimpassion'd grief,
+Which finds no natural outlet, no relief,
+In word, or sigh, or tear—
+O Lady! in this wan and heartless mood,
+To other thoughts by yonder throstle woo'd,
+All this long eve, so balmy and serene,
+Have I been gazing on the western sky,
+And it's peculiar tint of yellow green:
+And still I gaze—and with how blank an eye!
+And those thin clouds above, in flakes and bars,
+That give away their motion to the stars;
+Those stars, that glide behind them or between,
+Now sparkling, now bedimm'd, but always seen;
+Yon crescent Moon, as fix'd as if it grew
+In its own cloudless, starless lake of blue;
+I see them all so excellently fair,
+I see, not feel how beautiful they are!
+
+III.
+
+My genial spirits fail,
+And what can these avail,
+To lift the smoth'ring weight from off my breast?
+It were a vain endeavor,
+Though I should gaze for ever
+On that green light that lingers in the west:
+I may not hope from outward forms to win
+The passion and the life, whose fountains are within.
+
+IV.
+
+O Lady! we receive but what we give,
+And in our life alone does nature live:
+Ours is her wedding-garment, ours her shroud!
+And would we aught behold, of higher worth,
+Than that inanimate cold world allow'd
+To the poor loveless ever-anxious crowd,
+Ah! from the soul itself must issue forth,
+A light, a glory, a fair luminous cloud
+Enveloping the Earth—
+And from the soul itself must there be sent
+A sweet and potent voice, of its own birth,
+Of all sweet sounds the life and element!
+
+V.
+
+O pure of heart! thou need'st not ask of me
+What this strong music in the soul may be!
+What, and wherein it doth exist,
+This light, this glory, this fair luminous mist,
+This beautiful, and beauty-making power.
+Joy, virtuous Lady! Joy that ne'er was given,
+Save to the pure, and in their purest hour,
+Life, and Life's Effluence, Cloud at once and Shower,
+Joy, Lady! is the spirit and the power,
+Which wedding Nature to us gives in dow'r
+A new Earth and new Heaven,
+Undreamt of by the sensual and the proud—
+Joy is the sweet voice, Joy the luminous cloud—
+We in ourselves rejoice!
+And thence flows all that charms or ear or sight,
+All melodies the echoes of that voice,
+All colours a suffusion from that light.
+
+VI.
+
+There was a time when, though my path was rough,
+This joy within me dallied with distress,
+And all misfortunes were but as the stuff
+Whence Fancy made me dreams of happiness:
+For hope grew round me, like the twining vine,
+And fruits, and foliage, not my own, seem'd mine.
+But now afflictions bow me down to earth:
+Nor care I that they rob me of my mirth,
+But oh! each visitation
+Suspends what nature gave me at my birth,
+My shaping spirit of Imagination.
+For not to think of what I needs must feel,
+But to be still and patient, all I can;
+And haply by abstruse research to steal
+From my own nature all the natural Man—
+This was my sole resource, my only plan:
+Till that which suits a part infects the whole,
+And now is almost grown the habit of my Soul.
+
+VII.
+
+Hence, viper thoughts, that coil around my mind.
+Reality's dark dream!
+I turn from you, and listen to the wind,
+Which long has rav'd unnotic'd. What a scream
+Of agony by torture lengthen'd out
+That lute sent forth! Thou Wind, that rav'st without.
+Bare crag, or mountain-tairn,
+Or blasted tree.
+Or pine-grove whither woodman never clomb,
+Or lonely house, long held the witches' home,
+Methinks were fitter instruments for thee.
+Mad Lutanist! who in this month of show'rs,
+Of dark brown gardens, and of peeping flow'rs,
+Mak'st Devils' yule, with worse than wint'ry song,
+The blossoms, buds, and tim'rous leaves among.
+Thou Actor, perfect in all tragic sounds!
+Thou mighty Poet, e'en to Frenzy bold!
+What tell'st thou now about?
+'Tis of the Rushing of an Host in rout.
+With groans of trampled men, with smarting wounds—
+At once they groan with pain, and shudder with the cold!
+But hush! there is a pause of deepest silence!
+And all that noise, as of a rushing crowd,
+With groans, and tremulous shudderings—all is over—
+It tells another tale, with sounds less deep and loud!
+A tale of less aifright,
+And temper'd with delight,
+As Otway's self had fram'd the tender lay—
+'Tis of a little child
+Upon a lonesome wild,
+Not far from home, but she hath lost her way:
+And now moans low in bitter grief and fear,
+And now screams loud, and hopes to make her mother hear.
+
+VIII.
+
+'Tis midnight, but small thoughts have I of sleep:
+Full seldom may my friend such vigils keep!
+Visit her, gentle Sleep! with wings of healing,
+And may this storm be but a mountain-birth,
+May all the stars hang bright above her dwelling,
+Silent as though they watch'd the sleeping Earth!
+With light heart may she rise,
+Gay fancy, cheerful eyes,
+Joy lift her spirit, joy attune her voice:
+To her may all things live, from Pole to Pole,
+Their life the eddying of her living soul!
+O simple spirit, guided from above,
+Dear Lady! friend devoutest of my choice,
+Thus may'st thou ever, evermore rejoice.

--- a/poems/william-wordsworth/tintern-abbey.txt
+++ b/poems/william-wordsworth/tintern-abbey.txt
@@ -1,0 +1,164 @@
+FIVE years have passed; five summers, with the length
+Of five long winters! and again I hear
+These waters, rolling from their mountain-springs
+With a sweet inland murmur.—Once again
+Do I behold these steep and lofty cliffs,
+Which on a wild secluded scene impress
+Thoughts of more deep seclusion; and connect
+The landscape with the quiet of the sky.
+The day is come when I again repose
+Here, under this dark sycamore, and view
+These plots of cottage-ground, these orchard-tufts,
+Which, at this season, with their unripe fruits,
+Are clad in one green hue, and lose themselves
+Among the woods and copses, nor disturb
+The wild green landscape. Once again I see
+These hedge-rows, hardly hedge-rows, little lines
+Of sportive wood run wild; these pastoral farms
+Green to the very door; and wreaths of smoke
+Sent up, in silence, from among the trees;
+With some uncertain notice, as might seem,
+Of vagrant Dwellers in the houseless woods,
+Or of some Hermit's cave, where by his fire
+The Hermit sits alone.
+Though absent long,
+These forms of beauty have not been to me
+As is a landscape to a blind man's eye:
+But oft, in lonely rooms, and mid the din
+Of towns and cities, I have owed to them,
+In hours of weariness, sensations sweet,
+Felt in the blood, and felt along the heart;
+And passing even into my purer mind,
+With tranquil restoration:—feelings too
+Of unremembered pleasure: such, perhaps,
+As may have had no trivial influence
+On that best portion of a good man's life,
+His little, nameless, unremembered acts
+Of kindness and of love. Nor less, I trust,
+To them I may have owed another gift,
+Of aspect more sublime; that blessed mood,
+In which the burthen of the mystery,
+In which the heavy and the weary weight
+Of all this unintelligible world
+Is lightened:—that serene and blessed mood,
+In which the affections gently lead us on,—
+Until, the breath of this corporeal frame
+And even the motion of our human blood
+Almost suspended, we are laid asleep
+In body, and become a living soul:
+While with an eye made quiet by the power
+Of harmony, and the deep power of joy,
+We see into the life of things.
+If this
+Be but a vain belief, yet, oh! how oft,
+In darkness, and amid the many shapes
+Of joyless day-light; when the fretful stir
+Unprofitable, and the fever of the world,
+Have hung upon the beatings of my heart,
+How oft, in spirit, have I turned to thee,
+O sylvan Wye! Thou wanderer thro' the woods,
+How often has my spirit turned to thee!
+
+And now, with gleams of half-extinguished thought,
+With many recognitions dim and faint,
+And somewhat of a sad perplexity,
+The picture of the mind revives again:
+While here I stand, not only with the sense
+Of present pleasure, but with pleasing thoughts
+That in this moment there is life and food
+For future years. And so I dare to hope
+Though changed, no doubt; from what I was, when first
+I came among these hills; when like a roe
+I bounded o'er the mountains, by the sides
+Of the deep rivers, and the lonely streams,
+Wherever nature led: more like a man
+Flying from something that he dreads, than one
+Who sought the thing he loved. For nature then
+(The coarser pleasures of my boyish days,
+And their glad animal movements all gone by,)
+To me was all in all.—I cannot paint
+What then I was. The sounding cataract
+Haunted me like a passion: the tall rock,
+The mountain, and the deep and gloomy wood,
+Their colours and their forms, were then to me
+An appetite: a feeling and a love,
+That had no need of a remoter charm,
+By thought supplied, or any interest
+Unborrowed from the eye.—That time is past,
+And all its aching joys are now no more,
+And all its dizzy raptures. Not for this
+Faint I, nor mourn nor murmur; other gifts
+Have followed, for such loss, I would believe,
+Abundant recompense. For I have learned
+To look on nature, not as in the hour
+Of thoughtless youth; but hearing oftentimes
+The still, sad music of humanity,
+Nor harsh nor grating, though of ample power
+To chasten and subdue. And I have felt
+A presence that disturbs me with the joy
+Of elevated thoughts; a sense sublime
+Of something far more deeply interfused,
+Whose dwelling is the light of setting suns,
+And the round ocean and the living air,
+And the blue sky, and in the mind of man:
+A motion and a spirit, that impels
+All thinking things, all objects of all thought,
+And rolls through all things. Therefore am I still
+A lover of the meadows and the woods,
+And mountains; and of all that we behold
+From this green earth; of all the mighty world
+Of eye and ear, both what they half create,
+And what perceive; well pleased to recognize
+In nature and the language of the sense,
+The anchor of my purest thoughts, the nurse,
+The guide, the guardian of my heart, and soul
+Of all my moral beings.
+Nor perchance,
+If I were not thus taught, should I the more
+Suffer my genial spirits to decay:
+For thou art with me, here, upon the banks
+Of this fair river; thou, my dearest Friend,
+My dear, dear Friend, and in thy voice I catch
+The language of my former heart, and read
+My former pleasures in the shooting lights
+Of thy wild eyes. Oh! yet a little while
+May I behold in thee what I was once,
+My dear, dear Sister! And this prayer I make,
+Knowing that Nature never did betray
+The heart that loved her; 'tis her privilege,
+Through all the years of this our life, to lead
+From joy to joy: for she can so inform
+The mind that is within us, so impress
+With quietness and beauty, and so feed
+With lofty thoughts, that neither evil tongues,
+Rash judgments, nor the sneers of selfish men,
+Nor greetings where no kindness is, nor all
+The dreary intercourse of daily life,
+Shall e'er prevail against us, or disturb
+Our cheerful faith that all which we behold
+Is full of blessings. Therefore let the moon
+Shine on thee in thy solitary walk;
+And let the misty mountain winds be free
+To blow against thee: and, in after years,
+When these wild ecstasies shall be matured
+Into a sober pleasure, when thy mind
+Shall be a mansion for all lovely forms,
+Thy memory be as a dwelling-place
+For all sweet sounds and harmonies; Oh! then,
+If solitude, or fear, or pain, or grief,
+Should be thy portion, with what healing thoughts
+Of tender joy wilt thou remember me,
+And these my exhortations! Nor, perchance,
+If I should be where I no more can hear
+Thy voice, nor catch from thy wild eyes these gleams
+Of past existence, wilt thou then forget
+That on the banks of this delightful stream
+We stood together; and that I, so long
+A worshipper of Nature, hither came,
+Unwearied in that service: rather say
+With warmer love, oh! with far deeper zeal
+Of holier love. Nor wilt thou then forget,
+That after many wanderings, many years
+Of absence, these steep woods and lofty cliffs,
+And this green pastoral landscape, were to me
+More dear, both for themselves and for thy sake.

--- a/site/src/lib/collections.ts
+++ b/site/src/lib/collections.ts
@@ -40,13 +40,16 @@ const collectionRecords: CollectionRecord[] = [
     description:
       'A focused route through high-Romantic intensity: urns, skylarks, autumn, memory, and the unstable promise of transcendence.',
     poemIds: [
+      'john-keats/bright-star',
       'john-keats/ode-to-a-nightingale',
       'john-keats/ode-on-a-grecian-urn',
       'john-keats/to-autumn',
+      'samuel-taylor-coleridge/dejection-an-ode',
       'percy-bysshe-shelley/ozymandias',
       'percy-bysshe-shelley/to-a-skylark',
       'samuel-taylor-coleridge/kubla-khan',
       'william-wordsworth/i-wandered-lonely-as-a-cloud',
+      'william-wordsworth/tintern-abbey',
     ],
   },
 ];


### PR DESCRIPTION
Closes #81

## Summary
Add a focused Romantic-wave corpus expansion to Freeverse.

## What changed
- add John Keats's `Bright star, would I were stedfast as thou art`
- add William Wordsworth's `Lines Composed a few Miles above Tintern Abbey`
- add Samuel Taylor Coleridge's `Dejection: an Ode`
- add matching metadata sidecars for all three poems
- update the `romantic-odes` collection so the new poems appear in the curated reading path

## Verification
- `cd site && npm run build`

## Notes
Several issue candidates already existed in the corpus (`Ode to a Nightingale`, `To Autumn`, `Ozymandias`, `To a Skylark`, `Kubla Khan`), so this PR focuses on the highest-value missing poems instead of duplicating existing entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three romantic poems to the collection: "Bright Star" by John Keats, "Dejection: an Ode" by Samuel Taylor Coleridge, and "Lines Composed a few Miles above Tintern Abbey" by William Wordsworth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->