### PR TITLE
Deepen John Donne coverage

### DIFF
--- a/meta/john-donne/the-canonization.yml
+++ b/meta/john-donne/the-canonization.yml
@@ -1,0 +1,15 @@
+id: "john-donne/the-canonization"
+slug: "the-canonization"
+author: "John Donne"
+author_slug: "john-donne"
+title: "The Canonization"
+century: 17
+
+text_path: "poems/john-donne/the-canonization.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Canonization"
+public_domain_rationale: "Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography and capitalization preserved from Wikisource."

--- a/meta/john-donne/the-good-morrow.yml
+++ b/meta/john-donne/the-good-morrow.yml
@@ -1,0 +1,15 @@
+id: "john-donne/the-good-morrow"
+slug: "the-good-morrow"
+author: "John Donne"
+author_slug: "john-donne"
+title: "The Good-Morrow"
+century: 17
+
+text_path: "poems/john-donne/the-good-morrow.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Good-Morrow"
+public_domain_rationale: "Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography and capitalization preserved from Wikisource."

--- a/meta/john-donne/the-sun-rising.yml
+++ b/meta/john-donne/the-sun-rising.yml
@@ -1,0 +1,15 @@
+id: "john-donne/the-sun-rising"
+slug: "the-sun-rising"
+author: "John Donne"
+author_slug: "john-donne"
+title: "The Sun Rising"
+century: 17
+
+text_path: "poems/john-donne/the-sun-rising.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Sun_Rising"
+public_domain_rationale: "Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography and capitalization preserved from Wikisource."

--- a/poems/john-donne/the-canonization.txt
+++ b/poems/john-donne/the-canonization.txt
@@ -1,0 +1,45 @@
+FOR God's sake hold your tongue, and let me love;
+Or chide my palsy, or my gout;
+My five gray hairs, or ruin'd fortune flout;
+With wealth your state, your mind with arts improve;
+Take you a course, get you a place,
+Observe his Honour, or his Grace;
+Or the king's real, or his stamp'd face
+Contemplate; what you will, approve,
+So you will let me love.
+Alas! alas! who's injured by my love?
+What merchant's ships have my sighs drown'd?
+Who says my tears have overflow'd his ground?
+When did my colds a forward spring remove?
+When did the heats which my veins fill
+Add one more to the plaguy bill?
+Soldiers find wars, and lawyers find out still
+Litigious men, which quarrels move,
+Though she and I do love.
+Call's what you will, we are made such by love;
+Call her one, me another fly,
+We're tapers too, and at our own cost die,
+And we in us find th' eagle and the dove.
+The phoenix riddle hath more wit
+By us; we two being one, are it;
+So, to one neutral thing both sexes fit.
+We die and rise the same, and prove
+Mysterious by this love.
+We can die by it, if not live by love,
+And if unfit for tomb or hearse
+Our legend be, it will be fit for verse;
+And if no piece of chronicle we prove,
+We'll build in sonnets pretty rooms;
+As well a well-wrought urn becomes
+The greatest ashes, as half-acre tombs,
+And by these hymns, all shall approve
+Us canonized for love;
+And thus invoke us, "You, whom reverend love
+Made one another's hermitage;
+You, to whom love was peace, that now is rage;
+Who did the whole world's soul contract, and drove
+Into the glasses of your eyes;
+So made such mirrors, and such spies,
+That they did all to you epitomize—
+Countries, towns, courts beg from above
+A pattern of your love."

--- a/poems/john-donne/the-good-morrow.txt
+++ b/poems/john-donne/the-good-morrow.txt
@@ -1,0 +1,21 @@
+I WONDER by my troth, what thou and I
+Did, till we loved? were we not wean'd till then?
+But suck'd on country pleasures, childishly?
+Or snorted we in the Seven Sleepers' den?
+'Twas so; but this, all pleasures fancies be;
+If ever any beauty I did see,
+Which I desired, and got, 'twas but a dream of thee.
+And now good-morrow to our waking souls,
+Which watch not one another out of fear;
+For love all love of other sights controls,
+And makes one little room an everywhere.
+Let sea-discoverers to new worlds have gone;
+Let maps to other, worlds on worlds have shown;
+Let us possess one world; each hath one, and is one.
+My face in thine eye, thine in mine appears,
+And true plain hearts do in the faces rest;
+Where can we find two better hemispheres
+Without sharp north, without declining west?
+Whatever dies, was not mix'd equally;
+If our two loves be one, or thou and I
+Love so alike that none can slacken, none can die.

--- a/poems/john-donne/the-sun-rising.txt
+++ b/poems/john-donne/the-sun-rising.txt
@@ -1,0 +1,30 @@
+BUSY old fool, unruly Sun,
+Why dost thou thus,
+Through windows, and through curtains, call on us?
+Must to thy motions lovers' seasons run?
+Saucy pedantic wretch, go chide
+Late school-boys and sour prentices,
+Go tell court-huntsmen that the king will ride,
+Call country ants to harvest offices;
+Love, all alike, no season knows nor clime,
+Nor hours, days, months, which are the rags of time.
+Thy beams so reverend, and strong
+Why shouldst thou think?
+I could eclipse and cloud them with a wink,
+But that I would not lose her sight so long.
+If her eyes have not blinded thine,
+Look, and to-morrow late tell me,
+Whether both th' Indias of spice and mine
+Be where thou left'st them, or lie here with me.
+Ask for those kings whom thou saw'st yesterday,
+And thou shalt hear, "All here in one bed lay."
+She's all states, and all princes I;
+Nothing else is;
+Princes do but play us; compared to this,
+All honour's mimic, all wealth alchemy.
+Thou, Sun, art half as happy as we,
+In that the world's contracted thus;
+Thine age asks ease, and since thy duties be
+To warm the world, that's done in warming us.
+Shine here to us, and thou art everywhere;
+This bed thy center is, these walls thy sphere.


### PR DESCRIPTION
## Summary
- add three short Donne poems from poem-specific Wikisource pages
- preserve the source orthography and capitalization already used for the existing Donne entries
- deepen the Donne author page with a clean, source-consistent batch

## Testing
- cd site && npm run build
- cd site && npm run test:unit

Closes #109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three poems by John Donne: The Canonization (45 lines), The Good-Morrow (21 lines), and The Sun Rising (30 lines)
  * Included comprehensive metadata and source attribution for each work

<!-- end of auto-generated comment: release notes by coderabbit.ai -->