### PR TITLE
Deepen early modern author coverage

### DIFF
--- a/meta/andrew-marvell/the-definition-of-love.yml
+++ b/meta/andrew-marvell/the-definition-of-love.yml
@@ -1,0 +1,13 @@
+id: andrew-marvell/the-definition-of-love
+slug: the-definition-of-love
+author: Andrew Marvell
+author_slug: andrew-marvell
+title: The Definition of Love
+century: 17
+text_path: poems/andrew-marvell/the-definition-of-love.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/The_Definition_of_Love
+public_domain_rationale: 'Public domain in the United States: first published 1681 (pre-1929); text via English Wikisource.'
+collection_title: Miscellaneous Poems
+collection_source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)

--- a/meta/andrew-marvell/the-garden.yml
+++ b/meta/andrew-marvell/the-garden.yml
@@ -1,0 +1,13 @@
+id: andrew-marvell/the-garden
+slug: the-garden
+author: Andrew Marvell
+author_slug: andrew-marvell
+title: The Garden
+century: 17
+text_path: poems/andrew-marvell/the-garden.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/The_Garden
+public_domain_rationale: 'Public domain in the United States: first published 1681 (pre-1929); text via English Wikisource.'
+collection_title: Miscellaneous Poems
+collection_source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)

--- a/meta/john-milton/l-allegro.yml
+++ b/meta/john-milton/l-allegro.yml
@@ -1,0 +1,13 @@
+id: john-milton/l-allegro
+slug: l-allegro
+author: John Milton
+author_slug: john-milton
+title: L'Allegro
+century: 17
+text_path: poems/john-milton/l-allegro.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_of_Mr._John_Milton,_Both_English_and_Latin,_Compos%27d_at_several_times/L%27Allegro
+public_domain_rationale: 'Public domain in the United States: first published 1645 (pre-1929); text via English Wikisource.'
+collection_title: Poems of Mr. John Milton, Both English and Latin, Compos'd at several times
+collection_source_url: https://en.wikisource.org/wiki/Poems_of_Mr._John_Milton,_Both_English_and_Latin,_Compos%27d_at_several_times

--- a/meta/john-milton/lycidas.yml
+++ b/meta/john-milton/lycidas.yml
@@ -1,0 +1,13 @@
+id: john-milton/lycidas
+slug: lycidas
+author: John Milton
+author_slug: john-milton
+title: Lycidas
+century: 17
+text_path: poems/john-milton/lycidas.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_of_Mr._John_Milton,_Both_English_and_Latin,_Compos%27d_at_several_times/Lycidas
+public_domain_rationale: 'Public domain in the United States: first published 1638 (pre-1929); text via English Wikisource.'
+collection_title: Poems of Mr. John Milton, Both English and Latin, Compos'd at several times
+collection_source_url: https://en.wikisource.org/wiki/Poems_of_Mr._John_Milton,_Both_English_and_Latin,_Compos%27d_at_several_times

--- a/poems/andrew-marvell/the-definition-of-love.txt
+++ b/poems/andrew-marvell/the-definition-of-love.txt
@@ -1,0 +1,39 @@
+My Love is of a birth as rare
+As 'tis for object strange and high:
+It was begotten by despair
+Upon Impossibility.
+
+Magnanimous Despair alone
+Could show me so divine a thing,
+Where feeble Hope could ne'r have flown
+But vainly flapt its Tinsel Wing.
+
+And yet I quickly might arrive
+Where my extended Soul is fixt,
+But Fate does Iron wedges drive,
+And alwaies crouds it self betwixt.
+
+For Fate with jealous Eye does see
+Two perfect Loves; nor lets them close:
+Their union would her ruine be,
+And her Tyrannick pow'r depose.
+
+And therefore her Decrees of Steel
+Us as the distant Poles have plac'd,
+(Though Loves whole World on us doth wheel)
+Not by themselves to be embrac'd.
+
+Unless the giddy Heaven fall,
+And Earth some new Convulsion tear:
+And, us to joyn, the World should all
+Be cramp'd into a Planisphere.
+
+As Lines so Loves oblique may well
+Themselves in every Angle greet:
+But ours so truly Paralel,
+Though infinite can never meet.
+
+Therefore the Love which us doth bind,
+But Fate so enviously debarrs,
+Is the Conjunction of the Mind,
+And Opposition of the Stars.

