### PR TITLE
Deepen Henry Wadsworth Longfellow coverage

### DIFF
--- a/meta/henry-wadsworth-longfellow/footsteps-of-angels.yml
+++ b/meta/henry-wadsworth-longfellow/footsteps-of-angels.yml
@@ -1,0 +1,14 @@
+id: "henry-wadsworth-longfellow/footsteps-of-angels"
+slug: "footsteps-of-angels"
+author: "Henry Wadsworth Longfellow"
+author_slug: "henry-wadsworth-longfellow"
+title: "Footsteps of Angels"
+century: 19
+text_in_repo: true
+text_path: "poems/henry-wadsworth-longfellow/footsteps-of-angels.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/1365"
+public_domain_rationale: "Public domain (author died 1882; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Complete Poetical Works of Henry Wadsworth Longfellow"
+collection_source_url: "https://www.gutenberg.org/ebooks/1365"
+featured: false

--- a/meta/henry-wadsworth-longfellow/the-arrow-and-the-song.yml
+++ b/meta/henry-wadsworth-longfellow/the-arrow-and-the-song.yml
@@ -1,0 +1,14 @@
+id: "henry-wadsworth-longfellow/the-arrow-and-the-song"
+slug: "the-arrow-and-the-song"
+author: "Henry Wadsworth Longfellow"
+author_slug: "henry-wadsworth-longfellow"
+title: "The Arrow and the Song"
+century: 19
+text_in_repo: true
+text_path: "poems/henry-wadsworth-longfellow/the-arrow-and-the-song.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/1365"
+public_domain_rationale: "Public domain (author died 1882; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Complete Poetical Works of Henry Wadsworth Longfellow"
+collection_source_url: "https://www.gutenberg.org/ebooks/1365"
+featured: false

--- a/meta/henry-wadsworth-longfellow/the-day-is-done.yml
+++ b/meta/henry-wadsworth-longfellow/the-day-is-done.yml
@@ -1,0 +1,14 @@
+id: "henry-wadsworth-longfellow/the-day-is-done"
+slug: "the-day-is-done"
+author: "Henry Wadsworth Longfellow"
+author_slug: "henry-wadsworth-longfellow"
+title: "The Day Is Done"
+century: 19
+text_in_repo: true
+text_path: "poems/henry-wadsworth-longfellow/the-day-is-done.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/1365"
+public_domain_rationale: "Public domain (author died 1882; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Complete Poetical Works of Henry Wadsworth Longfellow"
+collection_source_url: "https://www.gutenberg.org/ebooks/1365"
+featured: false

--- a/poems/henry-wadsworth-longfellow/footsteps-of-angels.txt
+++ b/poems/henry-wadsworth-longfellow/footsteps-of-angels.txt
@@ -1,0 +1,49 @@
+When the hours of Day are numbered,
+  And the voices of the Night
+Wake the better soul, that slumbered,
+  To a holy, calm delight;
+
+Ere the evening lamps are lighted,
+  And, like phantoms grim and tall,
+Shadows from the fitful firelight
+  Dance upon the parlor wall;
+
+Then the forms of the departed
+  Enter at the open door;
+The beloved, the true-hearted,
+  Come to visit me once more;
+
+He, the young and strong, who cherished
+  Noble longings for the strife,
+By the roadside fell and perished,
+  Weary with the march of life!
+
+They, the holy ones and weakly,
+  Who the cross of suffering bore,
+Folded their pale hands so meekly,
+  Spake with us on earth no more!
+
+And with them the Being Beauteous,
+  Who unto my youth was given,
+More than all things else to love me,
+  And is now a saint in heaven.
+
+With a slow and noiseless footstep
+  Comes that messenger divine,
+Takes the vacant chair beside me,
+  Lays her gentle hand in mine.
+
+And she sits and gazes at me
+  With those deep and tender eyes,
+Like the stars, so still and saint-like,
+  Looking downward from the skies.
+
+Uttered not, yet comprehended,
+  Is the spirit's voiceless prayer,
+Soft rebukes, in blessings ended,
+  Breathing from her lips of air.
+
+Oh, though oft depressed and lonely,
+  All my fears are laid aside,
+If I but remember only
+  Such as these have lived and died!

--- a/poems/henry-wadsworth-longfellow/the-arrow-and-the-song.txt
+++ b/poems/henry-wadsworth-longfellow/the-arrow-and-the-song.txt
@@ -1,0 +1,14 @@
+I shot an arrow into the air,
+It fell to earth, I knew not where;
+For, so swiftly it flew, the sight
+Could not follow it in its flight.
+
+I breathed a song into the air,
+It fell to earth, I knew not where;
+For who has sight so keen and strong,
+That it can follow the flight of song?
+
+Long, long afterward, in an oak
+I found the arrow, still unbroke;
+And the song, from beginning to end,
+I found again in the heart of a friend.

--- a/poems/henry-wadsworth-longfellow/the-day-is-done.txt
+++ b/poems/henry-wadsworth-longfellow/the-day-is-done.txt
@@ -1,0 +1,54 @@
+The day is done, and the darkness
+  Falls from the wings of Night,
+As a feather is wafted downward
+  From an eagle in his flight.
+
+I see the lights of the village
+  Gleam through the rain and the mist,
+And a feeling of sadness comes o'er me
+  That my soul cannot resist:
+
+A feeling of sadness and longing,
+  That is not akin to pain,
+And resembles sorrow only
+  As the mist resembles the rain.
+
+Come, read to me some poem,
+  Some simple and heartfelt lay,
+That shall soothe this restless feeling,
+  And banish the thoughts of day.
+
+Not from the grand old masters,
+  Not from the bards sublime,
+Whose distant footsteps echo
+  Through the corridors of Time.
+
+For, like strains of martial music,
+  Their mighty thoughts suggest
+Life's endless toil and endeavor;
+  And to-night I long for rest.
+
+Read from some humbler poet,
+  Whose songs gushed from his heart,
+As showers from the clouds of summer,
+  Or tears from the eyelids start;
+
+Who, through long days of labor,
+  And nights devoid of ease,
+Still heard in his soul the music
+  Of wonderful melodies.
+
+Such songs have power to quiet
+  The restless pulse of care,
+And come like the benediction
+  That follows after prayer.
+
+Then read from the treasured volume
+  The poem of thy choice,
+And lend to the rhyme of the poet
+  The beauty of thy voice.
+
+And the night shall be filled with music
+  And the cares, that infest the day,
+Shall fold their tents, like the Arabs,
+  And as silently steal away.


### PR DESCRIPTION
## Summary
- add three missing Longfellow poems from the existing Gutenberg volume already used in-tree
- keep metadata consistent with the current Longfellow entries
- deepen the author page with a small, clean batch

## Testing
- cd site && npm run build
- cd site && npm run test:unit

Closes #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new poems by Henry Wadsworth Longfellow: "Footsteps of Angels," "The Arrow and the Song," and "The Day Is Done," including complete bibliographic information and source attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->