### PR TITLE
Deepen James Russell Lowell coverage

### DIFF
--- a/meta/james-russell-lowell/aladdin.yml
+++ b/meta/james-russell-lowell/aladdin.yml
@@ -1,0 +1,14 @@
+id: "james-russell-lowell/aladdin"
+slug: "aladdin"
+author: "James Russell Lowell"
+author_slug: "james-russell-lowell"
+title: "Aladdin"
+century: 19
+text_in_repo: true
+text_path: "poems/james-russell-lowell/aladdin.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/17119"
+public_domain_rationale: "Public domain (author died 1891; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Vision of Sir Launfal and Other Poems"
+collection_source_url: "https://www.gutenberg.org/ebooks/17119"
+featured: false

--- a/meta/james-russell-lowell/the-foot-path.yml
+++ b/meta/james-russell-lowell/the-foot-path.yml
@@ -1,0 +1,14 @@
+id: "james-russell-lowell/the-foot-path"
+slug: "the-foot-path"
+author: "James Russell Lowell"
+author_slug: "james-russell-lowell"
+title: "The Foot-Path"
+century: 19
+text_in_repo: true
+text_path: "poems/james-russell-lowell/the-foot-path.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/17119"
+public_domain_rationale: "Public domain (author died 1891; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Vision of Sir Launfal and Other Poems"
+collection_source_url: "https://www.gutenberg.org/ebooks/17119"
+featured: false

--- a/meta/james-russell-lowell/the-shepherd-of-king-admetus.yml
+++ b/meta/james-russell-lowell/the-shepherd-of-king-admetus.yml
@@ -1,0 +1,14 @@
+id: "james-russell-lowell/the-shepherd-of-king-admetus"
+slug: "the-shepherd-of-king-admetus"
+author: "James Russell Lowell"
+author_slug: "james-russell-lowell"
+title: "The Shepherd of King Admetus"
+century: 19
+text_in_repo: true
+text_path: "poems/james-russell-lowell/the-shepherd-of-king-admetus.txt"
+source_label: "Project Gutenberg"
+source_url: "https://www.gutenberg.org/ebooks/17119"
+public_domain_rationale: "Public domain (author died 1891; distributed by Project Gutenberg as public-domain text)."
+collection_title: "The Vision of Sir Launfal and Other Poems"
+collection_source_url: "https://www.gutenberg.org/ebooks/17119"
+featured: false

--- a/poems/james-russell-lowell/aladdin.txt
+++ b/poems/james-russell-lowell/aladdin.txt
@@ -1,0 +1,17 @@
+When I was a beggarly boy,
+  And lived in a cellar damp,
+I had not a friend nor a toy,
+  But I had Aladdin's lamp;
+When I could not sleep for cold,
+  I had fire enough in my brain,
+And builded with roofs of gold
+  My beautiful castles in Spain!
+
+Since then I have toiled day and night,
+  I have money and power good store,
+But, I'd give all my lamps of silver bright
+  For the one that is mine no more;
+Take, Fortune, whatever you choose,
+  You gave, and may snatch again;
+I have nothing 't would pain me to lose,
+  For I own no more castles in Spain!

--- a/poems/james-russell-lowell/the-foot-path.txt
+++ b/poems/james-russell-lowell/the-foot-path.txt
@@ -1,0 +1,54 @@
+It mounts athwart the windy hill
+  Through sallow slopes of upland bare,
+And Fancy climbs with foot-fall still
+  Its narrowing curves that end in air.
+
+By day, a warmer-hearted blue
+  Stoops softly to that topmost swell;
+Its thread-like windings seem a clew
+  To gracious climes where all is well.
+
+By night, far yonder, I surmise
+  An ampler world than clips my ken,
+Where the great stars of happier skies
+  Commingle nobler fates of men.
+
+I look and long, then haste me home,
+  Still master of my secret rare;
+Once tried, the path would end in Rome,
+  But now it leads me everywhere.
+
+Forever to the new it guides,
+  From former good, old overmuch;
+What Nature for her poets hides,
+  'Tis wiser to divine than clutch.
+
+The bird I list hath never come
+  Within the scope of mortal ear;
+My prying step would make him dumb,
+  And the fair tree, his shelter, sear.
+
+Behind the hill, behind the sky,
+  Behind my inmost thought, he sings;
+No feet avail; to hear it nigh,
+  The song itself must lend the wings.
+
+Sing on, sweet bird, close hid, and raise
+  Those angel stairways in my brain,
+That climb from these low-vaulted days
+  To spacious sunshines far from pain.
+
+Sing when thou wilt, enchantment fleet,
+  I leave thy covert haunt untrod,
+And envy Science not her feat
+  To make a twice-told tale of God.
+
+They said the fairies tript no more,
+  And long ago that Pan was dead;
+'Twas but that fools preferred to bore
+  Earth's rind inch-deep for truth instead.
+
+Pan leaps and pipes all summer long,
+  The fairies dance each full-mooned night,
+Would we but doff our lenses strong,
+  And trust our wiser eyes' delight.

--- a/poems/james-russell-lowell/the-shepherd-of-king-admetus.txt
+++ b/poems/james-russell-lowell/the-shepherd-of-king-admetus.txt
@@ -1,0 +1,54 @@
+There came a youth upon the earth,
+  Some thousand years ago,
+Whose slender hands were nothing worth,
+Whether to plough, or reap, or sow.
+
+Upon an empty tortoise-shell
+  He stretched some chords, and drew
+Music that made men's bosoms swell
+Fearless, or brimmed their eyes with dew.
+
+Then King Admetus, one who had
+  Pure taste by right divine,
+Decreed his singing not too bad
+To hear between the cups of wine:
+
+And so, well pleased with being soothed
+  Into a sweet half-sleep,
+Three times his kingly beard he smoothed,
+And made him viceroy o'er his sheep.
+
+His words were simple words enough,
+  And yet he used them so,
+That what in other mouths was rough
+In his seemed musical and low.
+
+Men called him but a shiftless youth,
+  In whom no good they saw;
+And yet, unwittingly, in truth,
+They made his careless words their law.
+
+They knew not how he learned at all,
+  For idly, hour by hour,
+He sat and watched the dead leaves fall,
+Or mused upon a common flower.
+
+It seemed the loveliness of things
+  Did teach him all their use,
+For, in mere weeds, and stones, and springs,
+He found a healing power profuse.
+
+Men granted that his speech was wise,
+  But, when a glance they caught
+Of his slim grace and woman's eyes,
+They laughed, and called him good-for-naught.
+
+Yet after he was dead and gone,
+  And e'en his memory dim,
+Earth seemed more sweet to live upon,
+More full of love, because of him.
+
+And day by day more holy grew
+  Each spot where he had trod,
+Till after-poets only knew
+Their first-born brother as a god.


### PR DESCRIPTION
## Summary
- add three missing Lowell poems from the same Gutenberg volume already used in-tree
- deepen the Lowell author page with a clean, source-consistent batch
- keep the scope narrow enough to verify and merge quickly

## Testing
- cd site && npm run build
- cd site && npm run test:unit

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new poems by James Russell Lowell to the collection: "Aladdin," "The Foot-Path," and "The Shepherd of King Admetus."
  * All poems are sourced from Project Gutenberg and available as public domain works.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->