### PR TITLE
Deepen American author coverage

### DIFF
--- a/meta/oliver-wendell-holmes-sr/the-deacons-masterpiece.yml
+++ b/meta/oliver-wendell-holmes-sr/the-deacons-masterpiece.yml
@@ -1,0 +1,13 @@
+id: oliver-wendell-holmes-sr/the-deacons-masterpiece
+slug: the-deacons-masterpiece
+author: Oliver Wendell Holmes, Sr.
+author_slug: oliver-wendell-holmes-sr
+title: The Deacon's Masterpiece
+century: 19
+text_path: poems/oliver-wendell-holmes-sr/the-deacons-masterpiece.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Deacon%27s_Masterpiece
+public_domain_rationale: 'Public domain in the United States: first published 1858 (pre-1929); text via English Wikisource.'
+collection_title: The Professor at the Breakfast-Table
+collection_source_url: https://en.wikisource.org/wiki/The_Professor_at_the_Breakfast-Table

--- a/meta/ralph-waldo-emerson/each-and-all.yml
+++ b/meta/ralph-waldo-emerson/each-and-all.yml
@@ -1,0 +1,13 @@
+id: ralph-waldo-emerson/each-and-all
+slug: each-and-all
+author: Ralph Waldo Emerson
+author_slug: ralph-waldo-emerson
+title: Each and All
+century: 19
+text_path: poems/ralph-waldo-emerson/each-and-all.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_(Emerson,_1847)/Each_and_All
+public_domain_rationale: 'Public domain in the United States: first published 1847 (pre-1929); text via English Wikisource.'
+collection_title: Poems
+collection_source_url: https://en.wikisource.org/wiki/Poems_(Emerson,_1847)

--- a/meta/ralph-waldo-emerson/give-all-to-love.yml
+++ b/meta/ralph-waldo-emerson/give-all-to-love.yml
@@ -1,0 +1,13 @@
+id: ralph-waldo-emerson/give-all-to-love
+slug: give-all-to-love
+author: Ralph Waldo Emerson
+author_slug: ralph-waldo-emerson
+title: Give All to Love
+century: 19
+text_path: poems/ralph-waldo-emerson/give-all-to-love.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_(Emerson,_1847)/Give_all_to_Love
+public_domain_rationale: 'Public domain in the United States: first published 1847 (pre-1929); text via English Wikisource.'
+collection_title: Poems
+collection_source_url: https://en.wikisource.org/wiki/Poems_(Emerson,_1847)

--- a/meta/ralph-waldo-emerson/the-snow-storm.yml
+++ b/meta/ralph-waldo-emerson/the-snow-storm.yml
@@ -1,0 +1,13 @@
+id: ralph-waldo-emerson/the-snow-storm
+slug: the-snow-storm
+author: Ralph Waldo Emerson
+author_slug: ralph-waldo-emerson
+title: The Snow-Storm
+century: 19
+text_path: poems/ralph-waldo-emerson/the-snow-storm.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_(Emerson,_1847)/The_Snow-Storm
+public_domain_rationale: 'Public domain in the United States: first published 1847 (pre-1929); text via English Wikisource.'
+collection_title: Poems
+collection_source_url: https://en.wikisource.org/wiki/Poems_(Emerson,_1847)