--- a/poems/andrew-marvell/the-garden.txt
+++ b/poems/andrew-marvell/the-garden.txt
@@ -1,0 +1,81 @@
+How vainly men themselves amaze
+To win the Palm, the Oke, or Bayes;
+And their uncessant Labours see
+Crown'd from some single Herb or Tree,
+Whose short and narrow verged Shade
+Does prudently their Toyles upbraid;
+
+While all Flow'rs and all Trees do close
+To weave the Garlands of repose.
+
+Fair quiet, have I found thee here,
+And Innocence thy Sister dear!
+Mistaken long, I sought you then
+In busie Companies of Men.
+Your sacred Plants, if here below,
+Only among the Plants will grow.
+Society is all but rude,
+To this delicious Solitude.
+
+No white nor red was ever seen
+So am'rous as this lovely green.
+Fond Lovers, cruel as their Flame,
+Cut in these Trees their Mistress name.
+Little, Alas, they know, or heed,
+How far these Beauties Hers exceed!
+Fair Trees! where s'eer you barkes I wound,
+No Name shall but your own be found.
+
+When we have run our Passions heat,
+Love hither makes his best retreat.
+The Gods, that mortal Beauty chase,
+Still in a Tree did end their race.
+Apollo hunted Daphne so,
+Only that She might Laurel grow.
+And Pan did after Syrinx speed,
+Not as a Nymph, but for a Reed.
+
+What wond'rous Life in this I lead!
+Ripe Apples drop about my head;
+The Luscious Clusters of the Vine
+Upon my Mouth do crush their Wine;
+The Nectaren, and curious Peach,
+Into my hands themselves do reach;
+Stumbling on Melons, as I pass,
+Insnar'd with Flow'rs, I fall on Grass.
+
+Mean while the Mind, from pleasure less,
+Withdraws into its happiness:
+The Mind, that Ocean where each kind
+Does streight its own resemblance find;
+Yet it creates, transcending these,
+Far other Worlds, and other Seas;
+Annihilating all that's made
+To a green Thought in a green Shade.
+
+Here at the Fountains sliding foot,
+Or at some Fruit-trees mossy root,
+Casting the Bodies Vest aside,
+My Soul into the boughs does glide:
+There like a Bird it sits, and sings,
+Then whets, and combs its silver Wings;
+And, till prepar'd for longer flight,
+Waves in its Plumes the various Light.
+
+Such was that happy Garden-state,
+While Man there walk'd without a Mate:
+After a Place so pure, and sweet,
+What other Help could yet be meet!
+But 'twas beyond a Mortal's share
+To wander solitary there:
+Two Paradises 'twere in one
+To live in Paradise alone.
+
+How well the skilful Gardner drew
+Of flow'rs and herbes this Dial new;
+Where from above the milder Sun
+Does through a fragrant Zodiack run;
+And, as it works, th' industrious Bee
+Computes its time as well as we.
+How could such sweet and wholsome Hours
+Be reckon'd but with herbs and flow'rs!

