### PR TITLE
feat: add classical lyric wave

### DIFF
--- a/meta/catullus/womans-faith.yml
+++ b/meta/catullus/womans-faith.yml
@@ -1,0 +1,15 @@
+id: "catullus/womans-faith"
+slug: "womans-faith"
+author: "Catullus"
+author_slug: "catullus"
+title: "Woman's Faith"
+century: -1
+
+text_path: "poems/catullus/womans-faith.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Woman%27s_Faith"
+public_domain_rationale: "Public domain in the United States: Catullus died in the 1st century BC and Edward Shepherd Creasy's translation was published in 1851 on Wikisource."
+
+notes: "Translation of Catullus 70 by Edward Shepherd Creasy."

--- a/meta/horace/nunc-est-bibendum.yml
+++ b/meta/horace/nunc-est-bibendum.yml
@@ -1,0 +1,15 @@
+id: "horace/nunc-est-bibendum"
+slug: "nunc-est-bibendum"
+author: "Horace"
+author_slug: "horace"
+title: "Nunc est Bibendum"
+century: -1
+
+text_path: "poems/horace/nunc-est-bibendum.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/This_Canada_of_ours_and_other_poems/Nunc_est_Bibendum"
+public_domain_rationale: "Public domain in the United States: Horace died 8 BC and James David Edgar's translation was published in 1893 on Wikisource."
+
+notes: "English translation of Horace, Ode 1.37, by James David Edgar."

--- a/meta/sappho/an-hymn-to-venus.yml
+++ b/meta/sappho/an-hymn-to-venus.yml
@@ -1,0 +1,15 @@
+id: "sappho/an-hymn-to-venus"
+slug: "an-hymn-to-venus"
+author: "Sappho"
+author_slug: "sappho"
+title: "An Hymn to Venus"
+century: -6
+
+text_path: "poems/sappho/an-hymn-to-venus.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Pastorals_Epistles_Odes_(1748)/An_Hymn_to_Venus,_from_the_Greek_of_Sappho"
+public_domain_rationale: "Public domain in the United States: Sappho died in the 6th century BC and Ambrose Philips's translation was published in 1748 on Wikisource."
+
+notes: "English translation from the Greek by Ambrose Philips."

--- a/poems/catullus/womans-faith.txt
+++ b/poems/catullus/womans-faith.txt
@@ -1,0 +1,6 @@
+MY Mistress tells me oft, that she
+Would not prefer Great Jove to me.
+She tells me:--but I know full well
+What women eager lovers tell
+Ought to be written on the breeze,
+The running streams, and flowing seas.

--- a/poems/horace/nunc-est-bibendum.txt
+++ b/poems/horace/nunc-est-bibendum.txt
@@ -1,0 +1,39 @@
+NOW drink and dance, my comrades,
+And spread the splendid feast,
+The haughty Queen of Egypt
+Is fleeing to the East.
+
+When Caesar led his war-ships,
+Spread far in battle line,
+A panic fell upon her,
+Half mad with lust and wine.
+
+She fled before his galleys
+Far from the Italian shore;
+The herd of loathsome traitors
+Now threaten Rome no more.
+
+As swoops the eagle on the dove,
+The hunter on the hare,
+So Caesar followed swiftly
+To bind her in her lair.
+
+The daughter of a hundred kings,
+She spurned the Roman chains,
+And sought to spill the fiery blood
+That swelled her ruby veins.
+
+She failed! but in her woman's breast
+Her courage rose serene;
+She walked again her father's halls,
+And still was Egypt's queen.
+
+She pictured the proud triumph
+Beneath the Roman sky,
+And fiercely flamed her passion,
+And sternly flashed her eye;
+
+In her ears the chariots rumbled,
+In her ears the shoutings rang,
+Then she bared her snowy bosom
+To the serpent's poisoned fang.

