### PR TITLE
Deepen Samuel Taylor Coleridge coverage

### DIFF
--- a/meta/samuel-taylor-coleridge/france-an-ode.yml
+++ b/meta/samuel-taylor-coleridge/france-an-ode.yml
@@ -1,0 +1,15 @@
+id: "samuel-taylor-coleridge/france-an-ode"
+slug: "france-an-ode"
+author: "Samuel Taylor Coleridge"
+author_slug: "samuel-taylor-coleridge"
+title: "France, an Ode"
+century: 19
+
+text_path: "poems/samuel-taylor-coleridge/france-an-ode.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Fears_in_Solitude_(Coleridge)/France,_an_Ode"
+public_domain_rationale: "Public domain in the United States: Coleridge died 1834; text from the 1798 Wikisource transcription of Fears in Solitude."
+
+notes: "Copied from the poem-specific Wikisource page."

--- a/meta/samuel-taylor-coleridge/frost-at-midnight.yml
+++ b/meta/samuel-taylor-coleridge/frost-at-midnight.yml
@@ -1,0 +1,15 @@
+id: "samuel-taylor-coleridge/frost-at-midnight"
+slug: "frost-at-midnight"
+author: "Samuel Taylor Coleridge"
+author_slug: "samuel-taylor-coleridge"
+title: "Frost at Midnight"
+century: 19
+
+text_path: "poems/samuel-taylor-coleridge/frost-at-midnight.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Fears_in_Solitude_(Coleridge)/Frost_at_Midnight"
+public_domain_rationale: "Public domain in the United States: Coleridge died 1834; text from the 1798 Wikisource transcription of Fears in Solitude."
+
+notes: "Copied from the poem-specific Wikisource page; page-note reference explaining 'film'/'stranger' was omitted from the poem text."

