### PR TITLE
Deepen Alfred Tennyson coverage

### DIFF
--- a/meta/alfred-tennyson/the-blackbird.yml
+++ b/meta/alfred-tennyson/the-blackbird.yml
@@ -1,0 +1,15 @@
+id: "alfred-tennyson/the-blackbird"
+slug: "the-blackbird"
+author: "Alfred Lord Tennyson"
+author_slug: "alfred-tennyson"
+title: "The Blackbird"
+century: 19
+text_in_repo: true
+text_path: "poems/alfred-tennyson/the-blackbird.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/8601"
+public_domain_rationale: "Public domain (author died 1892; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Early Poems of Alfred Lord Tennyson"
+collection_source_url: "https://www.gutenberg.org/ebooks/8601"
+featured: false
+notes: "Poem text extracted from the Gutenberg volume with editorial variant notes removed."

--- a/meta/alfred-tennyson/the-eagle.yml
+++ b/meta/alfred-tennyson/the-eagle.yml
@@ -1,0 +1,15 @@
+id: "alfred-tennyson/the-eagle"
+slug: "the-eagle"
+author: "Alfred Lord Tennyson"
+author_slug: "alfred-tennyson"
+title: "The Eagle"
+century: 19
+text_in_repo: true
+text_path: "poems/alfred-tennyson/the-eagle.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/8601"
+public_domain_rationale: "Public domain (author died 1892; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Early Poems of Alfred Lord Tennyson"
+collection_source_url: "https://www.gutenberg.org/ebooks/8601"
+featured: false
+notes: "Rendered from the Gutenberg text without the editor's fragment note or footnote."

--- a/meta/alfred-tennyson/the-kraken.yml
+++ b/meta/alfred-tennyson/the-kraken.yml
@@ -1,0 +1,15 @@
+id: "alfred-tennyson/the-kraken"
+slug: "the-kraken"
+author: "Alfred Lord Tennyson"
+author_slug: "alfred-tennyson"
+title: "The Kraken"
+century: 19
+text_in_repo: true
+text_path: "poems/alfred-tennyson/the-kraken.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/8601"
+public_domain_rationale: "Public domain (author died 1892; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Early Poems of Alfred Lord Tennyson"
+collection_source_url: "https://www.gutenberg.org/ebooks/8601"
+featured: false
+notes: "Poem text extracted from the Gutenberg volume; editorial headnotes and commentary omitted."

--- a/poems/alfred-tennyson/the-blackbird.txt
+++ b/poems/alfred-tennyson/the-blackbird.txt
@@ -1,0 +1,24 @@
+The espaliers and the standards all
+Are thine; the range of lawn and park:
+The unnetted black-hearts ripen dark,
+All thine, against the garden wall.
+
+Yet, tho' I spared thee all the spring,
+Thy sole delight is, sitting still,
+With that gold dagger of thy bill
+To fret the summer jenneting.
+
+A golden bill! the silver tongue,
+Cold February loved, is dry:
+Plenty corrupts the melody
+That made thee famous once, when young:
+
+And in the sultry garden-squares,
+Now thy flute-notes are changed to coarse,
+I hear thee not at all, or hoarse
+As when a hawker hawks his wares.
+
+Take warning! he that will not sing
+While yon sun prospers in the blue,
+Shall sing for want, ere leaves are new,
+Caught in the frozen palms of Spring.

--- a/poems/alfred-tennyson/the-eagle.txt
+++ b/poems/alfred-tennyson/the-eagle.txt
@@ -1,0 +1,6 @@
+He clasps the crag with hooked hands;
+Close to the sun in lonely lands,
+Ring'd with the azure world, he stands.
+The wrinkled sea beneath him crawls;
+He watches from his mountain walls,
+And like a thunderbolt he falls.

--- a/poems/alfred-tennyson/the-kraken.txt
+++ b/poems/alfred-tennyson/the-kraken.txt
@@ -1,0 +1,15 @@
+Below the thunders of the upper deep;
+Far, far beneath in the abysmal sea,
+His antient, dreamless, uninvaded sleep
+The Kraken sleepeth: faintest sunlights flee
+About his shadowy sides: above him swell
+Huge sponges of millennial growth and height;
+And far away into the sickly light,
+From many a wondrous grot and secret cell
+Unnumber'd and enormous polypi
+Winnow with giant arms the slumbering green.
+There hath he lain for ages and will lie
+Battening upon huge seaworms in his sleep,
+Until the latter fire shall heat the deep;
+Then once by man and angels to be seen,
+In roaring he shall rise and on the surface die.


### PR DESCRIPTION
## Summary
- add three short Tennyson poems from the existing Gutenberg source already used in-tree
- strip editorial headnotes and footnotes so only poem text lands in the corpus
- deepen the Tennyson author page with a small, clean batch

## Testing
- cd site && npm run build
- cd site && npm run test:unit

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three poems by Alfred Lord Tennyson: "The Blackbird," "The Eagle," and "The Kraken." Each includes complete poem text and comprehensive metadata with publication information and public domain documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->