--- a/poems/john-milton/l-allegro.txt
+++ b/poems/john-milton/l-allegro.txt
@@ -1,0 +1,158 @@
+HEnce, loathed Melancholy,
+Of Cerberus and blackest midnight born,
+In Stygian Cave forlorn
+'Mongst horrid shapes, and shrieks, and sights unholy,
+Find out som uncouth cell,
+Wher brooding darkness spreads his jealous wings,
+And the night-Raven sings;
+There, under Ebon shades and low-brow'd Rocks,
+As ragged as thy Locks,
+In dark Cimmerian desert ever dwell.
+
+But com thou Goddes fair and free,
+In Heav'n ycleap'd Euphrosyne,
+And by men, heart-easing Mirth,
+Whom lovely Venus at a birth
+With two sister Graces more
+To Ivy-crowned Bacchus bore;
+Or whether (as som Sager sing)
+The frolick Wind that breathes the Spring,
+Zephir with Aurora playing,
+As he met her once a Maying,
+There on Beds of Violets blew,
+And fresh-blown Roses washt in dew,
+Fill'd her with thee a daughter fair,
+So bucksom, blith, and debonair.
+Haste thee nymph, and bring with thee
+Jest and youthful Jollity,
+Quips and Cranks, and wanton Wiles,
+Nods, and Becks, and Wreathed Smiles,
+Such as hang on Hebe's cheek,
+And love to live in dimple sleek;
+Sport that wrincled Care derides,
+And Laughter holding both his sides,
+Com, and trip it as ye go
+On the light fantastick toe.
+
+And in thy right hand lead with thee,
+The Mountain Nymph, sweet Liberty;
+And if I give thee honour due,
+Mirth, admit me of thy crue
+To live with her, and live with thee,
+In unreproved pleasures free;
+To hear the Lark begin his flight.
+And singing startle the dull night,
+From his watch-towre in the skies,
+Till the dappled dawn doth rise;
+Then to com in spight of sorrow,
+And at my window bid good morrow,
+Through the Sweet-Briar, or the Vine,
+Or the twisted Eglantine.
+While the Cock with lively din,
+Scatters the rear of darknes thin,
+And to the stack, or the Barn dore,
+Stoutly struts his Dames before,
+Oft list'ning how the Hounds and horn,
+Chearly rouse the slumbring morn,
+From the side of som Hoar Hill,
+Through the high wood echoing shrill.
+Som time walking not unseen
+By Hedge-row Elms, on Hillocks green,
+
+Right against the Eastern gate,
+Wher the great Sun begins his state,
+Rob'd in flames, and Amber light,
+The clouds in thousand Liveries dight,
+While the Plowman neer at hand,
+Whistles ore the Furrow'd Land,
+And the Milkmaid fingeth blithe,
+And the Mower whets his sithe,
+And every Shepherd tells his tale
+Under the Hawthorn in the dale.
+Streit mine eye hath caught new pleasures
+Whilst the Lantskip round it measures,
+Russet Lawns, and Fallows Gray,
+Where the nibling flocks do stray,
+Mountains on whose barren brest
+The labouring clouds do often rest:
+Meadows trim with Daisies pide,
+Shallow Brooks, and Rivers wide
+Towers, and Battlements it sees
+Boosom'd high in tufted Trees,
+Wher perhaps fom beauty lies,
+The Cynosure of neighbouring eyes.
+Hard by, a Cottage chimney smokes,
+From betwixt two aged Okes,
+
+Where Corydon and Thyrsis met,
+Are at their savory dinner set
+Of Hearbs, and other Country Messes,
+Which the neat-handed Phillis dresses;
+And then in haste her Bowre she leaves,
+With Thestylis to bind the Sheaves;
+Or if the earlier season lead
+To the tann'd Haycock in the Mead,
+Som times with secure delight
+The up-land Hamlets will invite,
+When the merry Bells ring round,
+And the jocond rebecks sound
+To many a youth, and many a maid,
+Dancing in the Chequer'd shade;
+And young and old com forth to play
+On a Sunshine Holyday,
+Till the live-long day-light fail,
+Then to the Spicy Nut-brown Ale,
+With stories told of many a feat,
+How Faery Mab the junkets eat,
+She was pincht, and pull'd she sed,
+And he by Friars Lanthorn led
+Tells how the drudging Goblin swet,
+To ern his Cream-bowle duly set,
+
+When in one night, ere glimps of morn,
+His shadowy Flale hath thresh'd the Corn
+That ten day labourers could not end,
+Then lies him down the Lubbar Fend.
+And stretch'd out all the Chimney's length,
+Basks at the fire his hairy strength;
+And Crop-full out of dores he flings,
+Ere the first Cock his Maitin rings.
+Thus don the Tales, to bed they creep,
+By whispering Windes soon lull'd asleep.
+Towred Cities please us then,
+And the busie humm of men,
+Where throngs of Knights and Barons bold,
+In weeds of Peace high triumphs hold,
+With store of Ladies, whose bright eies
+Rain influence, and judge the prise
+Of Wit, or Arms, while both contend
+To win her Grace, whom all commend.
+There let Hymen oft appear
+In Saffron robe, with Taper clear,
+And pomp, and feast, and revelry,
+With mask, and antique Pageantry,
+Such sights as youthfull Poets dream
+On Summer eeves by haunted stream.
+
+Then to the well, trod stage anon,
+If Jonsons learned Sock be on,
+Or sweetest Shakespear fancies childe,
+Warble his native Wood-notes wilde,
+And ever against eating Cares,
+Lap me in soft Lydian Aires,
+Married to immortal verse
+Such as the meeting soul may pierce
+In notes, with many a winding bout
+Of lincked sweetnes long drawn out,
+With wanton heed, and giddy cunning,
+The melting voice through mazes running;
+Untwining all the chains that ty
+The hidden soul of harmony.
+That Orpheus self may heave his head
+From golden slumber on a bed
+Of heapt Elysian flowres, and hear
+Such streins as would have won the ear
+Of Pluto, to have quite set free
+His half regain'd Eurydice.
+These delights, if thou canst give,
+Mirth with thee, I mean to live.