--- a/poems/sappho/an-hymn-to-venus.txt
+++ b/poems/sappho/an-hymn-to-venus.txt
@@ -1,0 +1,55 @@
+I.
+[O] Venus, beauty of the skies,
+To whom a thousand temples rise,
+Gayly false in gentle smiles,
+Full of love-perplexing wiles,
+O goddess! from my heart remove
+The wasting cares and pains of love.
+
+II.
+If ever thou hast kindly hear'd
+A song in soft distress prefer'd,
+Propitious to my tuneful vow,
+O gentle goddess! hear me now.
+Descend thou bright, immortal, guest,
+In all thy radiant charms confess'd.
+
+III.
+Thou once didst leave almighty Jove,
+And all the golden roofs above:
+The car thy wanton sparrows drew;
+Hov'ring in air they lightly flew;
+As to my bower they wing'd their way,
+I saw their quiv'ring pinions play.
+
+IV.
+The birds dismiss'd (while you remain)
+Bore back their empty car again:
+Then you, with looks divinely mild,
+In ev'ry heav'nly feature smil'd,
+And ask'd, what new complaints I made,
+And why I call'd you to my aid?
+
+V.
+What frenzy in my bosom rag'd,
+And by what care to be asswag'd?
+What gentle youth I would allure,
+Whom in my artful toils secure?
+Who does thy tender heart subdue,
+Tell me, my Sappho, tell me who?
+
+VI.
+Tho now he shuns thy longing arms,
+He soon shall court thy slighted charms;
+Tho now thy off'rings he despise,
+He soon to thee shall sacrifice;
+Tho now he freez, he soon shall burn,
+And be thy victim in his turn.
+
+VII.
+Celestial visitant, once more
+Thy needful presence I implore!
+In pity come and ease my grief,
+Bring my distemper'd soul relief:
+Favour thy suppliant's hidden fires,
+And give me all my heart desires.

--- a/site/src/lib/authors.ts
+++ b/site/src/lib/authors.ts
@@ -6,6 +6,35 @@ export type AuthorInfo = {
   source_url: string;
 };
 
