### PR TITLE
Deepen William Wordsworth coverage

### DIFF
--- a/meta/william-wordsworth/composed-upon-westminster-bridge-sept-3-1803.yml
+++ b/meta/william-wordsworth/composed-upon-westminster-bridge-sept-3-1803.yml
@@ -1,0 +1,13 @@
+id: "william-wordsworth/composed-upon-westminster-bridge-sept-3-1803"
+slug: "composed-upon-westminster-bridge-sept-3-1803"
+author: "William Wordsworth"
+author_slug: "william-wordsworth"
+title: "Composed upon Westminster Bridge, Sept. 3, 1803"
+century: 19
+
+text_path: "poems/william-wordsworth/composed-upon-westminster-bridge-sept-3-1803.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Poems,_in_Two_Volumes_(Wordsworth,_1807)/Volume_1/Composed_upon_Westminster_Bridge,_Sept._3,_1803"
+public_domain_rationale: "Public domain in the United States: published 1807 (pre-1929) on Wikisource; Wordsworth died 1850."

--- a/meta/william-wordsworth/my-heart-leaps-up.yml
+++ b/meta/william-wordsworth/my-heart-leaps-up.yml
@@ -1,0 +1,15 @@
+id: "william-wordsworth/my-heart-leaps-up"
+slug: "my-heart-leaps-up"
+author: "William Wordsworth"
+author_slug: "william-wordsworth"
+title: "My Heart Leaps Up"
+century: 19
+
+text_path: "poems/william-wordsworth/my-heart-leaps-up.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Poems,_in_Two_Volumes_(Wordsworth,_1807)/Volume_2/%27My_heart_leaps_up_when_I_behold%27"
+public_domain_rationale: "Public domain in the United States: published 1807 (pre-1929) on Wikisource; Wordsworth died 1850."
+
+notes: "Text transcribed from the 1807 Wikisource page titled ''My heart leaps up when I behold''."

--- a/meta/william-wordsworth/she-dwelt-among-the-untrodden-ways.yml
+++ b/meta/william-wordsworth/she-dwelt-among-the-untrodden-ways.yml
@@ -1,0 +1,15 @@
+id: "william-wordsworth/she-dwelt-among-the-untrodden-ways"
+slug: "she-dwelt-among-the-untrodden-ways"
+author: "William Wordsworth"
+author_slug: "william-wordsworth"
+title: "She dwelt among the untrodden ways"
+century: 19
+
+text_path: "poems/william-wordsworth/she-dwelt-among-the-untrodden-ways.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/Poems_(Wordsworth,_1815)/Volume_1/She_dwelt_among_the_untrodden_ways"
+public_domain_rationale: "Public domain in the United States: published in an 1815 volume on Wikisource (pre-1929); Wordsworth died 1850."
+
+notes: "Text taken from the 1815 Wikisource version of the Lucy poem."

--- a/poems/william-wordsworth/composed-upon-westminster-bridge-sept-3-1803.txt
+++ b/poems/william-wordsworth/composed-upon-westminster-bridge-sept-3-1803.txt
@@ -1,0 +1,14 @@
+Earth has not any thing to shew more fair:
+Dull would he be of soul who could pass by
+A sight so touching in it's majesty:
+This City now doth like a garment wear
+The beauty of the morning; silent, bare,
+Ships, towers, domes, theatres, and temples lie
+Open unto the fields, and to the sky;
+All bright and glittering in the smokeless air.
+Never did sun more beautifully steep
+In his first splendor valley, rock, or hill;
+Ne'er saw I, never felt, a calm so deep!
+The river glideth at his own sweet will:
+Dear God! the very houses seem asleep;
+And all that mighty heart is lying still!

--- a/poems/william-wordsworth/my-heart-leaps-up.txt
+++ b/poems/william-wordsworth/my-heart-leaps-up.txt
@@ -1,0 +1,9 @@
+My heart leaps up when I behold
+A Rainbow in the sky:
+So was it when my life began;
+So is it now I am a Man;
+So be it when I shall grow old,
+Or let me die!
+The Child is Father of the Man;
+And I could wish my days to be
+Bound each to each by natural piety.

--- a/poems/william-wordsworth/she-dwelt-among-the-untrodden-ways.txt
+++ b/poems/william-wordsworth/she-dwelt-among-the-untrodden-ways.txt
@@ -1,0 +1,14 @@
+She dwelt among the untrodden ways
+Beside the springs of Dove,
+A Maid whom there were none to praise,
+And very few to love.
+
+A Violet by a mossy stone
+Half-hidden from the eye!
+Fair as a star, when only one
+Is shining in the sky.
+
+She lived unknown, and few could know
+When Lucy ceased to be;
+But she is in her Grave, and, oh,
+The difference to me!


### PR DESCRIPTION
## Summary
- add three clean Wordsworth poems from poem-specific Wikisource pages
- deepen the Wordsworth author page without pulling in a noisy anthology scrape
- keep the batch small enough to verify and merge quickly

## Testing
- cd site && npm run build
- cd site && npm run test:unit

Closes #105