--- a/poems/john-milton/lycidas.txt
+++ b/poems/john-milton/lycidas.txt
@@ -1,0 +1,193 @@
+YEt once more, O ye Laurels, and once more
+Ye Myrtles brown, with Ivy never-sear,
+I com to pluck your Berries harsh and crude,
+And with forc'd fingers rude,
+Shatter your leaves before the mellowing year.
+Bitter constraint, and sad occasion dear,
+Compels me to disturb your season due:
+For Lycidas is dead, dead ere his prime,
+Young Lycidas, and hath not left his peer:
+Who would not sing for Lycidas? he knew
+Himself to sing, and build the lofty rhyme.
+He must not flote upon his watry bear
+Unwept, and welter to the parching wind,
+Without the meed of som melodious tear.
+Begin then, Sisters of the sacred well,
+That from beneath the seat of Jove doth spring,
+Begin, and somwhat loudly sweep the string.
+Hence with denial vain, and coy excuse,
+So may som gentle Muse
+With lucky words favour my destin'd Urn,
+And as he passes turn,
+And bid fair peace be to my sable shrowd.
+For we were nurst upon the self-same hill,
+Fed the same flock, by fountain, shade, and rill.
+Together both, ere the high Lawns appear'd
+Under the opening eye-lids of the morn,
+We drove a field, and both together heard
+What time the Gray-fly winds her sultry horn,
+Batt'ning our flocks with the fresh dews of night,
+Oft till the Star that rose, at Ev'ning, bright
+Toward Heav'ns descent had slop'd his westering wheel.
+Mean while the Rural ditties were not mute,
+Temper'd to th' Oaten Flute,
+Rough Satyrs danc'd, and Fauns with clov'n heel,
+From the glad sound would not be absent long,
+And old Damœtas lov'd to hear our song.
+But O the heavy change, now thou art gon,
+Now thou art gon, and never must return!
+Thee Shepherd, thee the Woods, and desert Caves,
+With wilde Thyme and the gadding Vine o'regrown,
+And all their echoes mourn.
+The Willows, and the Hazle Copses green,
+Shall now no more be seen,
+Fanning their joyous Leaves to thy soft layes.
+As killing as the Canker to the Rose,
+Or Taint-worm to the weanling Herds that graze,
+Or Frost to Flowers, that their gay wardrop wear,
+When first the White thorn blows;
+Such, Lycidas, thy loss to Shepherds ear.
+Where were ye Nymphs when the remorseless deep
+Clos'd o're the head of your lov'd Lycidas?
+For neither were ye playing on the steep,
+Where your old Bards, the famous Druids ly,
+Nor on the shaggy top of Mona high,
+Nor yet where Deva spreads her wisard stream:
+Ay me, I fondly dream!
+Had ye bin there—for what could that have don?
+What could the Muse her self that Orpheus bore,
+The Muse her self, for her inchanting son
+Whom Universal nature did lament,
+When by the rout that made the hideous roar,
+His goary visage down the stream was sent,
+Down the swift Hebrus to the Lesbian shore.
+Alas! What boots it with uncessant care
+To tend the homely slighted Shepherds trade,
+And strictly meditate the thankles Muse,
+Were it not better don as others use,
+To sport with Amaryllis in the shade,
+Or with the tangles of Neæra's hair?
+Fame is the spur that the clear spirit doth raise
+(That last infirmity of Noble mind)
+To scorn delights, and live laborious dayes;
+But the fair Guerdon when we hope to find,
+And think to burst out into sudden blaze,
+Comes the blind Fury with th' abhorred shears,
+And slits the thin spun life. But not the praise,
+Phœbus repli'd, and touch'd my trembling ears;
+Fame is no plant that grows on mortal soil,
+Nor in the glistering foil
+Set off to th' world, nor in broad rumour lies,
+But lives and spreds aloft by those pure eyes,
+And perfet witnes of all judging Jove;
+As he pronounces lastly on each deed,
+Of so much fame in Heav'n expect thy meed.
+O Fountain Arethuse, and thou honour'd flood,
+Smooth-sliding Mincius, crown'd with vocall reeds,
+That strain I heard was of a higher mood:
+But now my Oate proceeds,
+And listens to the Herald of the Sea
+That came in Neptune's plea,
+He ask'd the Waves, and ask'd the Fellon winds,
+What hard mishap hath doom'd this gentle swain?
+And question'd every gust of rugged wings
+That blows from off each beaked Promontory,
+They knew not of his story,
+And sage Hippotades their answer brings,
+That not a blast was from his dungeon stray'd,
+The Ayr was calm, and on the level brine,
+Sleek Panope with all her sisters play'd.
+It was that fatall and perfidious Bark
+Built in th' eclipse, and rigg'd with curses dark,
+That sunk so low that sacred head of thine.
+Next Camus, reverend Sire, went footing slow,
+His Mantle hairy, and his Bonnet sedge,
+Inwrought with figures dim, and on the edge
+Like to that sanguine flower inscrib'd with woe.
+Ah! Who hath reft (quoth he) my dearest pledge?
+Last came, and last did go,
+The Pilot of the Galilean lake,
+Two massy Keyes he bore of metals twain,
+(The Golden opes, the Iron shuts amain)
+He shook his Miter'd locks, and stern bespake,
+How well could I have spar'd for thee young swain.
+Anow of such as for their bellies sake,
+Creep and intrude, and climb into the fold?
+Of other care they little reck'ning make,
+Then how to scramble at the shearers feast,
+And shove away the worthy bidden guest.
+Blind mouthes! that scarce themselves know how to hold
+A Sheep-hook, or have learn'd ought els the least
+That to the faithfull Herdmans art belongs!
+What recks it them? What need they? They are sped;
+And when they list, their lean and flashy songs
+Grate on their scrannel Pipes of wretched straw,
+The hungry Sheep look up, and are not fed,
+But swoln with wind, and the rank mist they draw,
+Rot inwardly, and foul contagion spread:
+Besides what the grim Woolf with privy paw
+Daily devours apace, and nothing sed,
+But that two-handed engine at the door,
+Stands ready to smite once, and smite no more.
+Return Alpheus, the dread voice is past,
+That shrunk thy streams; Return Sicilian Muse,
+And call the Vales, and bid them hither cast
+Their Bels, and Flourets of a thousand hues.
+Ye valleys low where the milde whispers use,
+Of shades and wanton winds, and gushing brooks,
+On whose fresh lap the swart Star sparely looks,
+Throw hither all your quaint enameld eyes,
+That on the green terf suck the honied showres,
+And purple all the ground with vernal flowres.
+Bring the rathe Primrose that forsaken dies.
+The tufted Crow-toe, and pale Gessamine,
+The white Pink, and the Pansie freakt with jeat,
+The glowing Violet.
+The Musk-rose, and the well attir'd Woodbine,
+With Cowslips wan that hang the pensive hed,
+And every flower that sad embroidery wears:
+Bid Amaranthus all his beauty shed,
+And Daffadillies fill their cups with tears,
+To strew the Laureat Herse where Lycid lies.
+For so to interpose a little ease,
+Let our frail thoughts dally with false surmise.
+Ay me! Whilst thee the shores and sounding Seas
+Wash far away, where ere thy bones are hurld,
+Whether beyond the stormy Hebrides,
+Where thou perhaps under the whelming tide
+Visit'st the bottom of the monstrous world;
+Or whether thou to our moist vows deny'd,
+Sleep'st by the fable of Bellerus old,
+Where the great vision of the guarded Mount
+Looks toward Namancos and Bayona's hold;
+Look homeward Angel now, and melt with ruth.
+And, O ye Dolphins, waft the haples youth.
+Weep no more, woful Shepherds weep no more,
+For Lycidas your sorrow is not dead,
+Sunk though he be beneath the watry floar,
+So sinks the day-star in the Ocean bed,
+And yet anon repairs his drooping head,
+And tricks his beams, and with new-spangled Ore,
+Flames in the forehead of the morning sky:
+So Lycidas sunk low, but mounted high,
+Through the dear might of him that walk'd the waves;
+Where other groves, and other streams along,
+With Nectar pure his oozy Lock's he laves,
+And hears the unexpressive nuptiall Song,
+In the blest Kingdoms meek of joy and love.
+There entertain him all the Saints above,
+In solemn troops, and sweet Societies
+That sing, and singing in their glory move,
+And wipe the tears for ever from his eyes.
+Now Lycidas the Shepherds weep no more;
+Hence forth thou art the Genius of the shore,
+In thy large recompense, and shalt be good
+To all that wander in that perilous flood.
+Thus sang the uncouth Swain to th' Okes and rills,
+While the still morn went out with Sandals gray,
+He touch'd the tender stops of various Quills,
+With eager thought warbling his Dorick lay:
+And now the Sun had stretch'd out all the hills,
+And now was dropt into the Western bay;
+At last he rose, and twitch'd his Mantle blew:
+To morrow to fresh Woods, and Pastures new.

