### PR TITLE
Add Claude Code workflow

### DIFF
--- a/.github/claude/mcp.json
+++ b/.github/claude/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "astro-docs": {
+      "type": "http",
+      "url": "https://mcp.docs.astro.build/mcp"
+    }
+  }
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,44 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened]
+  workflow_dispatch:
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && (
+        contains(github.event.issue.title, '@claude') ||
+        contains(github.event.issue.body, '@claude')
+      )) ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are working in the Freeverse repository.
+            Use the Astro Docs MCP server for Astro-specific questions before answering or editing.
+            Keep changes scoped to the user request or triggering thread.
+          claude_args: |
+            --mcp-config .github/claude/mcp.json
+            --allowedTools "mcp__astro-docs__search_astro_docs,Bash(cd site && npm ci),Bash(cd site && npm run build),Bash(cd site && npm run test:unit),Bash(cd site && npm run test:unit:coverage)"


### PR DESCRIPTION
Closes #72

## Summary
- add `claude.yml` for `@claude` issue/PR comment handling and new issues
- add a checked-in Astro Docs MCP config for HTTP transport
- wire `anthropics/claude-code-action@beta` with the required repo permissions

## Notes
- The workflow is mergeable as configuration-only work.
- Actual runtime use still depends on `ANTHROPIC_API_KEY` being present in repo Actions secrets.
- The Astro Docs MCP server is configured at `https://mcp.docs.astro.build/mcp` using HTTP transport.

## Validation
- parsed `.github/workflows/claude.yml`
- parsed `.github/claude/mcp.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow to enable Claude Code assistance in issues and pull requests (triggered via `@claude` mentions).
  * Configured AI-powered documentation integration for enhanced code assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->