### PR TITLE
Improve reader and search accessibility

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -67,10 +67,11 @@ const ogImageUrl = site ? new URL(`${base}og.png`, site).toString() : undefined;
     <title>{title}</title>
   </head>
   <body>
+    <a class="skip-link" href="#main-content">Skip to main content</a>
     <div class="container">
       <div class="shell">
         <SiteHeader currentPath={currentPath} />
-        <main>
+        <main id="main-content" tabindex="-1">
           <slot />
         </main>
         <footer class="footer">

--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -74,19 +74,30 @@ const canonicalPath = `${base}poem/${poem.id}/`;
     </header>
 
     {raw ? (
-      <ol class="poem-lines" aria-label="Poem">
+      <>
+        <p id="poem-reader-instructions" class="sr-only">
+          Use Tab to move through poem lines. Press Enter or Space to select a line. Hold Shift while selecting a second line to create a shared range.
+        </p>
+        <ol class="poem-lines" aria-label="Poem" aria-describedby="poem-reader-instructions">
         {lines.map((line, idx) => {
           const n = idx + 1;
           const id = `l${n}`;
           const isBlank = line === "";
           return (
-            <li id={id} data-line={n} class={isBlank ? "is-blank" : ""} aria-label={isBlank ? "Stanza break" : undefined}>
+            <li
+              id={id}
+              data-line={n}
+              class={isBlank ? "is-blank" : ""}
+              aria-label={isBlank ? "Stanza break" : undefined}
+              tabindex={isBlank ? undefined : 0}
+            >
               <span class="line-anchor" aria-hidden="true" data-line={n}></span>
               <span class="line-text">{isBlank ? "\u00A0" : line}</span>
             </li>
           );
         })}
-      </ol>
+        </ol>
+      </>
     ) : (
       <div class="card">
         <p class="muted" style="margin:0;">
@@ -204,10 +215,13 @@ const canonicalPath = `${base}poem/${poem.id}/`;
         const copyQuoteCardTextButton = document.querySelector('[data-copy-quote-card-text]');
         const nativeShareButton = document.querySelector('[data-native-share]');
         const closeQuoteCardButtons = Array.from(document.querySelectorAll('[data-close-quote-card]'));
+        const quoteCardPanel = document.querySelector('[data-quote-card-modal] .quote-card-panel');
+        const quoteCardCloseButton = document.querySelector('[data-close-quote-card].quote-card-close');
         const poemId = article.dataset.poemId || '';
         const poemTitle = article.dataset.poemTitle || '';
         const poemAuthor = article.dataset.poemAuthor || '';
         const shareBase = article.dataset.shareBase || '/';
+        let lastFocusedElement = null;
 
         const applyReaderMode = (mode) => {
           const nextMode = mode === 'scholar' ? 'scholar' : 'clean';
@@ -395,14 +409,17 @@ const canonicalPath = `${base}poem/${poem.id}/`;
           if (!quoteCardModal) return;
           quoteCardModal.hidden = true;
           document.body.classList.remove('quote-card-open');
+          if (lastFocusedElement instanceof HTMLElement) lastFocusedElement.focus();
         };
 
         const openQuoteCard = () => {
           const range = parseHash();
           if (!range || !quoteCardModal) return;
           syncQuoteCardState(range);
+          lastFocusedElement = document.activeElement;
           quoteCardModal.hidden = false;
           document.body.classList.add('quote-card-open');
+          if (quoteCardCloseButton instanceof HTMLElement) quoteCardCloseButton.focus();
         };
 
         closeQuoteCardButtons.forEach((button) => {
@@ -410,6 +427,22 @@ const canonicalPath = `${base}poem/${poem.id}/`;
         });
 
         document.addEventListener('keydown', (event) => {
+          if (event.key === 'Tab' && quoteCardModal && !quoteCardModal.hidden && quoteCardPanel instanceof HTMLElement) {
+            const focusable = Array.from(
+              quoteCardPanel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+            ).filter((el) => el instanceof HTMLElement && !el.hasAttribute('disabled'));
+            if (focusable.length) {
+              const first = focusable[0];
+              const last = focusable[focusable.length - 1];
+              if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+              } else if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+              }
+            }
+          }
           if (event.key === 'Escape') closeQuoteCard();
         });
 
@@ -470,6 +503,31 @@ const canonicalPath = `${base}poem/${poem.id}/`;
           // Don't hijack clicks on real links inside the poem (if we add any later).
           const isLink = e.target && e.target.closest ? e.target.closest('a') : null;
           if (isLink) return;