--- a/poems/samuel-taylor-coleridge/france-an-ode.txt
+++ b/poems/samuel-taylor-coleridge/france-an-ode.txt
@@ -1,0 +1,109 @@
+Ye Clouds, that far above me float and pause,
+Whose pathless march no mortal may control!
+Ye ocean waves, that, wheresoe'er ye roll,
+Yield homage only to eternal laws!
+Ye woods, that listen to the night-bird's singing,
+Midway the smooth and perilous steep reclin'd;
+Save when your own imperious branches swinging
+Have made a solemn music of the wind!
+Where, like a man belov'd of God,
+Thro' glooms, which never woodman trod,
+How oft, pursuing fancies holy,
+My moonlight way o'er flow'ring weeds I wound,
+Inspir'd beyond the guess of folly,
+By each rude shape, and wild unconquerable sound!
+O, ye loud waves, and O, ye forests high,
+And O, ye clouds, that far above me soar'd!
+Thou rising sun! thou blue rejoicing sky!
+Yea, every thing that is and will be free,
+Bear witness for me wheresoe'er ye be,
+With what deep worship I have still ador'd
+The spirit of divinest liberty.
+
+When France in wrath her giant limbs uprear'd,
+And with that oath which smote earth, air, and sea,
+Stamp'd her strong foot and said, she would be free,
+Bear witness for me, how I hop'd and fear'd!
+With what a joy my lofty gratulation
+Unaw'd I sung amid a slavish band:
+And when to whelm the disenchanted nation,
+Like fiends embattled by a wizard's wand,
+The monarchs march'd in evil day,
+And Britain join'd the dire array;
+Though dear her shores, and circling ocean,
+Though many friendships, many youthful loves
+Had swoln the patriot emotion,
+And flung a magic light o'er all her hills and groves;
+Yet still my voice unalter'd sang defeat
+To all that brav'd the tyrant-quelling lance,
+And shame too long delay'd, and vain retreat!
+For ne'er, O Liberty! with partial aim
+I dimm'd thy light, or damp'd thy holy flame;
+But blest the pæans of deliver'd France,
+And hung my head, and wept at Britain's name!
+
+"And what (I said) tho' blasphemy's loud scream
+With that sweet music of deliv'rance strove;
+Tho' all the fierce and drunken passions wove
+A dance more wild than ever maniac's dream;
+Ye storms, that round the dawning east assembled,
+The sun was rising, tho' ye hid his light!"
+And when to sooth my soul, that hop'd and trembled,
+The dissonance ceas'd, and all seem'd calm and bright;
+When France, her front deep-scar'd and gory,
+Conceal'd with clust'ring wreaths of glory;
+When insupportably advancing,
+Her arm made mock'ry of the warrior's ramp,
+While, timid looks of fury glancing,
+Domestic treason, crush'd beneath her fatal stamp,
+Writh'd, like a wounded dragon in his gore;
+Then I reproach'd my fears that would not flee,
+"And soon (I said) shall wisdom teach her lore
+In the low huts of them that toil and groan!
+And conqu'ring by her happiness alone,
+Shall France compel the nations to be free,
+Till love and joy look round, and call the earth their own!"
+
+Forgive me, Freedom! O forgive these dreams!
+I hear thy voice, I hear thy loud lament,
+From bleak Helvetia's icy caverns sent—
+I hear thy groans upon her blood-stain'd streams!
+Heroes, that for your peaceful country perish'd;
+And ye, that fleeing spot the mountain snows
+With bleeding wounds; forgive me, that I cherish'd
+One thought, that ever bless'd your cruel foes!
+To scatter rage and trait'rous guilt
+Where Peace her jealous home had built;
+A patriot race to disinherit
+Of all that made their stormy wilds so dear,
+And with inexpiable spirit
+To taint the bloodless freedom of the mountaineer.—
+O France! that mockest heav'n, adult'rous, blind,
+And patriot only in pernicious toils!
+Are these thy boasts, champion of human kind:
+To mix with kings in the low lull of sway,
+Yell in the hunt, and share the murd'rous prey;
+T' insult the shrine of liberty with spoils
+From freemen torn; to tempt and to betray!
+
+The sensual and the dark rebel in vain,
+Slaves by their own compulsion! In mad game
+They burst their manacles, and wear the name
+Of freedom graven on a heavier chain!
+O Liberty! with profitless endeavour
+Have I pursued thee many a weary hour:
+But thou nor swell'st the victor's strain, nor ever
+Didst breathe thy soul in forms of human pow'r.
+Alike from all, howe'er they praise thee,
+(Nor pray'r, nor boastful name delays thee)
+Alike from priesthood's harpy minions,
+And factious blasphemy's obscener slaves,
+Thou speedest on thy subtle pinions,
+To live amid the winds, and move upon the waves!
+And then I felt thee on that sea-cliff's verge,
+Whose pines, scarce travell'd by the breeze above,
+Had made one murmur with the distant surge!
+Yes! while I stood and gaz'd, my temples bare,
+And shot my being thro' earth, sea, and air,
+Possessing all things with intensest love,
+O Liberty, my spirit felt thee there!

--- a/poems/samuel-taylor-coleridge/frost-at-midnight.txt
+++ b/poems/samuel-taylor-coleridge/frost-at-midnight.txt
@@ -1,0 +1,90 @@
+The Frost performs it's secret ministry,
+Unhelp'd by any wind. The owlet's cry
+Came loud—and hark, again! loud as before.
+The inmates of my cottage, all at rest,
+Have left me to that solitude, which suits
+Abstruser musings: save that at my side
+My cradled infant slumbers peacefully.
+'Tis calm indeed! so calm, that it disturbs
+And vexes meditation with it's strange
+And extreme silentness. Sea, hill, and wood,
+This populous village! Sea, and hill, and wood,
+With all the numberless goings on of life,
+Inaudible as dreams! The thin blue flame
+Lies on my low burnt fire, and quivers not:
+
+Only that film, which flutter'd on the grate,
+Still flutters there, the sole unquiet thing,
+Methinks, it's motion in this hush of nature
+Gives it dim sympathies with me, who live,
+Making it a companionable form,
+With which I can hold commune. Idle thought!
+But still the living spirit in our frame,
+That loves not to behold a lifeless thing,
+Transfuses into all it's own delights
+It's own volition, sometimes with deep faith,
+And sometimes with fantastic playfulness.
+Ah me! amus'd by no such curious toys
+Of the self-watching subtilizing mind,
+How often in my early school-boy days,
+With most believing superstitious wish
+Presageful have I gaz'd upon the bars,
+To watch the stranger there! and oft belike,
+With unclos'd lids, already had I dreamt
+Of my sweet birthplace; and the old church-tower,
+Whose bells, the poor man's only music, rang
+
+From morn to evening, all the hot fair-day,
+So sweetly, that they stirr'd and haunted me
+With a wild pleasure, falling on mine ear
+Most like articulate sounds of things to come!
+So gaz'd I, till the soothing things, I dreamt,
+Lull'd me to sleep, and sleep prolong'd my dreams!
+And so I brooded all the following morn,
+Aw'd by the stern preceptor's face, mine eye
+Fix'd with mock study on my swimming book:
+Save if the door half-open'd, and I snatch'd
+A hasty glance, and still my heart leapt up,
+For still I hop'd to see the stranger's face,
+Townsman, or aunt, or sister more belov'd,
+My play-mate when we both were cloth'd alike!
+
+Dear babe, that sleepest cradled by my side,
+Whose gentle breathings, heard in this dead calm,
+Fill up the interspersed vacancies
+And momentary pauses of the thought!
+My babe so beautiful! it fills my heart
+With tender gladness, thus to look at thee,
+And think, that thou shalt learn far other lore,
+
+And in far other scenes! For I was rear'd
+In the great city, pent mid cloisters dim,
+And saw nought lovely but the sky and stars.
+But thou, my babe! Shalt wander, like a breeze,
+By lakes and sandy shores, beneath the crags
+Of ancient mountain, and beneath the clouds,
+Which image in their bulk both lakes and shores
+And mountain crags: so shalt thou see and hear
+The lovely shapes and sounds intelligible
+Of that eternal language, which thy God
+Utters, who from eternity doth teach
+Himself in all, and all things in himself.
+Great universal Teacher! he shall mould
+Thy spirit, and by giving make it ask.
+
+Therefore all seasons shall be sweet to thee,
+Whether the summer clothe the general earth
+With greenness, or the redbreasts sit and sing
+Betwixt the tufts of snow on the bare branch
+Of mossy apple-tree, while all the thatch
+Smokes in the sun-thaw: whether the eave-drops fall
+Heard only in the trances of the blast,
+Or whether the secret ministery of cold
+Shall hang them up in silent icicles,
+Quietly shining to the quiet moon,
+Like those, my babe! which, ere to-morrow's warmth
+Have capp'd their sharp keen points with pendulous drops,
+Will catch thine eye, and with their novelty
+Suspend thy little soul; then make thee shout,
+And stretch and flutter from thy mother's arms
+As thou would'st fly for very eagerness.


### PR DESCRIPTION
Closes #103.

## Summary
- add `Frost at Midnight` from the poem-specific Wikisource page
- add `France, an Ode` from the poem-specific Wikisource page
- deepen Coleridge from two poems to four without broad anthology ingest risk

## Verification
- `cd site && npm run build`
- `cd site && npm run test:unit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "France, an Ode" by Samuel Taylor Coleridge
  * Added "Frost at Midnight" by Samuel Taylor Coleridge

<!-- end of auto-generated comment: release notes by coderabbit.ai -->