### PR TITLE
Add static semantic search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ site/playwright-report/
 # Generated site data
 site/src/data/poem-index.json
 site/src/data/dedupe-report.json
+site/public/api/search-index.json
 
 # local ops
 inbox

--- a/site/package.json
+++ b/site/package.json
@@ -3,9 +3,9 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "predev": "node scripts/build-poem-index.mjs",
+    "predev": "node scripts/build-poem-index.mjs && node scripts/build-search-index.mjs",
     "dev": "astro dev",
-    "prebuild": "node scripts/build-poem-index.mjs",
+    "prebuild": "node scripts/build-poem-index.mjs && node scripts/build-search-index.mjs",
     "build": "astro build",
     "preview": "astro preview",
     "test": "npm run test:unit && npm run test:e2e",

--- a/site/scripts/build-poem-index.mjs
+++ b/site/scripts/build-poem-index.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import crypto from "node:crypto";
+import yaml from "js-yaml";
 
 const REQUIRED_FIELDS = [
   "id",
@@ -21,33 +22,6 @@ const outputPath = path.join(process.cwd(), "src", "data", "poem-index.json");
 const dedupeReportPath = path.join(process.cwd(), "src", "data", "dedupe-report.json");
 
 const STATIC_PAGE_LIMIT = 5000;
-
-function parseScalar(raw) {
-  const t = raw.trim();
-  if (t === "true") return true;
-  if (t === "false") return false;
-  if (/^-?\d+$/.test(t)) return Number(t);
-  if ((t.startsWith('"') && t.endsWith('"')) || (t.startsWith("'") && t.endsWith("'"))) {
-    return t.slice(1, -1).replace(/\\"/g, '"').replace(/\\'/g, "'");
-  }
-  return t;
-}
-
-function parseSimpleYaml(raw) {
-  const out = {};
-  const lines = raw.replace(/\r\n?/g, "\n").split("\n");
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const i = line.indexOf(":");
-    if (i === -1) continue;
-    const key = line.slice(0, i).trim();
-    const value = line.slice(i + 1).trim();
-    if (!key) continue;
-    out[key] = parseScalar(value);
-  }
-  return out;
-}
 
 function sha256(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
@@ -114,7 +88,7 @@ async function main() {
       if (!f.isFile() || !f.name.endsWith(".yml")) continue;
       const full = path.join(dir, f.name);
       const raw = await fs.readFile(full, "utf8");
-      const parsed = parseSimpleYaml(raw);
+      const parsed = yaml.load(raw);
       if (!parsed || typeof parsed !== "object") {
         errors.push(`${full}: metadata is not a YAML object`);
         continue;

--- a/site/scripts/build-search-index.mjs
+++ b/site/scripts/build-search-index.mjs
@@ -1,0 +1,153 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  detectThemes,
+  normalizeSearchText,
+  tokenizeSearchText,
+} from "../src/lib/search-taxonomy.mjs";
+import { collectionRecords } from "../src/lib/collection-records.mjs";
+import poemIndex from "../src/data/poem-index.json" with { type: "json" };
+
+const repoRoot = path.resolve(process.cwd(), "..");
+const outputPath = path.join(process.cwd(), "public", "api", "search-index.json");
+
+const KEYWORD_STOP_WORDS = new Set([
+  "among",
+  "been",
+  "from",
+  "have",
+  "into",
+  "more",
+  "must",
+  "shall",
+  "than",
+  "their",
+  "them",
+  "they",
+  "this",
+  "those",
+  "upon",
+  "were",
+  "when",
+  "which",
+  "while",
+  "with",
+  "would",
+  "your",
+]);
+
+function buildExcerpt(text) {
+  const lines = text
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.trimEnd());
+
+  const excerpt = [];
+  for (const line of lines) {
+    if (!line.trim()) {
+      if (excerpt.length > 0) break;
+      continue;
+    }
+
+    excerpt.push(line.trim());
+    if (excerpt.length >= 4) break;
+  }
+
+  return excerpt.join(" ");
+}
+
+function buildKeywords(text) {
+  const counts = new Map();
+  for (const token of tokenizeSearchText(text)) {
+    if (token.length < 4) continue;
+    if (KEYWORD_STOP_WORDS.has(token)) continue;
+    counts.set(token, (counts.get(token) || 0) + 1);
+  }
+
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 12)
+    .map(([token]) => token);
+}
+
+async function main() {
+  const poems = poemIndex.poems || [];
+  const collectionsByPoemId = new Map();
+
+  for (const collection of collectionRecords) {
+    for (const poemId of collection.poemIds) {
+      const existing = collectionsByPoemId.get(poemId) || [];
+      existing.push(collection);
+      collectionsByPoemId.set(poemId, existing);
+    }
+  }
+
+  const docs = [];
+
+  for (const poem of poems) {
+    let text = "";
+    if (poem.text_in_repo && poem.text_path) {
+      text = await fs.readFile(path.join(repoRoot, poem.text_path), "utf8");
+    }
+
+    const excerpt = buildExcerpt(text);
+    const collections = collectionsByPoemId.get(poem.id) || [];
+    const matchedThemes = Array.from(
+      new Map(
+        [
+          ...collections.flatMap((collection) => detectThemes(`${collection.title} ${collection.description}`, { minSignals: 1 })),
+          ...detectThemes(poem.title, { minSignals: 1 }),
+          ...detectThemes(`${excerpt}\n${text}`, { minSignals: 2 }),
+        ].map((theme) => [theme.id, theme]),
+      ).values(),
+    );
+    const themes = matchedThemes.map((theme) => theme.label);
+    const semanticTerms = Array.from(
+      new Set(
+        matchedThemes.flatMap((theme) => [
+          theme.id,
+          theme.label.toLowerCase(),
+          ...theme.queryTerms,
+        ]),
+      ),
+    );
+    const keywords = buildKeywords(`${poem.title} ${excerpt} ${text}`);
+
+    docs.push({
+      id: poem.id,
+      title: poem.title,
+      author: poem.author,
+      century: poem.century,
+      excerpt,
+      collections: collections.map((collection) => collection.title),
+      themes,
+      semanticTerms,
+      keywords,
+      searchText: normalizeSearchText(
+        [
+          poem.title,
+          poem.author,
+          excerpt,
+          collections.map((collection) => `${collection.title} ${collection.description}`).join(" "),
+          themes.join(" "),
+          semanticTerms.join(" "),
+          keywords.join(" "),
+        ].join(" "),
+      ),
+    });
+  }
+
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(
+    outputPath,
+    `${JSON.stringify({ generated_at: new Date().toISOString(), poems: docs }, null, 2)}\n`,
+    "utf8",
+  );
+
+  console.log(`Wrote semantic search index (${docs.length} poems)`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/site/src/lib/collection-records.mjs
+++ b/site/src/lib/collection-records.mjs
@@ -1,0 +1,38 @@
+export const collectionRecords = [
+  {
+    slug: 'grief-and-mortality',
+    title: 'Grief and Mortality',
+    dek: 'Elegies, reckonings, and poems that refuse to look away.',
+    description:
+      'A first curated path through death, mourning, and the afterlife, moving from lyric sorrow to harder forms of endurance.',
+    poemIds: [
+      'edgar-allan-poe/annabel-lee',
+      'edgar-allan-poe/the-raven',
+      'emily-dickinson/after-great-pain-a-formal-feeling-comes',
+      'emily-dickinson/as-imperceptibly-as-grief',
+      'emily-dickinson/i-felt-a-funeral-in-my-brain',
+      'emily-dickinson/i-measure-every-grief-i-meet',
+      'emily-dickinson/because-i-could-not-stop-for-death',
+      'william-ernest-henley/invictus',
+    ],
+  },
+  {
+    slug: 'romantic-odes',
+    title: 'Romantic Odes',
+    dek: 'A compact path through attention, beauty, and ruin.',
+    description:
+      'A focused route through high-Romantic intensity: urns, skylarks, autumn, memory, and the unstable promise of transcendence.',
+    poemIds: [
+      'john-keats/bright-star',
+      'john-keats/ode-to-a-nightingale',
+      'john-keats/ode-on-a-grecian-urn',
+      'john-keats/to-autumn',
+      'samuel-taylor-coleridge/dejection-an-ode',
+      'percy-bysshe-shelley/ozymandias',
+      'percy-bysshe-shelley/to-a-skylark',
+      'samuel-taylor-coleridge/kubla-khan',
+      'william-wordsworth/i-wandered-lonely-as-a-cloud',
+      'william-wordsworth/tintern-abbey',
+    ],
+  },
+];

--- a/site/src/lib/collections.ts
+++ b/site/src/lib/collections.ts
@@ -1,4 +1,5 @@
 import { loadPoemMetas, type PoemMeta } from './poems';
+import { collectionRecords } from './collection-records.mjs';
 
 export type CollectionRecord = {
   slug: string;
@@ -16,45 +17,6 @@ export type RelatedPoem = {
   poem: PoemMeta;
   reason: string;
 };
-
-const collectionRecords: CollectionRecord[] = [
-  {
-    slug: 'grief-and-mortality',
-    title: 'Grief and Mortality',
-    dek: 'Elegies, reckonings, and poems that refuse to look away.',
-    description:
-      'A first curated path through death, mourning, and the afterlife, moving from lyric sorrow to harder forms of endurance.',
-    poemIds: [
-      'edgar-allan-poe/annabel-lee',
-      'edgar-allan-poe/the-raven',
-      'emily-dickinson/after-great-pain-a-formal-feeling-comes',
-      'emily-dickinson/as-imperceptibly-as-grief',
-      'emily-dickinson/i-felt-a-funeral-in-my-brain',
-      'emily-dickinson/i-measure-every-grief-i-meet',
-      'emily-dickinson/because-i-could-not-stop-for-death',
-      'william-ernest-henley/invictus',
-    ],
-  },
-  {
-    slug: 'romantic-odes',
-    title: 'Romantic Odes',
-    dek: 'A compact path through attention, beauty, and ruin.',
-    description:
-      'A focused route through high-Romantic intensity: urns, skylarks, autumn, memory, and the unstable promise of transcendence.',
-    poemIds: [
-      'john-keats/bright-star',
-      'john-keats/ode-to-a-nightingale',
-      'john-keats/ode-on-a-grecian-urn',
-      'john-keats/to-autumn',
-      'samuel-taylor-coleridge/dejection-an-ode',
-      'percy-bysshe-shelley/ozymandias',
-      'percy-bysshe-shelley/to-a-skylark',
-      'samuel-taylor-coleridge/kubla-khan',
-      'william-wordsworth/i-wandered-lonely-as-a-cloud',
-      'william-wordsworth/tintern-abbey',
-    ],
-  },
-];
 
 export async function loadCollections(): Promise<CollectionWithPoems[]> {
   const poems = await loadPoemMetas();

--- a/site/src/lib/search-taxonomy.mjs
+++ b/site/src/lib/search-taxonomy.mjs
@@ -1,0 +1,138 @@
+const DEFAULT_STOP_WORDS = [
+  "a",
+  "about",
+  "an",
+  "and",
+  "for",
+  "in",
+  "into",
+  "of",
+  "on",
+  "or",
+  "poem",
+  "poems",
+  "the",
+  "to",
+  "with",
+];
+
+export const SEARCH_STOP_WORDS = new Set(DEFAULT_STOP_WORDS);
+
+export const SEMANTIC_THEMES = [
+  {
+    id: "grief",
+    label: "Grief and mortality",
+    queryTerms: ["grief", "mourning", "loss", "death", "funeral", "afterlife", "mortality", "sorrow"],
+    signalTerms: ["grief", "mourning", "loss", "death", "dead", "dying", "funeral", "tomb", "grave", "coffin", "afterlife", "sorrow"],
+  },
+  {
+    id: "love",
+    label: "Love and desire",
+    queryTerms: ["love", "desire", "beloved", "heart", "romance", "passion"],
+    signalTerms: ["love", "beloved", "heart", "kiss", "desire", "lover", "romance", "passion"],
+  },
+  {
+    id: "nature",
+    label: "Nature and seasons",
+    queryTerms: ["nature", "season", "spring", "summer", "autumn", "winter", "flower", "garden"],
+    signalTerms: ["nature", "spring", "summer", "autumn", "winter", "flower", "flowers", "rose", "garden", "field", "tree", "leaf", "leaves"],
+  },
+  {
+    id: "night",
+    label: "Night and dream",
+    queryTerms: ["night", "dream", "moon", "sleep", "dark", "midnight", "star"],
+    signalTerms: ["night", "dream", "dreams", "moon", "sleep", "dark", "midnight", "star", "stars", "shadow"],
+  },
+  {
+    id: "sea",
+    label: "Sea and voyage",
+    queryTerms: ["sea", "ocean", "shore", "voyage", "ship", "sail", "harbor"],
+    signalTerms: ["sea", "ocean", "shore", "wave", "waves", "ship", "ships", "sail", "harbor", "harbour", "voyage", "tide"],
+  },
+  {
+    id: "faith",
+    label: "Faith and devotion",
+    queryTerms: ["faith", "devotion", "prayer", "god", "soul", "heaven", "hymn"],
+    signalTerms: ["faith", "prayer", "god", "soul", "heaven", "divine", "hymn", "saint", "altar", "angel"],
+  },
+  {
+    id: "war",
+    label: "War and history",
+    queryTerms: ["war", "battle", "history", "empire", "nation", "soldier", "king"],
+    signalTerms: ["war", "battle", "empire", "nation", "soldier", "soldiers", "king", "queen", "history", "ruin", "ruins", "victory"],
+  },
+  {
+    id: "solitude",
+    label: "Solitude and inwardness",
+    queryTerms: ["solitude", "lonely", "silence", "memory", "mind", "inward", "alone"],
+    signalTerms: ["solitude", "lonely", "silence", "memory", "mind", "alone", "inward", "silent", "thought", "thoughts"],
+  },
+  {
+    id: "birdsong",
+    label: "Birdsong and music",
+    queryTerms: ["bird", "birdsong", "music", "song", "voice", "skylark", "nightingale"],
+    signalTerms: ["bird", "birds", "music", "song", "songs", "voice", "voices", "sing", "singing", "skylark", "nightingale"],
+  },
+];
+
+const THEME_LOOKUP = new Map(
+  SEMANTIC_THEMES.flatMap((theme) =>
+    [...theme.queryTerms, ...theme.signalTerms].map((term) => [term.toLowerCase(), theme]),
+  ),
+);
+
+export function normalizeSearchText(value) {
+  return value
+    .toLowerCase()
+    .replace(/\r\n?/g, "\n")
+    .replace(/[‘’]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/[—–]/g, "-")
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function tokenizeSearchText(value) {
+  return normalizeSearchText(value)
+    .split(" ")
+    .filter(Boolean)
+    .filter((token) => !SEARCH_STOP_WORDS.has(token));
+}
+
+function countSignalHits(normalized, signalTerms) {
+  let hits = 0;
+
+  for (const term of signalTerms) {
+    const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`(^|\\s)${escaped}(?=$|\\s)`, "i");
+    if (pattern.test(normalized)) hits += 1;
+  }
+
+  return hits;
+}
+
+export function detectThemes(value, options = {}) {
+  const { minSignals = 1 } = options;
+  const normalized = normalizeSearchText(value);
+
+  return SEMANTIC_THEMES.filter(
+    (theme) => countSignalHits(normalized, theme.signalTerms) >= minSignals,
+  );
+}
+
+export function expandSearchTerms(value) {
+  const tokens = tokenizeSearchText(value);
+  const expanded = new Set(tokens);
+
+  for (const token of tokens) {
+    const theme = THEME_LOOKUP.get(token);
+    if (!theme) continue;
+
+    expanded.add(theme.id);
+    expanded.add(theme.label.toLowerCase());
+    for (const term of theme.queryTerms) expanded.add(term);
+  }
+
+  return Array.from(expanded);
+}

--- a/site/src/pages/search.astro
+++ b/site/src/pages/search.astro
@@ -20,10 +20,10 @@ const docs = poems.map((p) => ({
 }));
 ---
 
-<BaseLayout title="Search · Freeverse" description="Search poems by title or author." currentPath="/search">
+<BaseLayout title="Search · Freeverse" description="Search poems by title, author, theme, or mood." currentPath="/search">
   <section class="hero">
     <h1>Search</h1>
-    <p class="lede">Type a title or author. Instant results. No server.</p>
+    <p class="lede">Type a title, author, theme, or mood. Instant results from a build-time semantic index.</p>
   </section>
 
   <div class="card">
@@ -31,35 +31,50 @@ const docs = poems.map((p) => ({
       <input
         id="q"
         type="search"
-        placeholder="Search titles and authors…"
+        placeholder="Try grief, night, sea, prayer, or a title..."
         autocomplete="off"
         style="flex: 1 1 18rem; padding: 0.6rem 0.75rem; border-radius: 12px; border: 1px solid var(--card-border); background: color-mix(in oklab, var(--paper) 92%, transparent); font-family: var(--sans); font-size: 1rem;"
       />
       <span class="pill" id="count">{docs.length} poems</span>
     </div>
 
+    <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-top:0.75rem;">
+      {['grief', 'love', 'nature', 'night', 'sea', 'faith', 'solitude'].map((term) => (
+        <button class="pill" type="button" data-suggestion={term} style="cursor:pointer; border:0;">
+          {term}
+        </button>
+      ))}
+    </div>
+
     <ul class="list" id="results" style="margin-top: 0.75rem;"></ul>
   </div>
 
-  <script type="module">
+  <script type="module" define:vars={{ base }}>
     import MiniSearch from 'minisearch';
+    import { expandSearchTerms, normalizeSearchText } from '../lib/search-taxonomy.mjs';
 
     const docs = JSON.parse(document.getElementById('search-data').textContent);
+    const searchIndexResponse = await fetch(`${base}api/search-index.json`);
+    const searchIndex = await searchIndexResponse.json();
+    const semanticDocs = new Map(searchIndex.poems.map((doc) => [doc.id, doc]));
+    const mergedDocs = docs.map((doc) => ({ ...semanticDocs.get(doc.id), ...doc }));
 
     const mini = new MiniSearch({
-      fields: ['title', 'author'],
-      storeFields: ['id', 'title', 'author', 'authorUrl', 'url', 'century', 'centuryLabel'],
+      fields: ['title', 'author', 'collections', 'themes', 'semanticTerms', 'keywords', 'excerpt', 'searchText'],
+      storeFields: ['id', 'title', 'author', 'authorUrl', 'url', 'century', 'centuryLabel', 'excerpt', 'themes', 'collections'],
       searchOptions: {
-        boost: { title: 2 },
+        boost: { title: 3, author: 2, collections: 4, themes: 5, semanticTerms: 5, keywords: 2, excerpt: 1 },
         fuzzy: 0.2,
         prefix: true,
       },
     });
-    mini.addAll(docs);
+    mini.addAll(mergedDocs);
 
     const input = document.getElementById('q');
     const resultsEl = document.getElementById('results');
     const countEl = document.getElementById('count');
+    const params = new URLSearchParams(window.location.search);
+    const suggestions = Array.from(document.querySelectorAll('[data-suggestion]'));
 
     const render = (items) => {
       resultsEl.innerHTML = '';
@@ -75,6 +90,9 @@ const docs = poems.map((p) => ({
           <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">
             ${r.centuryLabel}
           </div>
+          ${r.excerpt ? `<p class="muted" style="margin-top:0.45rem;">${r.excerpt}</p>` : ''}
+          ${r.collections?.length ? `<div class="muted" style="margin-top:0.45rem; font-family: var(--sans); font-size: 0.9rem;">Curated path: ${r.collections.join(', ')}</div>` : ''}
+          ${r.themes?.length ? `<div style="display:flex; gap:0.35rem; flex-wrap:wrap; margin-top:0.45rem;">${r.themes.map((theme) => `<span class="pill">${theme}</span>`).join('')}</div>` : ''}
         `;
         resultsEl.appendChild(li);
       }
@@ -91,13 +109,44 @@ const docs = poems.map((p) => ({
       if (!q) {
         countEl.textContent = `${docs.length} poems`;
         resultsEl.innerHTML = '';
+        params.delete('q');
+        history.replaceState({}, '', `${window.location.pathname}`);
         return;
       }
-      const hits = mini.search(q, { combineWith: 'AND' }).slice(0, 50).map(h => h);
+
+      const exactQuery = normalizeSearchText(q);
+      const expandedQuery = expandSearchTerms(q).join(' ');
+      const exactHits = exactQuery
+        ? mini.search(exactQuery, { combineWith: 'AND', prefix: true, fuzzy: 0.15 })
+        : [];
+      const semanticHits = expandedQuery
+        ? mini.search(expandedQuery, { combineWith: 'OR', prefix: true, fuzzy: 0.2 })
+        : [];
+
+      const mergedHits = new Map();
+      for (const hit of [...exactHits, ...semanticHits]) {
+        const existing = mergedHits.get(hit.id);
+        if (!existing || hit.score > existing.score) mergedHits.set(hit.id, hit);
+      }
+
+      const hits = Array.from(mergedHits.values())
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 50);
+
+      params.set('q', q);
+      history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
       render(hits);
     };
 
     input.addEventListener('input', run);
+    for (const button of suggestions) {
+      button.addEventListener('click', () => {
+        input.value = button.dataset.suggestion ?? '';
+        run();
+      });
+    }
+    input.value = params.get('q') ?? '';
+    if (input.value) run();
     input.focus();
   </script>
 

--- a/site/tests/unit/search-taxonomy.test.ts
+++ b/site/tests/unit/search-taxonomy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectThemes, expandSearchTerms, tokenizeSearchText } from '../../src/lib/search-taxonomy.mjs';
+
+describe('search taxonomy', () => {
+  it('strips generic search filler words', () => {
+    expect(tokenizeSearchText('poems about grief and loss')).toEqual(['grief', 'loss']);
+  });
+
+  it('expands thematic queries into semantic terms', () => {
+    const expanded = expandSearchTerms('poems about grief');
+
+    expect(expanded).toContain('grief');
+    expect(expanded).toContain('mourning');
+    expect(expanded).toContain('funeral');
+  });
+
+  it('detects themes from poem text signals', () => {
+    const themes = detectThemes('I felt a Funeral, in my Brain, and grief kept treading.');
+
+    expect(themes.map((theme) => theme.id)).toContain('grief');
+  });
+});


### PR DESCRIPTION
Closes #71

## Summary
- add a build-time semantic search artifact consumed by `/search`
- expand search ranking to use themes, moods, excerpts, and curated collections
- replace the ad-hoc YAML parser in `build-poem-index.mjs` with `js-yaml`

## Notes
- The original issue called for remote embeddings on BLD, but `192.168.50.252:11434` was not reachable from this workspace.
- I took the issue's allowed lightweight-alternative path instead: a static semantic index generated at build time and served as `/api/search-index.json`.
- This keeps search fast, rebuild-driven, and deployable with the existing static Astro site.

## Verification
- `cd site && npm run test:unit`
- `cd site && npm run build`
- smoke query: `poems about grief` surfaces the curated grief corpus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search results now include poem excerpts, collection metadata, and theme labels
  * Enhanced search indexing with semantic term detection and keyword extraction
  * Improved search result relevance through theme-based query expansion

* **Tests**
  * Added unit test coverage for search taxonomy functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->