+
+          const n = Number(li.id.replace(/^l/, ''));
+          if (!Number.isFinite(n)) return;
+
+          if (e.shiftKey) {
+            if (startLine == null) {
+              const r = parseHash();
+              if (r) startLine = r.start;
+            }
+            if (startLine != null) {
+              void setHash(startLine, n);
+              return;
+            }
+          }
+
+          startLine = n;
+          void setHash(n, n);
+        });
+
+        document.addEventListener('keydown', (e) => {
+          const li = e.target && e.target.closest ? e.target.closest('.poem-lines li[id^="l"]') : null;
+          if (!li || !li.id || li.classList.contains('is-blank')) return;
+          if (e.key !== 'Enter' && e.key !== ' ') return;
+
+          e.preventDefault();
 
           const n = Number(li.id.replace(/^l/, ''));
           if (!Number.isFinite(n)) return;

--- a/site/src/pages/search.astro
+++ b/site/src/pages/search.astro
@@ -27,24 +27,38 @@ const docs = poems.map((p) => ({
   </section>
 
   <div class="card">
-    <div style="display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
-      <input
-        id="q"
-        type="search"
-        placeholder="Try grief, night, sea, prayer, or a title..."
-        autocomplete="off"
-        style="flex: 1 1 18rem; padding: 0.6rem 0.75rem; border-radius: 12px; border: 1px solid var(--card-border); background: color-mix(in oklab, var(--paper) 92%, transparent); font-family: var(--sans); font-size: 1rem;"
-      />
-      <span class="pill" id="count">{docs.length} poems</span>
-    </div>
+    <form role="search" aria-labelledby="search-form-title">
+      <h2 id="search-form-title" class="sr-only">Search poems</h2>
+      <div style="display:flex; gap:0.75rem; align-items:center; flex-wrap:wrap;">
+        <label class="sr-only" for="q">Search poems</label>
+        <input
+          id="q"
+          type="search"
+          placeholder="Try grief, night, sea, prayer, or a title..."
+          autocomplete="off"
+          aria-describedby="search-help search-status"
+          aria-controls="results"
+          style="flex: 1 1 18rem; padding: 0.6rem 0.75rem; border-radius: 12px; border: 1px solid var(--card-border); background: color-mix(in oklab, var(--paper) 92%, transparent); font-family: var(--sans); font-size: 1rem;"
+        />
+        <span class="pill" id="count" aria-hidden="true">{docs.length} poems</span>
+      </div>
 
-    <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-top:0.75rem;">
-      {['grief', 'love', 'nature', 'night', 'sea', 'faith', 'solitude'].map((term) => (
-        <button class="pill" type="button" data-suggestion={term} style="cursor:pointer; border:0;">
-          {term}
-        </button>
-      ))}
-    </div>
+      <p id="search-help" class="muted" style="margin-top:0.75rem;">
+        Search by title, author, theme, or mood. Suggestions below fill the search field.
+      </p>
+
+      <div aria-label="Suggested searches" style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-top:0.75rem;">
+        {['grief', 'love', 'nature', 'night', 'sea', 'faith', 'solitude'].map((term) => (
+          <button class="pill" type="button" data-suggestion={term} style="cursor:pointer; border:0;">
+            {term}
+          </button>
+        ))}
+      </div>
+    </form>
+
+    <p id="search-status" class="muted" role="status" aria-live="polite" style="margin-top:0.75rem;">
+      {docs.length} poems available.
+    </p>
 
     <ul class="list" id="results" style="margin-top: 0.75rem;"></ul>
   </div>
@@ -73,12 +87,14 @@ const docs = poems.map((p) => ({
     const input = document.getElementById('q');
     const resultsEl = document.getElementById('results');
     const countEl = document.getElementById('count');
+    const statusEl = document.getElementById('search-status');
     const params = new URLSearchParams(window.location.search);
     const suggestions = Array.from(document.querySelectorAll('[data-suggestion]'));
 
     const render = (items) => {
       resultsEl.innerHTML = '';
       countEl.textContent = `${items.length} result${items.length === 1 ? '' : 's'}`;
+      if (statusEl) statusEl.textContent = `${items.length} result${items.length === 1 ? '' : 's'} available.`;
 
       for (const r of items) {
         const li = document.createElement('li');
@@ -109,6 +125,7 @@ const docs = poems.map((p) => ({
       if (!q) {
         countEl.textContent = `${docs.length} poems`;
         resultsEl.innerHTML = '';
+        if (statusEl) statusEl.textContent = `${docs.length} poems available.`;
         params.delete('q');
         history.replaceState({}, '', `${window.location.pathname}`);
         return;
@@ -147,7 +164,6 @@ const docs = poems.map((p) => ({
     }
     input.value = params.get('q') ?? '';
     if (input.value) run();
-    input.focus();
   </script>
 
   <script id="search-data" type="application/json">{JSON.stringify(docs)}</script>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -118,6 +118,18 @@ body {
   background: transparent;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 a {
   color: inherit;
   text-decoration-color: color-mix(in oklab, var(--ink) 35%, transparent);
@@ -126,6 +138,25 @@ a {
 
 a:hover {
   text-decoration-color: color-mix(in oklab, var(--ink) 70%, transparent);
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  z-index: 100;
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--paper) 96%, transparent);
+  border: 1px solid color-mix(in oklab, var(--border) 78%, transparent);
+  box-shadow: var(--shadow);
+  text-decoration: none;
+  transform: translateY(-180%);
+  transition: transform 140ms ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
 }
 
 p { line-height: 1.75; margin: 0.75rem 0; }
@@ -823,6 +854,12 @@ main {
   box-shadow: inset 3px 0 0 color-mix(in oklab, var(--accent) 70%, transparent);
 }
 
+.poem-lines li:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--accent) 72%, white 28%);
+  outline-offset: 0.12rem;
+  border-radius: 0.2rem;
+}
+
 .line-anchor {
   display: block;
   width: 1.2rem;
@@ -1009,6 +1046,13 @@ main {
 .quote-card-action-primary {
   background: color-mix(in oklab, var(--accent) 22%, var(--paper));
   border-color: color-mix(in oklab, var(--accent) 35%, var(--border));
+}
+
+.quote-card-action:focus-visible,
+.quote-card-close:focus-visible,
+.skip-link:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--accent) 72%, white 28%);
+  outline-offset: 2px;
 }
 
 .quote-card-modal[hidden] {


### PR DESCRIPTION
## Summary
- add a skip link and focus target for main content
- make poem line selection keyboard accessible and trap focus correctly in the quote-card modal
- add accessible labels and live status updates for search without stealing initial focus

## Verification
- `cd site && npm run build`
- `cd site && npm run test:unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "skip to main content" link for keyboard accessibility.
  * Enhanced keyboard navigation in poem reader with keyboard-focusable lines and selection support.
  * Improved search interface with screen reader support and live status updates.
  * Enhanced keyboard focus indicators throughout the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->