--- a/scripts/ingest-wikisource-early-modern-depth.mjs
+++ b/scripts/ingest-wikisource-early-modern-depth.mjs
@@ -1,0 +1,203 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const POEMS = [
+  {
+    author: "Andrew Marvell",
+    author_slug: "andrew-marvell",
+    century: 17,
+    slug: "the-garden",
+    title: "The Garden",
+    published_year: 1681,
+    source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/The_Garden",
+    collection_title: "Miscellaneous Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)",
+    page_title: "Miscellaneous Poems (Marvell)/The Garden",
+    start_line: "How vainly men themselves amaze",
+    end_line: "Be reckon'd but with herbs and flow'rs!",
+  },
+  {
+    author: "Andrew Marvell",
+    author_slug: "andrew-marvell",
+    century: 17,
+    slug: "the-definition-of-love",
+    title: "The Definition of Love",
+    published_year: 1681,
+    source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/The_Definition_of_Love",
+    collection_title: "Miscellaneous Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)",
+    page_title: "Miscellaneous Poems (Marvell)/The Definition of Love",
+    start_line: "My Love is of a birth as rare",
+    end_line: "And Opposition of the Stars.",
+  },
+  {
+    author: "John Milton",
+    author_slug: "john-milton",
+    century: 17,
+    slug: "l-allegro",
+    title: "L'Allegro",
+    published_year: 1645,
+    source_url:
+      "https://en.wikisource.org/wiki/Poems_of_Mr._John_Milton,_Both_English_and_Latin,_Compos%27d_at_several_times/L%27Allegro",
+    collection_title: "Poems of Mr. John Milton, Both English and Latin, Compos'd at several times",
+    collection_source_url:
+      "https://en.wikisource.org/wiki/Poems_of_Mr._John_Milton,_Both_English_and_Latin,_Compos%27d_at_several_times",
+    page_title: "Poems of Mr. John Milton, Both English and Latin, Compos'd at several times/L'Allegro",
+    start_line: "HEnce, loathed Melancholy,",
+    end_line: "Mirth with thee, I mean to live.",
+  },
+  {
+    author: "John Milton",
+    author_slug: "john-milton",
+    century: 17,
+    slug: "lycidas",
+    title: "Lycidas",
+    published_year: 1638,
+    source_url:
+      "https://en.wikisource.org/wiki/Poems_of_Mr._John_Milton,_Both_English_and_Latin,_Compos%27d_at_several_times/Lycidas",
+    collection_title: "Poems of Mr. John Milton, Both English and Latin, Compos'd at several times",
+    collection_source_url:
+      "https://en.wikisource.org/wiki/Poems_of_Mr._John_Milton,_Both_English_and_Latin,_Compos%27d_at_several_times",
+    page_title: "Poems of Mr. John Milton, Both English and Latin, Compos'd at several times/Lycidas",
+    start_line: "YEt once more, O ye Laurels, and once more",
+    end_line: "To morrow to fresh Woods, and Pastures new.",
+  },
+];
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#8195;/g, "")
+    .replace(/&#91;/g, "[")
+    .replace(/&#93;/g, "]")
+    .replace(/&#95;/g, "_")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…");
+}
+
+function cleanRenderedText(html) {
+  let body = html.slice(html.indexOf('<div class="prp-pages-output"'));
+  const referencesIndex = body.indexOf('<div class="mw-references-wrap');
+  if (referencesIndex !== -1) body = body.slice(0, referencesIndex);
+
+  body = body.replace(/<style[\s\S]*?<\/style>/g, "");
+  body = body.replace(/<link[^>]*>/g, "");
+  body = body.replace(/<sup[^>]*>.*?<\/sup>/gs, "");
+  body = body.replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+  body = body.replace(/<span[^>]*class="wst-gap[^"]*"[^>]*><\/span>/g, "    ");
+  body = body.replace(/<br\s*\/?>\n?/g, "\n");
+  body = body.replace(/<\/p>\s*<p>/g, "\n\n");
+  body = body.replace(/<[^>]+>/g, "");
+
+  return decodeHtml(body)
+    .replace(/\u00a0/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function extractPoem(text, startLine, endLine) {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  const start = lines.findIndex((line) => line.trim() === startLine);
+  if (start === -1) throw new Error(`Start line not found: ${startLine}`);
+
+  const end = lines.findIndex((line, index) => index >= start && line.trim() === endLine);
+  if (end === -1) throw new Error(`End line not found: ${endLine}`);
+
+  return lines
+    .slice(start, end + 1)
+    .filter((line) => !/^[IVXLC]+[.]?$/.test(line.trim()))
+    .filter(
+      (line) =>
+        !["L'Allegro.", "Lycidas.", "The Garden.", "The Definition of Love."].includes(
+          line.trim(),
+        ),
+    )
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchPoemText(pageTitle, startLine, endLine) {
+  const url =
+    "https://en.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to fetch Wikisource page ${pageTitle} (${response.status})`);
+
+  const json = await response.json();
+  if (!json.parse?.text) throw new Error(`Wikisource parse failed for ${pageTitle}`);
+  return extractPoem(cleanRenderedText(json.parse.text), startLine, endLine);
+}
+
+function buildMeta(poem) {
+  return yaml.dump(
+    {
+      id: `${poem.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: poem.author,
+      author_slug: poem.author_slug,
+      title: poem.title,
+      century: poem.century,
+      text_path: `poems/${poem.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: poem.source_url,
+      public_domain_rationale:
+        `Public domain in the United States: first published ${poem.published_year} ` +
+        `(pre-1929); text via English Wikisource.`,
+      collection_title: poem.collection_title,
+      collection_source_url: poem.collection_source_url,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  let created = 0;
+
+  for (const poem of POEMS) {
+    const poemsDir = path.join("poems", poem.author_slug);
+    const metaDir = path.join("meta", poem.author_slug);
+    await fs.mkdir(poemsDir, { recursive: true });
+    await fs.mkdir(metaDir, { recursive: true });
+
+    const text = await fetchPoemText(poem.page_title, poem.start_line, poem.end_line);
+    const poemPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    let existed = true;
+    try {
+      await fs.access(poemPath);
+    } catch {
+      existed = false;
+    }
+
+    await fs.writeFile(poemPath, `${text}\n`, "utf8");
+    await fs.writeFile(metaPath, buildMeta(poem), "utf8");
+    created += 1;
+    console.log(`${poem.author}: ${existed ? "updated" : "created"} ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #99

## What changed
- add 4 early-modern poems for Andrew Marvell and John Milton
- add a source-specific Wikisource ingest script so the wave is reproducible

## Copyright guardrails
- approved source only: Wikisource
- no modern translations
- each metadata sidecar states an explicit US public-domain basis

## Verification
- `cd site && npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four early modern poems: "The Definition of Love" and "The Garden" by Andrew Marvell, and "L'Allegro" and "Lycidas" by John Milton.
  * Complete metadata and public-domain source attribution now available for each poem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->