+function formatHistoricalYear(year: number): string {
+  return year < 0 ? `${Math.abs(year)} BC` : `${year}`;
+}
+
+function ordinal(value: number): string {
+  const mod100 = value % 100;
+  if (mod100 >= 11 && mod100 <= 13) return `${value}th`;
+
+  switch (value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+}
+
+export function formatAuthorYears(birthYear: number, deathYear: number): string {
+  return `${formatHistoricalYear(birthYear)}–${formatHistoricalYear(deathYear)}`;
+}
+
+export function formatCenturyLabel(century: number): string {
+  if (century < 0) return `${ordinal(Math.abs(century))} century BC`;
+  return `${ordinal(century)} century`;
+}
+
 export const AUTHOR_INFO: Record<string, AuthorInfo> = {
   "alfred-tennyson": {
     birth_year: 1809,
@@ -69,6 +98,20 @@ export const AUTHOR_INFO: Record<string, AuthorInfo> = {
     bio: "Roman lyric poet of the Augustan age, celebrated for the Odes and enduring maxims including 'non omnis moriar'.",
     source_label: "Wikipedia",
     source_url: "https://en.wikipedia.org/wiki/Horace",
+  },
+  catullus: {
+    birth_year: -84,
+    death_year: -54,
+    bio: "Roman lyric poet whose brief, intensely personal poems on love, betrayal, friendship, and invective shaped later European lyric.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Catullus",
+  },
+  sappho: {
+    birth_year: -630,
+    death_year: -570,
+    bio: "Archaic Greek lyric poet from Lesbos, famed for fragments on desire, devotion, and intimate speech that became foundational for lyric tradition.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Sappho",
   },
   "john-keats": {
     birth_year: 1795,

--- a/site/src/pages/author/[slug].astro
+++ b/site/src/pages/author/[slug].astro
@@ -1,7 +1,7 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { loadPoemMetas, type PoemMeta } from "../../lib/poems";
-import { AUTHOR_INFO } from "../../lib/authors";
+import { AUTHOR_INFO, formatAuthorYears, formatCenturyLabel } from "../../lib/authors";
 
 type AuthorPageProps = {
   author: string;
@@ -53,7 +53,7 @@ const description = `Read public-domain poems by ${author}.`;
     </p>
     {info ? (
       <p class="muted" style="margin: 0.55rem 0 0.25rem;">
-        {info.birth_year}–{info.death_year}
+        {formatAuthorYears(info.birth_year, info.death_year)}
       </p>
     ) : null}
     {info ? (
@@ -79,7 +79,7 @@ const description = `Read public-domain poems by ${author}.`;
             <strong>{p.title}</strong>
           </a>
           <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">
-            {p.century}th century
+            {formatCenturyLabel(p.century)}
           </div>
         </li>
       ))}

--- a/site/src/pages/authors/index.astro
+++ b/site/src/pages/authors/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { loadPoemMetas } from "../../lib/poems";
 import { authorPath } from "../../lib/url";
+import { AUTHOR_INFO, formatAuthorYears } from "../../lib/authors";
 import { AUTHOR_INFO } from "../../lib/authors";
 
 const base = import.meta.env.BASE_URL.endsWith("/")
@@ -45,7 +46,7 @@ authors.sort((a, b) => a.name.localeCompare(b.name));
               <strong>{a.name}</strong>
             </a>
             <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">
-              {info ? `${info.birth_year}–${info.death_year}` : "Dates unavailable"} · {a.count} poem{a.count === 1 ? "" : "s"}
+              {info ? formatAuthorYears(info.birth_year, info.death_year) : "Dates unavailable"} · {a.count} poem{a.count === 1 ? "" : "s"}
             </div>
           </li>
         );

--- a/site/src/pages/browse/index.astro
+++ b/site/src/pages/browse/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
+import { formatCenturyLabel } from "../../lib/authors";
 import { loadPoemMetas } from "../../lib/poems";
 import { authorPath } from "../../lib/url";
 
@@ -128,7 +129,7 @@ const defaultStatus = `Showing ${statsLabel}. All author groups start collapsed.
                     <strong>{poem.title}</strong>
                   </a>
                   <span class="muted browse-poem-century">
-                    {poem.century}th century
+                    {formatCenturyLabel(poem.century)}
                   </span>
                   <span class="browse-star" role="img" aria-label="Starred">★</span>
                 </div>

--- a/site/src/pages/search.astro
+++ b/site/src/pages/search.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
+import { formatCenturyLabel } from "../lib/authors";
 import { loadPoemMetas } from "../lib/poems";
 import { authorPath } from "../lib/url";
 
@@ -14,6 +15,7 @@ const docs = poems.map((p) => ({
   author: p.author,
   authorUrl: authorPath(base, p.author_slug),
   century: p.century,
+  centuryLabel: formatCenturyLabel(p.century),
   url: `${base}poem/${p.id}/`,
 }));
 ---
@@ -46,7 +48,7 @@ const docs = poems.map((p) => ({
 
     const mini = new MiniSearch({
       fields: ['title', 'author'],
-      storeFields: ['id', 'title', 'author', 'authorUrl', 'url', 'century'],
+      storeFields: ['id', 'title', 'author', 'authorUrl', 'url', 'century', 'centuryLabel'],
       searchOptions: {
         boost: { title: 2 },
         fuzzy: 0.2,
@@ -71,7 +73,7 @@ const docs = poems.map((p) => ({
             <span class="muted">— <a class="muted" href="${r.authorUrl}">${r.author}</a></span>
           </div>
           <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">
-            ${r.century}th century
+            ${r.centuryLabel}
           </div>
         `;
         resultsEl.appendChild(li);


### PR DESCRIPTION
Closes #83

## Summary
Add a first classical lyric wave to Freeverse from approved public-domain translations.

## What changed
- add Horace's `Nunc est Bibendum` in James David Edgar's 1893 translation
- add Catullus's `Woman's Faith` in Edward Shepherd Creasy's translation of Catullus 70
- add Sappho's `An Hymn to Venus` in Ambrose Philips's translation
- add author registry entries for Catullus and Sappho
- fix BC year and BC century display across author, browse, and search pages

## Verification
- `cd site && npm run build`

## Notes
This is a deliberately small first wave chosen from stable, easily attributable Wikisource pages. It gives the corpus one clean translation for each target classical author while also correcting the site's ancient-date rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new classical poems: "Woman's Faith" (Catullus), "Nunc est Bibendum" (Horace), and "An Hymn to Venus" (Sappho). Each includes complete source attribution and translator information linked to Wikisource.
  * Improved historical date formatting: author lifespans now display with proper year formatting, and poem centuries display with correct ordinal labels and era designations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->