### PR TITLE
Deepen George Herbert coverage

### DIFF
--- a/meta/george-herbert/easter-wings.yml
+++ b/meta/george-herbert/easter-wings.yml
@@ -1,0 +1,15 @@
+id: "george-herbert/easter-wings"
+slug: "easter-wings"
+author: "George Herbert"
+author_slug: "george-herbert"
+title: "Easter Wings"
+century: 17
+
+text_path: "poems/george-herbert/easter-wings.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Easter_Wings"
+public_domain_rationale: "Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography preserved from the 1633 text on Wikisource."

--- a/meta/george-herbert/the-call.yml
+++ b/meta/george-herbert/the-call.yml
@@ -1,0 +1,15 @@
+id: "george-herbert/the-call"
+slug: "the-call"
+author: "George Herbert"
+author_slug: "george-herbert"
+title: "The Call"
+century: 17
+
+text_path: "poems/george-herbert/the-call.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/The_Call"
+public_domain_rationale: "Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography preserved from the 1633 text on Wikisource."

--- a/meta/george-herbert/the-collar.yml
+++ b/meta/george-herbert/the-collar.yml
@@ -1,0 +1,15 @@
+id: "george-herbert/the-collar"
+slug: "the-collar"
+author: "George Herbert"
+author_slug: "george-herbert"
+title: "The Collar"
+century: 17
+
+text_path: "poems/george-herbert/the-collar.txt"
+text_in_repo: true
+
+source_label: "Wikisource"
+source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/The_Collar"
+public_domain_rationale: "Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source."
+
+notes: "Orthography preserved from the 1633 text on Wikisource."

--- a/poems/george-herbert/easter-wings.txt
+++ b/poems/george-herbert/easter-wings.txt
@@ -1,0 +1,21 @@
+Lord, who createdst man in wealth and store,
+Though foolishly he lost the same,
+Decaying more and more,
+Till he became
+Most poore:
+With thee
+O let me rise
+As larks, harmoniously,
+And sing this day thy victories:
+Then shall the fall further the flight in me.
+
+My tender age in sorrow did beginne:
+And still with sicknesses and shame
+Thou didst so punish sinne,
+That I became
+Most thinne.
+With thee
+Let me combine,
+And feel this day thy victorie:
+For, if I imp my wing on thine,
+Affliction shall advance the flight in me.

--- a/poems/george-herbert/the-call.txt
+++ b/poems/george-herbert/the-call.txt
@@ -1,0 +1,12 @@
+Come, my Way, my Truth, my Life:
+Such a Way, as gives us breath:
+Such a Truth, as ends all strife:
+And such a Life, as killeth death.
+Come, my Light, my Feast, my Strength:
+Such a Light, as shows a feast:
+Such a Feast, as mends in length:
+Such a Strength, as makes his guest.
+Come, my Joy, my Love, my Heart:
+Such a Joy, as none can move:
+Such a Love, as none can part:
+Such a Heart, as joyes in love.

--- a/poems/george-herbert/the-collar.txt
+++ b/poems/george-herbert/the-collar.txt
@@ -1,0 +1,36 @@
+I struck the board, and cry'd, No more;
+I will abroad.
+What? shall I ever sigh and pine?
+My lines and life are free; free as the rode,
+Loose as the winde, as large as store.
+Shall I be still in suit?
+Have I no harvest but a thorn
+To let me bloud, and not restore
+What I have lost with cordiall fruit?
+Sure there was wine
+Before my sighs did drie it: there was corn
+Before my tears did drown it.
+Is the yeare onely lost to me?
+Have I no bayes to crown it?
+No flowers, no garlands gay? all blasted?
+All wasted?
+Not so, my heart: but there is fruit,
+And thou hast hands.
+Recover all thy sigh-blown age
+On double pleasures: leave thy cold dispute
+Of what is fit, and not. Forsake thy cage,
+Thy rope of sands,
+Which pettie thoughts have made, and made to thee
+Good cable, to enforce and draw,
+And be thy law,
+While thou didst wink and wouldst not see.
+Away; take heed,
+I will abroad.
+Call in thy deaths head there: tie up thy fears.
+He that forbears
+To suit and serve his need,
+Deserves his load.
+But as I rav'd and grew more fierce and wilde
+At every word,
+Me thoughts I heard one calling, Childe:
+And I reply'd, My Lord.


### PR DESCRIPTION
## Summary
- add three missing Herbert poems from the same 1633 Wikisource edition already used in-tree
- preserve the source orthography while stripping out the decorative drop-cap splitting from the extracted text
- deepen the Herbert author page with a small, clean batch

## Testing
- cd site && npm run build
- cd site && npm run test:unit

Closes #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three poems by George Herbert: "Easter Wings," "The Call," and "The Collar."
  * Includes complete poem texts with bibliographic information and public domain attribution sourced from the 1633 Wikisource edition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->