### PR TITLE
Prepare metadata for multilingual poems

### DIFF
--- a/docs/multilingual-poems.md
+++ b/docs/multilingual-poems.md
@@ -1,0 +1,78 @@
+# Multilingual Poems Groundwork
+
+This note defines the first safe step toward non-English poems in Freeverse.
+
+## Core distinction
+
+Do not treat UI language and poem language as the same thing.
+
+- `ui_locale`: the language of the surrounding site chrome
+- `text_locale`: the language of the poem text file itself
+
+An English UI should be able to render a French, Latin, or Greek poem without changing the poem's identity.
+
+## Metadata direction
+
+Poem sidecars may now carry:
+
+- `text_locale`: BCP 47 tag for the text in the repository file
+- `original_language`: BCP 47 tag for the work's original language
+- `text_direction`: `ltr` or `rtl`
+- `translator`: translator credit when the file is a translation
+- `translation_of`: canonical poem id for the source text, when applicable
+
+Defaults for the current English corpus:
+
+- `text_locale: en`
+- `original_language: en`
+- `text_direction: ltr`
+
+These defaults are injected by the poem-index build step so existing English sidecars do not need immediate bulk edits.
+
+## Route strategy
+
+Keep poem identity stable and UI routing separate.
+
+Recommended long-term shape:
+
+- English UI: `/poem/charles-baudelaire/correspondances/`
+- French UI: `/fr/poem/charles-baudelaire/correspondances/`
+
+That means the poem id should continue to describe the work, not the UI locale.
+
+## Rendering direction
+
+The site should keep English as the default UI for now.
+
+When a poem's `text_locale` differs from English, render the poem block itself with:
+
+- `lang={text_locale}`
+- `dir={text_direction}`
+
+This is enough for screen readers and browser text handling without committing to full UI localization yet.
+
+## Search implications
+
+Current search remains English-biased and should not be treated as multilingual-ready.
+
+Before ingesting substantial non-English corpus, search should be updated for:
+
+- Unicode-aware normalization and tokenization
+- locale-aware stop words
+- locale-aware stemming or no stemming where inappropriate
+
+## Conservative US copyright policy
+
+We are operating under US copyright constraints and should stay conservative.
+
+- Public-domain foreign-language originals may be ingested when the work is clearly public domain in the US.
+- Modern translations should be treated as in-copyright unless there is explicit evidence otherwise.
+- Prefer original-language texts over translations unless a translation's US public-domain basis is clear.
+- When a file is a translation, record both `translator` and `translation_of`.
+
+## Non-goals in this issue
+
+- No full localized UI launch
+- No locale-prefixed routes yet
+- No multilingual search rollout yet
+- No change to existing English URLs

--- a/meta/SCHEMA.md
+++ b/meta/SCHEMA.md
@@ -25,9 +25,19 @@ featured: false
 collection_title: "TBD"
 collection_source_url: "https://..."
 notes: "Any special formatting notes, alternate titles, etc."