--- a/poems/oliver-wendell-holmes-sr/the-deacons-masterpiece.txt
+++ b/poems/oliver-wendell-holmes-sr/the-deacons-masterpiece.txt
@@ -1,0 +1,130 @@
+Have you heard of the wonderful one-hoss shay,
+That was built in such a logical way
+It ran a hundred years to a day,
+And then, of a sudden, it — ah, but stay,
+I'll tell you what happened without delay,
+Scaring the parson into fits,
+Frightening people out of their wits, —
+Have you ever heard of that, I say?
+
+Seventeen hundred and fifty-five.
+Georgius Secundus was then alive, —
+Snuffy old drone from the German hive.
+That was the year when Lisbon-town
+Saw the earth open and gulp her down,
+And Braddock's army was done so brown,
+Left without a scalp to its crown.
+It was on the terrible Earthquake-day
+That the Deacon finished the one-hoss shay.
+
+Now in building of chaises, I tell you what,
+There is always somewhere a weakest spot, —
+In hub, tire, felloe, in spring or thill,
+In panel, or crossbar, or floor, or sill,
+In screw, bolt, thoroughbrace, — lurking still,
+Find it somewhere you must and will, —
+Above or below, or within or without, —
+And that's the reason, beyond a doubt,
+A chaise breaks down, but doesn't wear out.
+
+But the Deacon swore (as Deacons do,
+With an "I dew vum," or an "I tell yeou")
+He would build one shay to beat the taown
+'N' the keounty 'n' all the kentry raoun';
+It should be so built that it could n' break daown:
+"Fur," said the Deacon, "'t 's mighty plain
+Thut the weakes' place mus' stan' the strain;
+'N' the way t' fix it, uz I maintain,
+Is only jest
+T' make that place uz strong uz the rest."
+
+So the Deacon inquired of the village folk
+Where he could find the strongest oak,
+That could n't be split nor bent nor broke, —
+That was for spokes and floor and sills;
+He sent for lancewood to make the thills;
+The crossbars were ash, from the straightest trees,
+The panels of white-wood, that cuts like cheese,
+But lasts like iron for things like these;
+The hubs of logs from the "Settler's ellum," —
+Last of its timber, — they could n't sell 'em,
+Never an axe had seen their chips,
+And the wedges flew from between their lips,
+Their blunt ends frizzled like celery-tips;
+Step and prop-iron, bolt and screw,
+Spring, tire, axle, and linchpin too,
+Steel of the finest, bright and blue;
+Thoroughbrace bison-skin, thick and wide;
+Boot, top, dasher, from tough old hide
+Found in the pit when the tanner died.
+That was the way he "put her through."
+"There!" said the Deacon, "naow she'll dew!"
+
+Do! I tell you, I rather guess
+She was a wonder, and nothing less!
+Colts grew horses, beards turned gray,
+Deacon and deaconess dropped away,
+Children and grandchildren — where were they?
+But there stood the stout old one-hoss shay
+As fresh as on Lisbon-earthquake-day!
+
+EIGHTEEN HUNDRED; — it came and found
+The Deacon's masterpiece strong and sound.
+Eighteen hundred increased by ten; —
+"Hahnsum kerridge" they called it then.
+Eighteen hundred and twenty came; —
+Running as usual; much the same.
+Thirty and forty at last arrive,
+And then come fifty, and FIFTY-FIVE.
+
+Little of all we value here
+Wakes on the morn of its hundreth year
+Without both feeling and looking queer.
+In fact, there's nothing that keeps its youth,
+So far as I know, but a tree and truth.
+(This is a moral that runs at large;
+Take it. — You're welcome. — No extra charge.)
+
+FIRST OF NOVEMBER, — the Earthquake-day, —
+There are traces of age in the one-hoss shay,
+A general flavor of mild decay,
+But nothing local, as one may say.
+There could n't be, — for the Deacon's art
+Had made it so like in every part
+That there was n't a chance for one to start.
+For the wheels were just as strong as the thills,
+And the floor was just as strong as the sills,
+And the panels just as strong as the floor,
+And the whipple-tree neither less nor more,
+And the back crossbar as strong as the fore,
+And spring and axle and hub encore.
+And yet, as a whole, it is past a doubt
+In another hour it will be worn out!
+
+First of November, 'Fifty-five!
+This morning the parson takes a drive.
+Now, small boys, get out of the way!
+Here comes the wonderful one-hoss shay,
+Drawn by a rat-tailed, ewe-necked bay.
+"Huddup!" said the parson. — Off went they.
+The parson was working his Sunday's text, —
+Had got to fifthly, and stopped perplexed
+At what the — Moses — was coming next.
+All at once the horse stood still,
+Close by the meet'n'-house on the hill.
+First a shiver, and then a thrill,
+Then something decidedly like a spill, —
+And the parson was sitting upon a rock,
+At half past nine by the meet'n-house clock, —
+Just the hour of the Earthquake shock!
+What do you think the parson found,
+When he got up and stared around?
+The poor old chaise in a heap or mound,
+As if it had been to the mill and ground!
+You see, of course, if you're not a dunce,
+How it went to pieces all at once, —
+All at once, and nothing first, —
+Just as bubbles do when they burst.
+
+End of the wonderful one-hoss shay.
+Logic is logic. That's all I say.

--- a/poems/ralph-waldo-emerson/each-and-all.txt
+++ b/poems/ralph-waldo-emerson/each-and-all.txt
@@ -1,0 +1,51 @@
+Little thinks, in the field, yon red-cloaked clown,
+Of thee from the hill-top looking down;
+The heifer that lows in the upland farm,
+Far-heard, lows not thine ear to charm;
+The sexton, tolling his bell at noon,
+Deems not that great Napoleon
+Stops his horse, and lists with delight,
+Whilst his files sweep round yon Alpine height;
+Nor knowest thou what argument
+Thy life to thy neighbor's creed has lent.
+All are needed by each one;
+Nothing is fair or good alone.
+I thought the sparrow's note from heaven,
+Singing at dawn on the alder bough;
+I brought him home, in his nest, at even;
+He sings the song, but it pleases not now,
+For I did not bring home the river and sky;—
+He sang to my ear,—they sang to my eye.
+The delicate shells lay on the shore;
+The bubbles of the latest wave
+Fresh pearls to their enamel gave;
+And the bellowing of the savage sea
+Greeted their safe escape to me.
+I wiped away the weeds and foam,
+I fetched my sea-born treasures home;
+But the poor, unsightly, noisome things
+Had left their beauty on the shore,
+With the sun, and the sand, and the wild uproar.
+The lover watched his graceful maid,
+As 'mid the virgin train she strayed,
+Nor knew her beauty's best attire
+Was woven still by the snow-white choir.
+At last she came to his hermitage,
+Like the bird from the woodlands to the cage;—
+The gay enchantment was undone,
+A gentle wife, but fairy none.
+Then I said, 'I covet truth;
+Beauty is unripe childhood's cheat;
+I leave it behind with the games of youth.'—
+As I spoke, beneath my feet
+The ground-pine curled its pretty wreath,
+Running over the club-moss burrs;
+I inhaled the violet's breath;
+Around me stood the oaks and firs;
+Pine-cones and acorns lay on the ground,
+Over me soared the eternal sky,
+Full of light and of deity;
+Again I saw, again I heard,
+The rolling river, the morning bird;—
+Beauty through my senses stole;
+I yielded myself to the perfect whole.

--- a/poems/ralph-waldo-emerson/give-all-to-love.txt
+++ b/poems/ralph-waldo-emerson/give-all-to-love.txt
@@ -1,0 +1,54 @@
+Give all to love;
+Obey thy heart;
+Friends, kindred, days,
+Estate, good-fame,
+Plans, credit, and the Muse,—
+Nothing refuse.
+
+'Tis a brave master;
+Let it have scope:
+Follow it utterly,
+Hope beyond hope:
+High and more high
+It dives into noon,
+With wing unspent,
+Untold intent;
+But it is a god,
+Knows its own path;
+And the outlets of the sky.
+
+It was not for the mean;
+It requireth courage stout,
+Souls above doubt,
+Valor unbending;
+Such 'twill reward,—
+They shall return
+More than they were,
+And ever ascending.
+
+Leave all for love;
+Yet, hear me, yet,
+One word more thy heart behoved,
+One pulse more of firm endeavor,—
+Keep thee to-day,
+To-morrow, forever,
+Free as an Arab
+Of thy beloved.
+
+Cling with life to the maid;
+But when the surprise,
+First vague shadow of surmise
+Flits across her bosom young
+Of a joy apart from thee,
+Free be she, fancy-free;
+Nor thou detain her vesture's hem,
+Nor the palest rose she flung
+From her summer diadem.
+
+Though thou loved her as thyself,
+As a self of purer clay,
+Though her parting dims the day,
+Stealing grace from all alive;
+Heartily know,
+When half-gods go,
+The gods arrive.

--- a/poems/ralph-waldo-emerson/the-snow-storm.txt
+++ b/poems/ralph-waldo-emerson/the-snow-storm.txt
@@ -1,0 +1,29 @@
+Announced by all the trumpets of the sky,
+Arrives the snow, and, driving o'er the fields,
+Seems nowhere to alight: the whited air
+Hides hills and woods, the river, and the heaven,
+And veils the farm-house at the garden's end.
+The sled and traveller stopped, the courier's feet
+Delayed, all friends shut out, the housemates sit
+Around the radiant fireplace, enclosed
+In a tumultuous privacy of storm.
+
+Come see the north wind's masonry.
+Out of an unseen quarry evermore
+Furnished with tile, the fierce artificer
+Curves his white bastions with projected roof
+Round every windward stake, or tree, or door.
+Speeding, the myriad-handed, his wild work
+So fanciful, so savage, nought cares he
+For number or proportion. Mockingly,
+On coop or kennel he hangs Parian wreaths;
+A swan-like form invests the hidden thorn;
+Fills up the farmer's lane from wall to wall,
+Maugre the farmer's sighs; and, at the gate,
+A tapering turret overtops the work.
+And when his hours are numbered, and the world
+Is all his own, retiring, as he were not,
+Leaves, when the sun appears, astonished Art
+To mimic in slow structures, stone by stone,
+Built in an age, the mad wind's night-work,
+The frolic architecture of the snow.

--- a/scripts/ingest-wikisource-american-depth.mjs
+++ b/scripts/ingest-wikisource-american-depth.mjs
@@ -1,0 +1,213 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const POEMS = [
+  {
+    author: "Ralph Waldo Emerson",
+    author_slug: "ralph-waldo-emerson",
+    century: 19,
+    slug: "each-and-all",
+    title: "Each and All",
+    published_year: 1847,
+    source_url: "https://en.wikisource.org/wiki/Poems_(Emerson,_1847)/Each_and_All",
+    collection_title: "Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Poems_(Emerson,_1847)",
+    page_title: "Poems (Emerson, 1847)/Each and All",
+    start_line: "Little thinks, in the field, yon red-cloaked clown,",
+    end_line: "I yielded myself to the perfect whole.",
+  },
+  {
+    author: "Ralph Waldo Emerson",
+    author_slug: "ralph-waldo-emerson",
+    century: 19,
+    slug: "the-snow-storm",
+    title: "The Snow-Storm",
+    published_year: 1847,
+    source_url: "https://en.wikisource.org/wiki/Poems_(Emerson,_1847)/The_Snow-Storm",
+    collection_title: "Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Poems_(Emerson,_1847)",
+    page_title: "Poems (Emerson, 1847)/The Snow-Storm",
+    start_line: "Announced by all the trumpets of the sky,",
+    end_line: "The frolic architecture of the snow.",
+  },
+  {
+    author: "Ralph Waldo Emerson",
+    author_slug: "ralph-waldo-emerson",
+    century: 19,
+    slug: "give-all-to-love",
+    title: "Give All to Love",
+    published_year: 1847,
+    source_url: "https://en.wikisource.org/wiki/Poems_(Emerson,_1847)/Give_all_to_Love",
+    collection_title: "Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Poems_(Emerson,_1847)",
+    page_title: "Poems (Emerson, 1847)/Give all to Love",
+    start_line: "Give all to love;",
+    end_line: "The gods arrive.",
+  },
+  {
+    author: "Oliver Wendell Holmes, Sr.",
+    author_slug: "oliver-wendell-holmes-sr",
+    century: 19,
+    slug: "the-deacons-masterpiece",
+    title: "The Deacon's Masterpiece",
+    published_year: 1858,
+    source_url: "https://en.wikisource.org/wiki/The_Deacon%27s_Masterpiece",
+    collection_title: "The Professor at the Breakfast-Table",
+    collection_source_url: "https://en.wikisource.org/wiki/The_Professor_at_the_Breakfast-Table",
+    page_title: "The Deacon's Masterpiece",
+    start_line: "Have you heard of the wonderful one-hoss shay,",
+    end_line: "Logic is logic. That's all I say.",
+  },
+  {
+    author: "Oliver Wendell Holmes, Sr.",
+    author_slug: "oliver-wendell-holmes-sr",
+    century: 19,
+    slug: "the-last-leaf",
+    title: "The Last Leaf",
+    published_year: 1831,
+    source_url: "https://en.wikisource.org/wiki/The_Last_Leaf_(Holmes)",
+    collection_title: "Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/The_Last_Leaf_(Holmes)",
+    page_title: "The Last Leaf (Holmes)",
+    start_line: "I saw him once before,",
+    end_line: "Where I cling.",
+  },
+];
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#8195;/g, "")
+    .replace(/&#91;/g, "[")
+    .replace(/&#93;/g, "]")
+    .replace(/&#95;/g, "_")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…");
+}
+
+function cleanRenderedText(html) {
+  let body = html.includes('<div class="prp-pages-output"')
+    ? html.slice(html.indexOf('<div class="prp-pages-output"'))
+    : html;
+  const referencesIndex = body.indexOf('<div class="mw-references-wrap');
+  if (referencesIndex !== -1) body = body.slice(0, referencesIndex);
+
+  body = body.replace(/<style[\s\S]*?<\/style>/g, "");
+  body = body.replace(/<link[^>]*>/g, "");
+  body = body.replace(/<sup[^>]*>.*?<\/sup>/gs, "");
+  body = body.replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+  body = body.replace(/<span[^>]*class="wst-gap[^"]*"[^>]*><\/span>/g, "    ");
+  body = body.replace(/<br\s*\/?>\n?/g, "\n");
+  body = body.replace(/<\/p>\s*<p>/g, "\n\n");
+  body = body.replace(/<[^>]+>/g, "");
+
+  return decodeHtml(body)
+    .replace(/\u00a0/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function extractPoem(text, startLine, endLine) {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  const start = lines.findIndex((line) => line.trim() === startLine);
+  if (start === -1) throw new Error(`Start line not found: ${startLine}`);
+
+  const end = lines.findIndex((line, index) => index >= start && line.trim() === endLine);
+  if (end === -1) throw new Error(`End line not found: ${endLine}`);
+
+  return lines
+    .slice(start, end + 1)
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchRenderedText(pageTitle) {
+  const url =
+    "https://en.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  const { stdout } = await execFileAsync("curl", ["-L", "--fail", "--silent", url], {
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  const json = JSON.parse(stdout);
+  if (!json.parse?.text) throw new Error(`Wikisource parse failed for ${pageTitle}`);
+  return cleanRenderedText(json.parse.text);
+}
+
+function buildMeta(poem) {
+  return yaml.dump(
+    {
+      id: `${poem.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: poem.author,
+      author_slug: poem.author_slug,
+      title: poem.title,
+      century: poem.century,
+      text_path: `poems/${poem.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: poem.source_url,
+      public_domain_rationale:
+        `Public domain in the United States: first published ${poem.published_year} ` +
+        `(pre-1929); text via English Wikisource.`,
+      collection_title: poem.collection_title,
+      collection_source_url: poem.collection_source_url,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  let created = 0;
+
+  for (const poem of POEMS) {
+    const poemsDir = path.join("poems", poem.author_slug);
+    const metaDir = path.join("meta", poem.author_slug);
+    await fs.mkdir(poemsDir, { recursive: true });
+    await fs.mkdir(metaDir, { recursive: true });
+
+    const rendered = await fetchRenderedText(poem.page_title);
+    const text = extractPoem(rendered, poem.start_line, poem.end_line);
+    const poemPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    let existed = true;
+    try {
+      await fs.access(poemPath);
+    } catch {
+      existed = false;
+    }
+
+    await fs.writeFile(poemPath, `${text}\n`, "utf8");
+    await fs.writeFile(metaPath, buildMeta(poem), "utf8");
+    created += 1;
+    console.log(`${poem.author}: ${existed ? "updated" : "created"} ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #100

## What changed
- add 4 American 19th-century poems for Ralph Waldo Emerson and Oliver Wendell Holmes Sr.
- add a source-specific Wikisource ingest script so the wave is reproducible

## Copyright guardrails
- approved source only: Wikisource
- no modern translations
- existing `the-last-leaf` was left unchanged after checking source differences
- each metadata sidecar states an explicit US public-domain basis

## Verification
- `cd site && npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four public domain poems to the collection: "The Deacon's Masterpiece" by Oliver Wendell Holmes Sr., and three works by Ralph Waldo Emerson—"Each and All," "Give All to Love," and "The Snow-Storm"—each with complete source attribution and provenance information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->