+
+# Optional multilingual groundwork
+text_locale: "en"          # BCP 47 language tag for the text in this file
+original_language: "en"    # BCP 47 language tag for the work's original language
+text_direction: "ltr"      # "ltr" or "rtl"; defaults to "ltr"
+translator: "Translator"   # only when this file is a translation
+translation_of: "catullus/womans-faith-latin" # canonical poem id of the source text, if translated
 ```
 
 ## Notes
 - `id` is the canonical key.
 - If `text_in_repo` is `false`, omit `text_path`.
 - Keep `public_domain_rationale` short but explicit.
+- `text_locale` is the language of the text file itself, not the UI language.
+- `original_language` may differ from `text_locale` when the file is a translation.
+- Keep translation provenance conservative under US copyright law. A foreign-language original can be public domain while a modern translation is still in copyright.

--- a/site/scripts/build-poem-index.mjs
+++ b/site/scripts/build-poem-index.mjs
@@ -16,6 +16,9 @@ const REQUIRED_FIELDS = [
   "public_domain_rationale",
 ];
 
+const LOCALE_RE = /^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$/;
+const TEXT_DIRECTIONS = new Set(["ltr", "rtl"]);
+
 const repoRoot = path.resolve(process.cwd(), "..");
 const metaRoot = path.join(repoRoot, "meta");
 const outputPath = path.join(process.cwd(), "src", "data", "poem-index.json");
@@ -75,6 +78,24 @@ function rightsLooksValid(rationale) {
   return hasPd && hasBasis;
 }
 
+function localeLooksValid(value) {
+  return typeof value === "string" && LOCALE_RE.test(value);
+}
+
+function normalizeLocaleMetadata(meta) {
+  const text_locale = typeof meta.text_locale === "string" ? meta.text_locale : "en";
+  const original_language =
+    typeof meta.original_language === "string" ? meta.original_language : text_locale;
+  const text_direction = typeof meta.text_direction === "string" ? meta.text_direction : "ltr";
+
+  return {
+    ...meta,
+    text_locale,
+    original_language,
+    text_direction,
+  };
+}
+
 async function main() {
   const errors = [];
   const metas = [];
@@ -94,7 +115,7 @@ async function main() {
         continue;
       }
 
-      const meta = parsed;
+      const meta = normalizeLocaleMetadata(parsed);
       for (const field of REQUIRED_FIELDS) {
         if (!(field in meta)) errors.push(`${full}: missing required field '${field}'`);
       }
@@ -111,6 +132,21 @@ async function main() {
       }
       if (typeof meta.public_domain_rationale === "string" && !rightsLooksValid(meta.public_domain_rationale)) {
         errors.push(`${full}: public_domain_rationale must mention 'Public domain' and a year/basis`);
+      }
+      if (!localeLooksValid(meta.text_locale)) {
+        errors.push(`${full}: text_locale must be a valid BCP 47-style tag`);
+      }
+      if (!localeLooksValid(meta.original_language)) {
+        errors.push(`${full}: original_language must be a valid BCP 47-style tag`);
+      }
+      if (!TEXT_DIRECTIONS.has(meta.text_direction)) {
+        errors.push(`${full}: text_direction must be 'ltr' or 'rtl'`);
+      }
+      if (meta.translation_of && typeof meta.translation_of !== "string") {
+        errors.push(`${full}: translation_of must be a canonical poem id string when present`);
+      }
+      if (meta.translator && typeof meta.translator !== "string") {
+        errors.push(`${full}: translator must be a string when present`);
       }
 
       let text = "";

--- a/site/src/lib/poems.ts
+++ b/site/src/lib/poems.ts
@@ -9,11 +9,16 @@ export type PoemMeta = {
   author_slug: string;
   title: string;
   century: number;
+  text_locale: string;
+  original_language: string;
+  text_direction: 'ltr' | 'rtl';
   text_in_repo: boolean;
   text_path?: string;
   source_label?: string;
   source_url?: string;
   public_domain_rationale?: string;
+  translator?: string;
+  translation_of?: string;
   featured?: boolean;
   notes?: string;
 };

--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -78,7 +78,13 @@ const canonicalPath = `${base}poem/${poem.id}/`;
         <p id="poem-reader-instructions" class="sr-only">
           Use Tab to move through poem lines. Press Enter or Space to select a line. Hold Shift while selecting a second line to create a shared range.
         </p>
-        <ol class="poem-lines" aria-label="Poem" aria-describedby="poem-reader-instructions">
+        <ol
+          class="poem-lines"
+          aria-label="Poem"
+          aria-describedby="poem-reader-instructions"
+          lang={poem.text_locale}
+          dir={poem.text_direction}
+        >
         {lines.map((line, idx) => {
           const n = idx + 1;
           const id = `l${n}`;
@@ -97,6 +103,13 @@ const canonicalPath = `${base}poem/${poem.id}/`;
           );
         })}
         </ol>
+        {poem.text_locale !== "en" || poem.original_language !== "en" || poem.translator ? (
+          <p class="muted" style="margin: 0.9rem 0 0;">
+            Text language: <strong>{poem.text_locale}</strong>
+            {poem.original_language !== poem.text_locale ? ` · Original language: ${poem.original_language}` : ""}
+            {poem.translator ? ` · Translator: ${poem.translator}` : ""}
+          </p>
+        ) : null}
       </>
     ) : (
       <div class="card">


### PR DESCRIPTION
Closes #119

## What changed
- add multilingual poem metadata support to the schema and generated poem index
- default the current corpus to `text_locale: en`, `original_language: en`, `text_direction: ltr`
- validate locale metadata during index generation
- render poem text with `lang` and `dir` from poem metadata
- add a design note covering route strategy, UI-locale vs text-locale separation, search implications, and conservative US copyright handling

## Copyright handling
- keeps existing approved sources unchanged
- explicitly distinguishes foreign-language originals from potentially in-copyright modern translations
- introduces `translator` and `translation_of` metadata for future translation provenance

## Verification
- `cd site && npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Poems now support multiple languages with proper text rendering attributes (language and text direction)
  * Display original language and translator metadata for translated poems

* **Documentation**
  * Added comprehensive multilingual support documentation with locale strategy and current limitations
  * Updated schema to include multilingual metadata fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->