### PR TITLE
Add romance-language corpus

### DIFF
--- a/meta/gustavo-adolfo-becquer/rima-001.yml
+++ b/meta/gustavo-adolfo-becquer/rima-001.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-001
+slug: rima-001
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima I
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-001.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_1
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-002.yml
+++ b/meta/gustavo-adolfo-becquer/rima-002.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-002
+slug: rima-002
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima II
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-002.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_2
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-003.yml
+++ b/meta/gustavo-adolfo-becquer/rima-003.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-003
+slug: rima-003
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima III
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-003.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_3
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-004.yml
+++ b/meta/gustavo-adolfo-becquer/rima-004.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-004
+slug: rima-004
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima IV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-004.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_4
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-005.yml
+++ b/meta/gustavo-adolfo-becquer/rima-005.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-005
+slug: rima-005
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima V
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-005.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_5
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-006.yml
+++ b/meta/gustavo-adolfo-becquer/rima-006.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-006
+slug: rima-006
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima VI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-006.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_6
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-007.yml
+++ b/meta/gustavo-adolfo-becquer/rima-007.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-007
+slug: rima-007
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima VII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-007.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_7
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-008.yml
+++ b/meta/gustavo-adolfo-becquer/rima-008.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-008
+slug: rima-008
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima VIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-008.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_8
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-009.yml
+++ b/meta/gustavo-adolfo-becquer/rima-009.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-009
+slug: rima-009
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima IX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-009.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_9
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-010.yml
+++ b/meta/gustavo-adolfo-becquer/rima-010.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-010
+slug: rima-010
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima X
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-010.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_10
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-011.yml
+++ b/meta/gustavo-adolfo-becquer/rima-011.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-011
+slug: rima-011
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-011.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_11
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-012.yml
+++ b/meta/gustavo-adolfo-becquer/rima-012.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-012
+slug: rima-012
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-012.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_12
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-013.yml
+++ b/meta/gustavo-adolfo-becquer/rima-013.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-013
+slug: rima-013
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-013.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_13
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-014.yml
+++ b/meta/gustavo-adolfo-becquer/rima-014.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-014
+slug: rima-014
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XIV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-014.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_14
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-015.yml
+++ b/meta/gustavo-adolfo-becquer/rima-015.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-015
+slug: rima-015
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-015.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_15
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-016.yml
+++ b/meta/gustavo-adolfo-becquer/rima-016.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-016
+slug: rima-016
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XVI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-016.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_16
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-017.yml
+++ b/meta/gustavo-adolfo-becquer/rima-017.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-017
+slug: rima-017
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XVII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-017.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_17
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-018.yml
+++ b/meta/gustavo-adolfo-becquer/rima-018.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-018
+slug: rima-018
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XVIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-018.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_18
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-019.yml
+++ b/meta/gustavo-adolfo-becquer/rima-019.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-019
+slug: rima-019
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XIX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-019.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_19
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-020.yml
+++ b/meta/gustavo-adolfo-becquer/rima-020.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-020
+slug: rima-020
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-020.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_20
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-021.yml
+++ b/meta/gustavo-adolfo-becquer/rima-021.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-021
+slug: rima-021
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-021.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_21
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-022.yml
+++ b/meta/gustavo-adolfo-becquer/rima-022.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-022
+slug: rima-022
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-022.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_22
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-023.yml
+++ b/meta/gustavo-adolfo-becquer/rima-023.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-023
+slug: rima-023
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-023.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_23
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-024.yml
+++ b/meta/gustavo-adolfo-becquer/rima-024.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-024
+slug: rima-024
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXIV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-024.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_24
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-025.yml
+++ b/meta/gustavo-adolfo-becquer/rima-025.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-025
+slug: rima-025
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-025.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_25
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-026.yml
+++ b/meta/gustavo-adolfo-becquer/rima-026.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-026
+slug: rima-026
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXVI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-026.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_26
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-027.yml
+++ b/meta/gustavo-adolfo-becquer/rima-027.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-027
+slug: rima-027
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXVII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-027.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_27
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-028.yml
+++ b/meta/gustavo-adolfo-becquer/rima-028.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-028
+slug: rima-028
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXVIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-028.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_28
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-029.yml
+++ b/meta/gustavo-adolfo-becquer/rima-029.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-029
+slug: rima-029
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXIX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-029.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_29
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-030.yml
+++ b/meta/gustavo-adolfo-becquer/rima-030.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-030
+slug: rima-030
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-030.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_30
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-031.yml
+++ b/meta/gustavo-adolfo-becquer/rima-031.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-031
+slug: rima-031
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-031.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_31
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-032.yml
+++ b/meta/gustavo-adolfo-becquer/rima-032.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-032
+slug: rima-032
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-032.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_32
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-033.yml
+++ b/meta/gustavo-adolfo-becquer/rima-033.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-033
+slug: rima-033
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-033.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_33
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-034.yml
+++ b/meta/gustavo-adolfo-becquer/rima-034.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-034
+slug: rima-034
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXIV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-034.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_34
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-035.yml
+++ b/meta/gustavo-adolfo-becquer/rima-035.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-035
+slug: rima-035
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-035.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_35
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-036.yml
+++ b/meta/gustavo-adolfo-becquer/rima-036.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-036
+slug: rima-036
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXVI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-036.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_36
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-037.yml
+++ b/meta/gustavo-adolfo-becquer/rima-037.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-037
+slug: rima-037
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXVII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-037.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_37
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-038.yml
+++ b/meta/gustavo-adolfo-becquer/rima-038.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-038
+slug: rima-038
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXVIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-038.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_38
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-039.yml
+++ b/meta/gustavo-adolfo-becquer/rima-039.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-039
+slug: rima-039
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XXXIX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-039.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_39
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-040.yml
+++ b/meta/gustavo-adolfo-becquer/rima-040.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-040
+slug: rima-040
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XL
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-040.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_40
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-041.yml
+++ b/meta/gustavo-adolfo-becquer/rima-041.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-041
+slug: rima-041
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-041.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_41
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-042.yml
+++ b/meta/gustavo-adolfo-becquer/rima-042.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-042
+slug: rima-042
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-042.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_42
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-043.yml
+++ b/meta/gustavo-adolfo-becquer/rima-043.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-043
+slug: rima-043
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-043.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_43
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-044.yml
+++ b/meta/gustavo-adolfo-becquer/rima-044.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-044
+slug: rima-044
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLIV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-044.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_44
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-045.yml
+++ b/meta/gustavo-adolfo-becquer/rima-045.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-045
+slug: rima-045
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-045.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_45
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-046.yml
+++ b/meta/gustavo-adolfo-becquer/rima-046.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-046
+slug: rima-046
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLVI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-046.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_46
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-047.yml
+++ b/meta/gustavo-adolfo-becquer/rima-047.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-047
+slug: rima-047
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLVII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-047.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_47
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-048.yml
+++ b/meta/gustavo-adolfo-becquer/rima-048.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-048
+slug: rima-048
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLVIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-048.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_48
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-049.yml
+++ b/meta/gustavo-adolfo-becquer/rima-049.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-049
+slug: rima-049
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima XLIX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-049.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_49
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-050.yml
+++ b/meta/gustavo-adolfo-becquer/rima-050.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-050
+slug: rima-050
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima L
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-050.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_50
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-051.yml
+++ b/meta/gustavo-adolfo-becquer/rima-051.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-051
+slug: rima-051
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-051.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_51
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-052.yml
+++ b/meta/gustavo-adolfo-becquer/rima-052.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-052
+slug: rima-052
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-052.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_52
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-053.yml
+++ b/meta/gustavo-adolfo-becquer/rima-053.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-053
+slug: rima-053
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-053.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_53
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-054.yml
+++ b/meta/gustavo-adolfo-becquer/rima-054.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-054
+slug: rima-054
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LIV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-054.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_54
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-055.yml
+++ b/meta/gustavo-adolfo-becquer/rima-055.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-055
+slug: rima-055
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-055.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_55
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-056.yml
+++ b/meta/gustavo-adolfo-becquer/rima-056.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-056
+slug: rima-056
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LVI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-056.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_56
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-057.yml
+++ b/meta/gustavo-adolfo-becquer/rima-057.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-057
+slug: rima-057
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LVII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-057.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_57
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-058.yml
+++ b/meta/gustavo-adolfo-becquer/rima-058.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-058
+slug: rima-058
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LVIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-058.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_58
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-059.yml
+++ b/meta/gustavo-adolfo-becquer/rima-059.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-059
+slug: rima-059
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LIX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-059.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_59
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-060.yml
+++ b/meta/gustavo-adolfo-becquer/rima-060.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-060
+slug: rima-060
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-060.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_60
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-061.yml
+++ b/meta/gustavo-adolfo-becquer/rima-061.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-061
+slug: rima-061
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-061.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_61
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-062.yml
+++ b/meta/gustavo-adolfo-becquer/rima-062.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-062
+slug: rima-062
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-062.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_62
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-063.yml
+++ b/meta/gustavo-adolfo-becquer/rima-063.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-063
+slug: rima-063
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-063.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_63
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-064.yml
+++ b/meta/gustavo-adolfo-becquer/rima-064.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-064
+slug: rima-064
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXIV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-064.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_64
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-065.yml
+++ b/meta/gustavo-adolfo-becquer/rima-065.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-065
+slug: rima-065
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-065.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_65
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-066.yml
+++ b/meta/gustavo-adolfo-becquer/rima-066.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-066
+slug: rima-066
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXVI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-066.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_66
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-067.yml
+++ b/meta/gustavo-adolfo-becquer/rima-067.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-067
+slug: rima-067
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXVII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-067.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_67
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-068.yml
+++ b/meta/gustavo-adolfo-becquer/rima-068.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-068
+slug: rima-068
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXVIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-068.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_68
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-069.yml
+++ b/meta/gustavo-adolfo-becquer/rima-069.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-069
+slug: rima-069
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXIX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-069.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_69
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-070.yml
+++ b/meta/gustavo-adolfo-becquer/rima-070.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-070
+slug: rima-070
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXX
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-070.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_70
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-071.yml
+++ b/meta/gustavo-adolfo-becquer/rima-071.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-071
+slug: rima-071
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXXI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-071.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_71
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-072.yml
+++ b/meta/gustavo-adolfo-becquer/rima-072.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-072
+slug: rima-072
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXXII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-072.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_72
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-073.yml
+++ b/meta/gustavo-adolfo-becquer/rima-073.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-073
+slug: rima-073
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXXIII
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-073.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_73
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-074.yml
+++ b/meta/gustavo-adolfo-becquer/rima-074.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-074
+slug: rima-074
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXXIV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-074.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_74
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-075.yml
+++ b/meta/gustavo-adolfo-becquer/rima-075.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-075
+slug: rima-075
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXXV
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-075.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_75
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/gustavo-adolfo-becquer/rima-076.yml
+++ b/meta/gustavo-adolfo-becquer/rima-076.yml
@@ -1,0 +1,16 @@
+id: gustavo-adolfo-becquer/rima-076
+slug: rima-076
+author: Gustavo Adolfo Bécquer
+author_slug: gustavo-adolfo-becquer
+title: Rima LXXVI
+century: 19
+text_locale: es
+original_language: es
+text_direction: ltr
+text_path: poems/gustavo-adolfo-becquer/rima-076.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_76
+public_domain_rationale: 'Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.'
+collection_title: Rimas (1925)
+collection_source_url: https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)

--- a/meta/louise-labe/elegie-01.yml
+++ b/meta/louise-labe/elegie-01.yml
@@ -1,0 +1,16 @@
+id: louise-labe/elegie-01
+slug: elegie-01
+author: Louise Labé
+author_slug: louise-labe
+title: Élégie I
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/elegie-01.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/elegie-02.yml
+++ b/meta/louise-labe/elegie-02.yml
@@ -1,0 +1,16 @@
+id: louise-labe/elegie-02
+slug: elegie-02
+author: Louise Labé
+author_slug: louise-labe
+title: Élégie II
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/elegie-02.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/elegie-03.yml
+++ b/meta/louise-labe/elegie-03.yml
@@ -1,0 +1,16 @@
+id: louise-labe/elegie-03
+slug: elegie-03
+author: Louise Labé
+author_slug: louise-labe
+title: Élégie III
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/elegie-03.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-01.yml
+++ b/meta/louise-labe/sonnet-01.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-01
+slug: sonnet-01
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet I
+century: 16
+text_locale: it
+original_language: it
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-01.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-02.yml
+++ b/meta/louise-labe/sonnet-02.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-02
+slug: sonnet-02
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet II
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-02.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-03.yml
+++ b/meta/louise-labe/sonnet-03.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-03
+slug: sonnet-03
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet III
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-03.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-04.yml
+++ b/meta/louise-labe/sonnet-04.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-04
+slug: sonnet-04
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet IV
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-04.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-05.yml
+++ b/meta/louise-labe/sonnet-05.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-05
+slug: sonnet-05
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet V
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-05.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-06.yml
+++ b/meta/louise-labe/sonnet-06.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-06
+slug: sonnet-06
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet VI
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-06.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-07.yml
+++ b/meta/louise-labe/sonnet-07.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-07
+slug: sonnet-07
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet VII
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-07.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-08.yml
+++ b/meta/louise-labe/sonnet-08.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-08
+slug: sonnet-08
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet VIII
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-08.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-09.yml
+++ b/meta/louise-labe/sonnet-09.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-09
+slug: sonnet-09
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet IX
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-09.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-10.yml
+++ b/meta/louise-labe/sonnet-10.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-10
+slug: sonnet-10
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet X
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-10.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-11.yml
+++ b/meta/louise-labe/sonnet-11.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-11
+slug: sonnet-11
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XI
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-11.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-12.yml
+++ b/meta/louise-labe/sonnet-12.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-12
+slug: sonnet-12
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XII
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-12.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-13.yml
+++ b/meta/louise-labe/sonnet-13.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-13
+slug: sonnet-13
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XIII
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-13.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-14.yml
+++ b/meta/louise-labe/sonnet-14.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-14
+slug: sonnet-14
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XIV
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-14.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-15.yml
+++ b/meta/louise-labe/sonnet-15.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-15
+slug: sonnet-15
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XV
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-15.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-16.yml
+++ b/meta/louise-labe/sonnet-16.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-16
+slug: sonnet-16
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XVI
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-16.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-17.yml
+++ b/meta/louise-labe/sonnet-17.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-17
+slug: sonnet-17
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XVII
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-17.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-18.yml
+++ b/meta/louise-labe/sonnet-18.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-18
+slug: sonnet-18
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XVIII
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-18.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-19.yml
+++ b/meta/louise-labe/sonnet-19.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-19
+slug: sonnet-19
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XIX
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-19.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-20.yml
+++ b/meta/louise-labe/sonnet-20.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-20
+slug: sonnet-20
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XX
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-20.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-21.yml
+++ b/meta/louise-labe/sonnet-21.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-21
+slug: sonnet-21
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XXI
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-21.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-22.yml
+++ b/meta/louise-labe/sonnet-22.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-22
+slug: sonnet-22
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XXII
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-22.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-23.yml
+++ b/meta/louise-labe/sonnet-23.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-23
+slug: sonnet-23
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XXIII
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-23.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/meta/louise-labe/sonnet-24.yml
+++ b/meta/louise-labe/sonnet-24.yml
@@ -1,0 +1,16 @@
+id: louise-labe/sonnet-24
+slug: sonnet-24
+author: Louise Labé
+author_slug: louise-labe
+title: Sonnet XXIV
+century: 16
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/louise-labe/sonnet-24.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets
+public_domain_rationale: 'Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.'
+collection_title: Élégies et Sonnets
+collection_source_url: https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets

--- a/poems/gustavo-adolfo-becquer/rima-001.txt
+++ b/poems/gustavo-adolfo-becquer/rima-001.txt
@@ -1,0 +1,12 @@
+Yo sé un himno gigante y extraño
+Que anuncia en la noche del alma una aurora,
+Y estas páginas son de ese himno
+Calencias que el aire dilata en las sombras.
+Yo quisiera escribirle, del hombre
+Domando el rebelde, mezquino idioma,
+Con palabras que fuesen a un tiempo
+Suspiros y risas, colores y notas.
+Pero en vano es luchar; que no hay cifra
+Capaz de encerrarlo, y apenas joh hermosa!
+Si, temendo en mis manos las tuyas,
+Pudiera, al oído, cantártelo a solas.

--- a/poems/gustavo-adolfo-becquer/rima-002.txt
+++ b/poems/gustavo-adolfo-becquer/rima-002.txt
@@ -1,0 +1,20 @@
+Saeta que voladora
+Cruza, arrojada al azar,
+Sin adivinarse dónde
+Temblando se clavará;
+Hoja que del árbol seca
+Arrebata el vendaval,
+Sin que nadie acierte el surco
+Donde a caer volverá;
+Gigante ola que el viento
+Riza y empuja en el mar,
+Y rueda y pasa, y no sabe
+Qué playa buscando va;
+Luz que en cercos temblorosos
+Brilla, próxima a expirar,
+Ignorándose cuál de ellos
+El último brillará;
+Eso soy yo, que al acaso
+Cruzo el mundo, sin pensar
+De dónde vengo, ni adóndé
+Mis pasos me llevarán.

--- a/poems/gustavo-adolfo-becquer/rima-003.txt
+++ b/poems/gustavo-adolfo-becquer/rima-003.txt
@@ -1,0 +1,70 @@
+Sacudimiento extraño
+Que agita las ideas,
+Como huracán que empuja
+Las elas en tropel;
+Murmullo que en el alma
+Se eleva y va creciendo,
+Como volcán que sordo
+Anuncia que va a arder;
+Deformes siluetas
+De seres imposibles;
+Paisajes que aparecen
+Como a través de un tul;
+Colores que fundiéndose
+Remedan en el aire
+Los átomos del iris,
+Que nadan en la luz;
+Ideas sin palabras,
+Palabras sin sentido;
+Cadencias que no tienen
+Ni ritmo ni compás;
+Memorias y deseos
+De cosas que no existen;
+Accesos de alegría,
+Impulsos de llorar;
+Actividad nerviosa
+Que no halla en qué emplearse;
+Sin rienda que le guíe
+Caballo volador;
+Locura que el espíritu
+Exalta y enardece;
+Embriaguez divina
+Del genio creador...
+¡Tal es la inspiración!
+Gigante voz que el caos
+Ordena en el cerebro,
+Y entre las sombras hace
+La luz aparecer;
+Brillante rienda de oro
+Que poderosa enfrena
+De la exaltada mente
+El volador corcel;
+Hilo de luz que en haces
+Los pensamientos ata;
+Sol que las nubes rompe
+Y toca en el cenit;
+Inteligente mano
+Que en un collar de perlas
+Consigue las indóciles
+Palabras reunir;
+Armonioso ritmo
+Que con cadencia y número
+Las fugitivas notas
+Encierra en el compás;
+Cincel que el bloque muerde
+La estatua modelando,
+Y la belleza plástica.
+Añade a la ideal;
+Atmósfera en que giran
+Con orden las ideas,
+Cual átomos que agrupa
+Recóndita atracción;
+Raudal en cuyas ondas
+Su sed la fiebre apaga;
+Oasis que al espíritu
+Devuelve su vigor...
+¡Tal es nuestra razón!
+Con ambas siempre en lucha
+Y de ambas vencedor,
+Tan sólo el genio puede
+A un yugo atar las dos.

--- a/poems/gustavo-adolfo-becquer/rima-004.txt
+++ b/poems/gustavo-adolfo-becquer/rima-004.txt
@@ -1,0 +1,36 @@
+No digáis que agotado su tesoro,
+De asuntos falta, enmudeció la lira;
+Podrá no haber poetas; pero siempre
+Habrá poesía.
+Mientras las ondas de la luz al beso
+Palpiten encendidas;
+Mientras el sol las desgarradas nubes
+De fuego y oro vista;
+Mientras el aire en su regazo lleve
+Perfumes y armonías;
+Mientras haya en el mundo primavera,
+¡Habrá poesía!
+Mientras la ciencia a descubrir no alcance
+Las fuentes de la vida,
+Y en el mar o en el cielo haya un abismo
+Que al cálculo resista;
+Mientras la humanidad siempre avanzando
+No sepa a dó camina;
+Mientras haya un misterio para el hombre,
+¡Habrá poesía!
+Mientras sintamos que se alegra el alma,
+Sin que los labios rían;
+Mientras se llore, sin que el llanto acuda
+A nublar la pupila;
+Mientras el corazón y la cabeza
+Batallando prosigan;
+Mientras haya esperanzas y recuerdos,
+¡Habrá poesía!
+Mientras haya unos ojos que reflejen
+Los ojos que los miran;
+Mientras responda el labio suspirando
+Al labio que suspira;
+Mientras sentirse puedan en un beso
+Dos almas confundidas;
+Mientras exista una mujer hermosa,
+¡Habrá poesía!

--- a/poems/gustavo-adolfo-becquer/rima-005.txt
+++ b/poems/gustavo-adolfo-becquer/rima-005.txt
@@ -1,0 +1,76 @@
+Espíritu sin nombre,
+Indefinible esencia,
+Yo vivo con la vida
+Sin formas de la idea.
+Yo nado en el vacío,
+Del sol tiemblo en la hoguera,
+Palpito entre las sombras
+Y floto con las nieblas.
+Yo soy el fleco de oro
+De la lejana estrella;
+Yo soy de la alta luna
+La luz tibia y serena.
+Yo soy la ardiente nube
+Que en el ocaso ondea;
+Yo soy del astro errante
+La luminosa estela.
+Yo soy nieve en las cumbres,
+Soy fuego en las arenas,
+Azul onda en los mares,
+Y espuma en las riberas.
+En el laúd soy nota,
+Perfume en la violeta,
+Fugaz llama en las tumbas
+Y en las ruinas hiedra.
+Yo atrueno en el torrente,
+Y silbo en la centella,
+Y ciego en el relámpago,
+Y rujo en la tormenta.
+Yo río en los alcores,
+Susurro en la alta verba,
+Suspiro en la onda pura,
+Y lloro en la hoja seca.
+Yo ondulo con los átomos
+Del humo que se eleva,
+Y al cielo lento sube
+En espiral inmensa.
+Yo, en los dorados hilos
+Que los insectos cuelgan,
+Me mezco entre los árboles,
+En la ardorosa siesta.
+Yo corro tras las ninfas
+Que en la corriente fresca
+Del cristalino arroyo
+Desnudas juguetean.
+Yo, en bosques de corales,
+Que alfombran blancas perlas,
+Persigo en el océano
+Las náyades ligeras.
+Yo, en las cavernas cóncavas,
+Do el sol nunca penetra,
+Mezelándome a los gnomos,
+Contemplo sus riquezas.
+Yo busco de los siglos
+Las ya borradas huellas,
+Y sé de esos imperios
+De que ni el nombre queda.
+Yo sigo en raudo vértigo
+Los mundos que voltean,
+Y mi pupila abarca
+La creación entera.
+Yo sé de esas regiones
+A do un rumor no llega,
+Y donde informes astros
+De vida un soplo esperan.
+Yo soy sobre el abismo
+El puente que atraviesa;
+Yo soy la ignota escala
+Que el cielo une a la tierra.
+Yo soy el invisible
+Anillo que sujeta
+El mundo de la forma
+Al mundo de la idea.
+Yo, en fin, soy ese espíritu,
+Desconocida esencia,
+Perfume misterioso,
+De que es vaso el poeta.

--- a/poems/gustavo-adolfo-becquer/rima-006.txt
+++ b/poems/gustavo-adolfo-becquer/rima-006.txt
@@ -1,0 +1,8 @@
+Como la brisa que la sangre orea
+Sobre el oscuro campo de batalla,
+Cargada de perfumes y armonías
+En el silencio de la noche vaga;
+Símbolo del dolor y la ternura,
+Del bardo inglés en el horrible drama,
+La dulce Ofelia, la razón perdida,
+Cogiendo flores y cantando pasa.

--- a/poems/gustavo-adolfo-becquer/rima-007.txt
+++ b/poems/gustavo-adolfo-becquer/rima-007.txt
@@ -1,0 +1,12 @@
+Del salón en el ángulo oscuro,
+De su dueño tal vez olvidada,
+Silenciosa y cubierta de polvo
+Veíase el arpa.
+¡Cuánta nota dormía en sus cuerdas,
+Como el pájaro duerme en las ramas,
+Esperando la mano de nieve
+Que sabe arrancarla!
+¡Ay! pensé, ¡cuántas veces el genio
+Así duerme en el fondo del alma,
+Y una voz, como Lázaro, espera
+Que le diga: "¡Levántate y anda!"

--- a/poems/gustavo-adolfo-becquer/rima-008.txt
+++ b/poems/gustavo-adolfo-becquer/rima-008.txt
@@ -1,0 +1,23 @@
+Cuando miro el azul horizonte
+Perderse a lo lejos,
+Al través de una gasa de polvo
+Dorado e inquieto;
+Me parece posible arrancarme
+Del mísero suelo,
+Y flotar con la niebla dorada
+En átomos leves
+Cual ella deshecho.
+Cuando miro de noche en el fondo
+Oscuro del cielo
+Las estrellas temblar, como ardientes
+Pupilas de fuego;
+Me parece posible a do brillan
+Subir en un vuelo,
+Y anegarme en su luz, y con ellas
+En lumbre encendido
+Fundirme en un beso.
+En el mar de la duda en que bogo
+Ni aún sé lo que creo;
+Sin embargo, estas ansias me dicen
+Que yo llevo algo
+Divino aquí dentro!...

--- a/poems/gustavo-adolfo-becquer/rima-009.txt
+++ b/poems/gustavo-adolfo-becquer/rima-009.txt
@@ -1,0 +1,8 @@
+Besa el aura que gime blandamente
+Las leves ondas que jugando riza;
+El sol besa a la nube en Occidente,
+Y de púrpura y oro la matiza;
+La llama en derredor del tronco ardiente
+Por besar a otra llama se desliza,
+Y hasta el sauce, inclinándose a su peso,
+Al río que le besa, vuelve un beso.

--- a/poems/gustavo-adolfo-becquer/rima-010.txt
+++ b/poems/gustavo-adolfo-becquer/rima-010.txt
@@ -1,0 +1,8 @@
+Los invisibles átomos del aire
+En derredor palpitan y se inflaman;
+El ciclo se deshace en rayos de oro;
+La tierra se estremece alborozada;
+Oigo flotando en olas de armonía
+Rumor de besos y batir de alas;
+Mis párpados se cierran... ¿Qué sucede
+—¡Es el amor que pasa!

--- a/poems/gustavo-adolfo-becquer/rima-011.txt
+++ b/poems/gustavo-adolfo-becquer/rima-011.txt
@@ -1,0 +1,12 @@
+Yo soy ardiente, yo soy morena,
+Yo soy el símbolo de la pasión;
+De ansia de goces mi alma está llena.
+—A mí me buscas?—No es a ti; no.
+—Mi frente es pálida, mis trenzas de oro;
+Puedo brindarte dichas sin fin;
+Yo de ternura guardo un tesoro.
+¿A mí me llamas?—No; no es a ti.
+—Yo soy un sueño, un imposible,
+Vano fantasma de niebla y luz;
+Soy incorpórea, soy intangible;
+No puedo amarte.—Oh, ven; ven tú!

--- a/poems/gustavo-adolfo-becquer/rima-012.txt
+++ b/poems/gustavo-adolfo-becquer/rima-012.txt
@@ -1,0 +1,53 @@
+Porque son, niña, tus ojos
+Verdes como el mar, te quejas,
+Verdes los tienen las náyades,
+Verdes los tuvo Minerva,
+Y verdes son las pupilas
+De las hurís del Profeta.
+El verde es gala y ornato
+Del bosque en la primavera.
+Entre sus siete colores
+Brillante el iris lo ostenta.
+Las esmeraldas son verdes,
+Verde el color del que espera,
+Y las ondas del océano,
+Y el laurel de los poetas.
+Es tu mejilla temprana
+Rosa de escarcha cubierta,
+En que el carmín de los pétalos
+Se ve al través de las perlas.
+Y sin embargo,
+Sé que te quejas,
+Porque tus ojos
+Crees que la afean:
+Pues no lo creas;
+Que parecen tus pupilas,
+Húmedas, verdes e inquietas,
+Tempranas hojas de almendro,
+Que al soplo del aire tiemblan.
+Es tu boca de rubíes
+Purpúrea granada abierta,
+Que en el estío convida
+A apagar la sed en ella.
+Y sin embargo,
+Sé que te quejas,
+Porque tus ojos
+Crees que la afean:
+Pues no lo creas;
+Que parecen, si enojada,
+Tus pupilas centellean,
+Las olas del mar que rompen
+En las cantábricas peñas.
+Es tu frente que corona
+Crespo el oro en ancha trenza,
+Nevada cumbre en que el día
+Su postrera luz refleja.
+Y sin embargo,
+Sé que te quejas,
+Porque tus ojos
+Crees que la afean:
+Pues no lo creas;
+Que, entre las rubias pestañas,
+Junto a las sienes, semejan
+Broches de esmeralda y oro,
+Que un blanco armiño sujetan.

--- a/poems/gustavo-adolfo-becquer/rima-013.txt
+++ b/poems/gustavo-adolfo-becquer/rima-013.txt
@@ -1,0 +1,12 @@
+Tu pupila es azul, y cuando ríes,
+Su claridad suave me recuerda
+El trémulo fulgor de la mañana
+Que en el mar se refleja.
+Tu pupila es azul, y cuando lloras,
+Las trasparentes lágrimas en ella
+Se me figuran gotas de rocío
+Sobre una violeta.
+Tu pupila es azul, y si en su fondo
+Como un punto de luz radia una idea,
+Me parece en el cielo de la tarde
+¡Una perdida estrella!

--- a/poems/gustavo-adolfo-becquer/rima-014.txt
+++ b/poems/gustavo-adolfo-becquer/rima-014.txt
@@ -1,0 +1,16 @@
+Te vi un punto, y, flotando ante mis ojos,
+La imagen de tus ojos se quedó,
+Como la mancha oscura, orlada en fuego,
+Que flota y ciega, si se mira al sol.
+A donde quiera que la vista fijo,
+Torno a ver tus pupilas llamear;
+Mas no te encuentro a ti; que es tu mirada:
+Unos ojos, los tuyos, nada más.
+De mi alcoba en el ángulo los miro
+Desasidos, fantásticos lucir;
+Cuando duermo, los siento que se eiernen
+De par en par abiertos sobre mí.
+Yo sé que hay fuegos fatuos que en la noche
+Llevan al caminante a perecer:
+Yo me siento arrastrado por tus ojos,
+Pero adónde me arrastran, no lo sé.

--- a/poems/gustavo-adolfo-becquer/rima-015.txt
+++ b/poems/gustavo-adolfo-becquer/rima-015.txt
@@ -1,0 +1,22 @@
+Cendal flotante de leve bruma,
+Rizada cinta de blanca espuma,
+Rumor sonoro
+De arpa de oro,
+Beso del aura, onda de luz:
+Eso eres tú.
+Tú, sombra aérea, que cuantas veces
+Voy a tocarte, te desvaneces
+Como la llama, como el sonido,
+Como la niebla, como el gemido
+Del lago azul.
+En mar sin playas onda sonante,
+En el vacío cometa errante,
+Largo lamento
+Del ronco viento,
+Ansia perpetua de algo mejor:
+Eso soy yo.
+¡Yo, que a tus ojos en mi agonía
+Los ojos vuelvo de noche y día;
+Yo, que incansable corro y demente
+Tras una sombra, tras la hija ardiente
+De una visión!

--- a/poems/gustavo-adolfo-becquer/rima-016.txt
+++ b/poems/gustavo-adolfo-becquer/rima-016.txt
@@ -1,0 +1,18 @@
+Si al mecer las azules campanillas
+De tu balcón,
+Crees que suspirando pasa el viento
+Murmurador,
+Sabe que, oculto entre las verdes hojas,
+Suspiro yo.
+Si al resonar confuso a tus espaldas
+Vago rumor,
+Crees que por tu nombre te ha llamado
+Lejana voz,
+Sabe que, entre las sombras que te cercan,
+Te llamo yo.
+Si se turba medroso en la alta noche
+Tu corazón,
+Al sentir en tus labios un aliento
+Abrasador,
+Sabe que, aunque invisible, al lado tuyo
+Respiro yo.

--- a/poems/gustavo-adolfo-becquer/rima-017.txt
+++ b/poems/gustavo-adolfo-becquer/rima-017.txt
@@ -1,0 +1,4 @@
+Hoy la tierra y los cielos me sonríen;
+Hoy llega al fondo de mi alma el sol;
+Hoy la he visto... la he visto y me lia mirado...
+¡Hoy creo en Dios!

--- a/poems/gustavo-adolfo-becquer/rima-018.txt
+++ b/poems/gustavo-adolfo-becquer/rima-018.txt
@@ -1,0 +1,16 @@
+Fatigada del baile,
+Encendido el color, breve el aliento,
+Apoyada en mi brazo,
+Del salón se detuvo en un extremo.
+Entre la leve gasa
+Que levantaba el palpitante seno,
+Una flor se mecía
+En compasado y dulce movimiento.
+Como en cuna de nácar
+Que empuja el mar y que acaricia el céfiro,
+Tal vez allí dormía
+Al soplo de sus labios entreabiertos.
+—Oh! ¿Quién así, — pensaba, —
+Dejar pudiera deslizarse el tiempo?
+¡Oh, si las flores duermen,
+Qué dulcísimo sueño!

--- a/poems/gustavo-adolfo-becquer/rima-019.txt
+++ b/poems/gustavo-adolfo-becquer/rima-019.txt
@@ -1,0 +1,8 @@
+Cuando sobre el pecho inclines
+La melancólica frente,
+Una azucena tronchada
+Me pareces.
+Porque al darte la pureza,
+De que es símbolo celeste,
+Como a ella, te hizo Dios
+De oro y nieve.

--- a/poems/gustavo-adolfo-becquer/rima-020.txt
+++ b/poems/gustavo-adolfo-becquer/rima-020.txt
@@ -1,0 +1,4 @@
+Sabe, si alguna vez tus labios rojos
+Quema invisible atmósfera abrasada,
+Que el alma que hablar puede con los ojos,
+También puede besar con la mirada.

--- a/poems/gustavo-adolfo-becquer/rima-021.txt
+++ b/poems/gustavo-adolfo-becquer/rima-021.txt
@@ -1,0 +1,4 @@
+¡Qué es poesía? dices mientras clavas
+En mi pupila tu pupila azul;
+¿Qué es poesía? Y tú me lo preguntas?
+¡Poesía... eres tú!

--- a/poems/gustavo-adolfo-becquer/rima-022.txt
+++ b/poems/gustavo-adolfo-becquer/rima-022.txt
@@ -1,0 +1,4 @@
+¡Cómo vive esa rosa que has prendido
+Junto a tu corazón?
+Nunca hasta ahora contemplé en la tierra
+Sobre el volcán la flor.

--- a/poems/gustavo-adolfo-becquer/rima-023.txt
+++ b/poems/gustavo-adolfo-becquer/rima-023.txt
@@ -1,0 +1,4 @@
+Por una mirada, un mundo;
+Por una sonrisa, un cielo;
+Por un beso... ¡yo no sé
+Qué te diera por un beso!

--- a/poems/gustavo-adolfo-becquer/rima-024.txt
+++ b/poems/gustavo-adolfo-becquer/rima-024.txt
@@ -1,0 +1,20 @@
+Dos rojas lenguas de fuego
+Que, a un mismo tronco enlazadas,
+Se aproximan, y al besarse
+Forman una sola llama;
+Dos notas que del laúd
+A un tiempo la mano arranca,
+Y en el espacio se encuentran
+Y armoniosas se abrazan;
+Dos olas que vienen juntas
+A morir sobre una playa,
+Y que al romper se coronan
+Con un penacho de plata;
+Dos jirones de vapor
+Que del lago se levantan,
+Y al juntarse allá en el cielo,
+Forman una nube blanca;
+Dos ideas que al par brotan,
+Dos besos que a un tiempo estallan,
+Dos ecos que se confunden...
+Eso son nuestras dos almas.

--- a/poems/gustavo-adolfo-becquer/rima-025.txt
+++ b/poems/gustavo-adolfo-becquer/rima-025.txt
@@ -1,0 +1,36 @@
+Cuando en la noche te envuelven
+Las alas de tul del sueño,
+Y tus tendidas pestañas
+Semejan arcos de ébano;
+Por escuchar los latidos
+De tu corazón inquieto,
+Y reclinar tu dormida
+Cabeza sobre mi pecho,
+Diera, alma mía,
+Cuanto poseo:
+¡La luz, el aire
+Y el pensamiento!
+Cuando se clavan tus ojos
+En un invisible objeto,
+Y tus labios ilumina
+De una sonrisa el reflejo;
+Por leer sobre tu frente
+El callado pensamiento
+Que pasa como la nube
+Del mar sobre el ancho espejo,
+Diera, alma mía,
+Cuanto deseo:
+¡La fama, el oro,
+La gloria, el genio!
+Cuando enmudece tu lengua,
+Y se apresura tu aliento,
+Y tus mejillas se encienden,
+Y entornas tus ojos negros;
+Por ver entre sus pestañas
+Brillar con húmedo fuego
+La ardiente chispa que brota
+Del volcán de los deseos,
+Diera, alma mía,
+Por cuanto espero,
+¡La fe, el espíritu,
+La tierra, el cielo!

--- a/poems/gustavo-adolfo-becquer/rima-026.txt
+++ b/poems/gustavo-adolfo-becquer/rima-026.txt
@@ -1,0 +1,14 @@
+Voy contra mi interés al confesarlo;
+Pero yo, amada mía,
+Pienso, cual tú, que una oda sólo es buena
+De un billete del Banco al dorso escrita.
+No faltará algún necio que al oirlo
+Se haga cruees y diga:
+"Mujer al fin del siglo diez y nueve,
+Material y prosaica"... ¡Bobería!
+¡Voces que hacen correr cuatro poetas
+Que en invierno se embozan con la lira!
+¡Ladridos de los perros a la luna!
+Tú sabes y yo sé que en esta vida,
+Con genio, es muy contado quien la escribe;
+Y con oro, cualquiera hace poesía.

--- a/poems/gustavo-adolfo-becquer/rima-027.txt
+++ b/poems/gustavo-adolfo-becquer/rima-027.txt
@@ -1,0 +1,40 @@
+Despierta, tiemblo al mirarte;
+Dormida, me atrevo a verte;
+Por eso, alma de mi alma,
+Yo velo mientras tú duermes.
+Despierta, ríes, y al reir, tus labios
+Inquietos me parecen
+Relámpagos de grana que serpean
+Sobre un cielo de nieve.
+Dormida, los extremos de tu boca
+Pliega sonrisa leve,
+Save como el rastro luminoso
+Que deja un sol que muere...
+—Duerme!
+Despierta, miras, y al mirar, tus ojos
+Húmedos resplandecen,
+Como la onda azul en cuya cresta
+Chispeando el sol hiere.
+Al través de tus párpados, dormida,
+Tranquilo fulgor viertes,
+Cual derrama de luz templado rayo
+Lámpara trasparente...
+—Duerme!
+Despierta, hablas, y al hablar, vibrantes
+Tus palabras parecen
+Lluvia de perlas que en dorada copa
+Se derrama a torrentes.
+Dormida, en el murmullo de tu aliento
+Acompasado y tenue,
+Escucho yo un poema, que mi alma
+Enamorada entiende...
+—Duerme!
+Sobre el corazón la mano
+Me he puesto, por que no suene
+Su latido, y de la noche
+Turbe la calma solemne.
+De tu balcón las persianas
+Cerré ya, por que no entre
+El resplandor enojoso
+De la aurora, y te despierte...
+—Duerme!

--- a/poems/gustavo-adolfo-becquer/rima-028.txt
+++ b/poems/gustavo-adolfo-becquer/rima-028.txt
@@ -1,0 +1,24 @@
+Cuando entre la sombra oscura
+Perdida una voz murmura
+Turbando su triste calma,
+Si en el fondo de mi alma
+La oigo dulce resonar;
+Díme: es que el viento en sus giros
+Se queja, o que tus suspiros
+Me hablan de amor al pasar?
+Cuando el sol en mi ventana
+Rojo brilla a la mañana,
+Y mi amor tu sombra evoca,
+Si en mi boca de otra boca
+Sentir creo la impresión;
+Díme: es que ciego deliro,
+O que un beso en un suspiro
+Me envía tu corazón?
+Si en el luminoso día,
+Y en la alta noche sombría;
+Si en todo cuanto rodea
+Al alma que te desea
+Te creo sentir y ver;
+Díme: es que toco y respiro
+Soñando, o que en in suspiro
+Me das tu aliento a beber?

--- a/poems/gustavo-adolfo-becquer/rima-029.txt
+++ b/poems/gustavo-adolfo-becquer/rima-029.txt
@@ -1,0 +1,27 @@
+Sobre la falda tenía
+El libro abierto;
+En mi mejilla tocaban
+Sus rizos negros;
+No veíamos las letras
+Ninguno, creo;
+Pero guardábamos ambos
+Hondo silencio.
+¿Cuánto duró? Ni aun entonces
+Pude saberlo;
+Sólo sé que no se oía
+Más que el aliento,
+Que apresurado escapaba
+Del labio seco.
+Sólo sé que nos volvimos
+Los dos a un tiempo,
+Y nuestros ojos se hallaron,
+¡Y sonó un beso!
+... ... ... ... ... ... ... ...
+Creación de Dante era el libro,
+Era su Infierno.
+Cuando a él bajamos los ojos,
+Yo dije trémulo:
+¡Comprendes ya que un poema
+Cabe en un verso?
+Y ella respondió encendida:
+—¡Ya lo comprendo!

--- a/poems/gustavo-adolfo-becquer/rima-030.txt
+++ b/poems/gustavo-adolfo-becquer/rima-030.txt
@@ -1,0 +1,8 @@
+Asomaba a sus ojos una lágrima
+Y a mi labio una frase de perdón;
+Habló el orgullo y se enjugó su llanto,
+Y la frase en mis labios expiró.
+Yo voy por un camino, ella por otro;
+Pero al pensar en nuestro mutuo amor,
+Yo digo aún: ¿Por qué callé aquel día?
+Y ella dirá: ¿por qué no lloré yo?

--- a/poems/gustavo-adolfo-becquer/rima-031.txt
+++ b/poems/gustavo-adolfo-becquer/rima-031.txt
@@ -1,0 +1,8 @@
+Nuestra pasión fué un trágico sainete
+En cuya absurda fábula
+Lo cómico y lo grave confundidos
+Risas y llanto arrancan.
+Pero fué lo peor de aquella historia
+que al fin de la jornada,
+A ella tocaron lágrimas y risas,
+¡Y a mí sólo las lágrimas!

--- a/poems/gustavo-adolfo-becquer/rima-032.txt
+++ b/poems/gustavo-adolfo-becquer/rima-032.txt
@@ -1,0 +1,8 @@
+Pasaba arrolladora en su hermosura,
+Y el paso la dejé;
+Ni aun a mirarla me volví, y no obstante
+Algo a mi oído murmuró: "esa es".
+¿Quién reunió la tarde a la mañana?
+Lo ignoro: sólo sé
+Que en una breve noche de verano
+Se unieron los crepúsculos, y... "fué".

--- a/poems/gustavo-adolfo-becquer/rima-033.txt
+++ b/poems/gustavo-adolfo-becquer/rima-033.txt
@@ -1,0 +1,8 @@
+Es cuestión de palabras, y no obstante,
+Ni tú ni yo jamás,
+Después de lo pasado, convendremos
+En quién la eulpa está.
+¡Lástima que el amor un diccionario
+No tenga donde hallar
+Cuándo el orgullo es simplemente orgullo.
+Y cuándo es dignidad!

--- a/poems/gustavo-adolfo-becquer/rima-034.txt
+++ b/poems/gustavo-adolfo-becquer/rima-034.txt
@@ -1,0 +1,20 @@
+Cruza callada, y son sus movimientos
+Silenciosa armonía;
+Suenan sus pasos, y al sonar, recuerdan
+Del himno alado la cadencia rítmica.
+Los ojos entreabre, aquellos ojos
+Tan claros como el día;
+Y la tierra y el cielo, cuanto abarcan,
+Arden con nueva luz en sus pupilas.
+Ríe, y su carcajada tiene notas
+Del agua fugitiva;
+Llora, y es cada lágrima un poema
+De ternura infinita.
+Ella tiene la luz, tiene el perfume,
+El color y la línea,
+La forma, engendradora de deseos,
+La expresión, fuente eterna de poesía.
+¿Qué es estúpida?... ¡Bah! mientras callando
+Guarde oscuro el enigma,
+Siempre valdrá, a mi ver, lo que ella calla
+Más que lo que cualquiera otro me diga.

--- a/poems/gustavo-adolfo-becquer/rima-035.txt
+++ b/poems/gustavo-adolfo-becquer/rima-035.txt
@@ -1,0 +1,4 @@
+No me admiró tu olvido! Aunque de un dia,
+Me admiró tu cariño mucho más;
+Porque lo que hay en mi que vale algo,
+Eso ni lo pudiste sospechar!

--- a/poems/gustavo-adolfo-becquer/rima-036.txt
+++ b/poems/gustavo-adolfo-becquer/rima-036.txt
@@ -1,0 +1,8 @@
+Si de nuestros agravios en un libro
+Se escribiese la historia,
+Y se borrase en nuestras almas cuanto
+Se borrase en sus hojas:
+Te quiero tanto aún, dejó en mi pecho
+Tu amor huellas tan hondas,
+Que sólo con que tú borrases una,
+¡Las borraba yo todas!

--- a/poems/gustavo-adolfo-becquer/rima-037.txt
+++ b/poems/gustavo-adolfo-becquer/rima-037.txt
@@ -1,0 +1,24 @@
+Antes que tú me moriré: escondido
+En las entrañas ya
+El hierro llevo con que abrió tu mano
+La ancha herida mortal.
+Antes que tú me moriré: y mi espíritu,
+En su empeño tenaz,
+Sentándose a las puertas de la muerte,
+Allí te esperará.
+Con las horas los días, con los días
+Los años, volarán,
+Y a aquella puerta llamarás al cabo...
+¿Quién deja de llamar?
+Entonces, que tu culpa y tus despojos
+La tierra guardará,
+Lavándote en las ondas de la muerte
+Como en otro Jordán;
+Allí, donde el murmullo de la vida
+Temblando a morir va,
+Como la ola que a la playa viene
+Silenciosa a expirar;
+Allí, donde el sepulcro que se cierra
+Abre una eternidad...
+¡Todo cuanto los dos hemos callado
+Lo tenemos que hablar!

--- a/poems/gustavo-adolfo-becquer/rima-038.txt
+++ b/poems/gustavo-adolfo-becquer/rima-038.txt
@@ -1,0 +1,4 @@
+Los suspiros son aire, y van al aire.
+Las lágrimas son agua, y van al mar.
+Díme, mujer: cuando el amor se olvida,
+¿Sabes tú a dónde va?

--- a/poems/gustavo-adolfo-becquer/rima-039.txt
+++ b/poems/gustavo-adolfo-becquer/rima-039.txt
@@ -1,0 +1,8 @@
+¿A qué me lo decís? Lo sé: es mudable,
+Es altanera y vana y caprichosa;
+Antes que el sentimiento de su alma,
+Brotará el agua de la estéril roca.
+Sé que en su corazón, nido de sierpes,
+No hay una fibra que al amor responda;
+Que es una estatua inanimada... pero...
+¡Es tan hermosa!

--- a/poems/gustavo-adolfo-becquer/rima-040.txt
+++ b/poems/gustavo-adolfo-becquer/rima-040.txt
@@ -1,0 +1,39 @@
+Su mano entre mis manos,
+Sus ojos en mis ojos,
+La amorosa cabeza
+Apoyada en mi hombro,
+¡Dios sabe cuántas veces,
+Con paso perezoso,
+Hemos vagado juntos
+Bajo los altos olmos
+Que de su casa prestan
+Misterio y sombra al pórtico!
+Y ayer... un año apenas,
+Pasado como un soplo,
+Con qué exquisita gracia,
+Con qué admirable aplomo,
+Me dijo, al presentarnos
+Un amigo oficioso:
+"—Creo que en alguna parte
+He visto a usted.—" ¡Ah! bobos,
+Que sois de los salones
+Comadres de buen tono,
+Y andáis por allí a caza
+De galantes embrollos:
+Qué historia habéis perdido!
+¡Qué manjar tan sabroso
+Para ser devorado
+Sotto voce en un corro,
+Detrás del abanico
+de plumas y de oro!
+... ... ... ... ... ... ... ...
+¡Discreta y casta luna,
+Copudos y altos olmos,
+Paredes de su casa,
+Umbrales de su pórtico,
+Callad, y que el secreto
+No salga de vosotros!
+Callad; que por mi parte
+Lo he olvidado todo:
+Y ella... ella... ¡no hay máscara
+Semejante a su rostro!

--- a/poems/gustavo-adolfo-becquer/rima-041.txt
+++ b/poems/gustavo-adolfo-becquer/rima-041.txt
@@ -1,0 +1,12 @@
+Tú eras el huracán, y yo la alta
+Torre que desafía su poder:
+Tenías que estrellarte o abatirme!...
+¡No pudo ser!
+Tú eras el océano, y yo la enhiesta
+Roca que firme aguarda su vaivén:
+¡Tenías que romperte o que arrancarme!
+¡No pudo ser!
+Hermosa tú, yo altivo; acostumbrados
+Uno a arrollar, el otro a no ceder:
+La senda estrecha, inevitable el choque...
+¡No pudo ser!

--- a/poems/gustavo-adolfo-becquer/rima-042.txt
+++ b/poems/gustavo-adolfo-becquer/rima-042.txt
@@ -1,0 +1,12 @@
+Cuando me lo contaron sentí el frío
+De una hoja de acero en las entrañas;
+Me apoyé contra el muro, y un instante
+La conciencia perdí de donde estaba.
+Cayó sobre mi espíritu la noche;
+En ira y en piedad se anegó el alma...
+Y entonces comprendí por qué se llora,
+Y entonces comprendí por qué se mata!
+Pasó la nube de dolor... con pena
+Logré balbucear breves palabras...
+Quién me dió la noticia?... Un fiel amigo...
+Me hacía un gran favor!... Le di las gracias.

--- a/poems/gustavo-adolfo-becquer/rima-043.txt
+++ b/poems/gustavo-adolfo-becquer/rima-043.txt
@@ -1,0 +1,12 @@
+Dejé la luz a un lado, y en el borde
+De la revuelta cama me senté,
+Mude, somrbío, la pupila inmóvil
+Clavada en la pared.
+¿Qué tiempo estuve así? No sé: al dejarme
+La embriaguez horrible del dolor,
+Expiraba la luz, y en mis balcones
+Reía el sol.
+Ni sé tampoco en tan terrible horas
+En qué pensaba o qué pasó por mí;
+Sólo recuerdo que lloré y maldije,
+¡Y que en aquella noche envejecí!

--- a/poems/gustavo-adolfo-becquer/rima-044.txt
+++ b/poems/gustavo-adolfo-becquer/rima-044.txt
@@ -1,0 +1,8 @@
+Como en un libro abierto
+Leo de tus pupilas en el fondo;
+A qué fingir el labio
+Risas que se desmienten con los ojos?
+¡Llora! No te avergüences
+De confesar que me quisiste un poco.
+¡Llora! Nadie nos mira.
+Ya ves; yo soy un hombre... ¡y también lloro!

--- a/poems/gustavo-adolfo-becquer/rima-045.txt
+++ b/poems/gustavo-adolfo-becquer/rima-045.txt
@@ -1,0 +1,16 @@
+En la clave del arco mal seguro,
+Cuyas piedras el tiempo enrojeció,
+Obra de cincel rudo, campeaba
+El gótico blasón.
+Penacho de su yelmo de granito,
+La hiedra que colgaba en derredor
+Daba sombra al escudo, en que una mano
+Tenía un corazón.
+A contemplarle en la desierta plaza
+Nos paramos los dos:
+Y "ese, me dijo, es el cabai emblema
+De mi constante amor."
+¡Ay! es verdad lo que me dijo entonces:
+Verdad que el corazón
+Lo llevará en la mano... en cualquier parte...
+Pero en el pecho, ¡no!

--- a/poems/gustavo-adolfo-becquer/rima-046.txt
+++ b/poems/gustavo-adolfo-becquer/rima-046.txt
@@ -1,0 +1,8 @@
+Me ha herido recatándose en las sombras.
+Sellando con un beso su traición.
+Los brazos me echó al cuello, y por la espalda
+Partiéme a sangre fría el corazón.
+Y ella prosigue alegre su camino,
+Feliz, risueña, impávida; y por qué?
+Porque no brota sangre de la herida...
+¡Porque el muerto está en pie!

--- a/poems/gustavo-adolfo-becquer/rima-047.txt
+++ b/poems/gustavo-adolfo-becquer/rima-047.txt
@@ -1,0 +1,8 @@
+Yo me he asomado a las profundas simas
+De la tierra y del cielo,
+Y les he visto el fin o con los ojos,
+O con el pensamiento.
+Mas jay! de un corazón llegué al abismo,
+Y me incliné por verlo,
+Y mi alma y mis ojos se turbaron:
+¡Tan hondo era y tan negro!

--- a/poems/gustavo-adolfo-becquer/rima-048.txt
+++ b/poems/gustavo-adolfo-becquer/rima-048.txt
@@ -1,0 +1,12 @@
+Como se arranca el hierro de una herida,
+Su amor de las entrañas me arranqué,
+Aunque sentí, al hacerlo, que la vida.
+Me arrancaba con él.
+Del altar que la alcé en el alma mía
+La voluntad su imagen arrojó,
+Y la luz de la fe que én ella ardía
+Ante el ara desierta se apagó.
+Aun para combatir mi firme empeño
+Viene a mi mente. su visión tenaz...
+¡Cuándo podré dormir con ese sueño
+En que acaba el soñar!

--- a/poems/gustavo-adolfo-becquer/rima-049.txt
+++ b/poems/gustavo-adolfo-becquer/rima-049.txt
@@ -1,0 +1,8 @@
+Alguna vez la encuentro por el mundo
+Y pasa junto a mí;
+Y pasa sonriéndose, y yo digo:
+¿Cómo puede reir?
+Luego asoma a mi labio otra sonrisa,
+Máscara del dolor,
+Y entonces pienso:—¡Acaso ella se ríe,
+Como me río yo!

--- a/poems/gustavo-adolfo-becquer/rima-050.txt
+++ b/poems/gustavo-adolfo-becquer/rima-050.txt
@@ -1,0 +1,8 @@
+Lo que el salvaje, que con torpe mano
+Hace de un tronco a su capricho un dios,
+Y luego ante su obra se arrodilla,
+Eso hicimos tú y yo.
+Dimos formas reales a un fantasma,
+De la mente ridícula invención,
+Y hecho el ídolo ya, sacrificamos
+En su altar nuestro amor.

--- a/poems/gustavo-adolfo-becquer/rima-051.txt
+++ b/poems/gustavo-adolfo-becquer/rima-051.txt
@@ -1,0 +1,8 @@
+De lo poco de vida que me resta
+Diera con gusto los mejores años,
+Por saber lo que a otros
+De mí has hablado.
+Y esta vida mortal... y de la eterna
+Lo que me toque, si me toca algo,
+Por saber lo que a solas
+De mí has pensado.

--- a/poems/gustavo-adolfo-becquer/rima-052.txt
+++ b/poems/gustavo-adolfo-becquer/rima-052.txt
@@ -1,0 +1,16 @@
+Olas gigantes que os rompéis bramando
+En las playas desiertas y remotas,
+Envuelto entre la sábana de espumas,
+¡Llevadme con vosotras!
+Ráfagas de huracán, que arrebatáis
+Del alto bosque las marchitas hojas,
+Arrastrado en el ciego torbellino,
+¡Llevadmé con vosotras!
+Nubes de tempestad, que rompe el rayo
+Y en fuego ornáis las desprendidas orlas,
+Arrebatado entre la niebla oscura,
+¡Llevadme con vosotras!
+Llevadme, por piedad, a donde el vértigo
+Con la razón me arranque la memoria...
+¡Por piedad!... ¡Tengo miedo de quedarme
+Con mi dolor a solas!

--- a/poems/gustavo-adolfo-becquer/rima-053.txt
+++ b/poems/gustavo-adolfo-becquer/rima-053.txt
@@ -1,0 +1,24 @@
+Volverán las oscuras golondrinas
+En tu balcón sus nidos a colgar,
+Y, otra vez, con el ala a sus cristales
+Jugando llamarán;
+Però aquellas que el vuelo refrenaban
+Tu hermosura y mi dicha a contemplar,
+Aquellas que aprendieron nuestros nombres
+Esas... ¡no volverán!
+Volverán las tupidas madreselvas
+De tu jardín las tapias a escalar,
+Y otra vez a la tarde, aun más hermosas,
+Sus flores se abrirán;
+Pero aquellas cuajadas de rocío,
+Cuyas gotas mirábamos temblar
+Y caer, como lágrimas del día...
+Esas... no volverán!
+Volverán del amor en tus oídos
+Las palabras ardientes a sonar;
+Tu corazón de su profundo sueño
+Tal vez despertará;
+Pero mudo y absorto y de rodillas,
+Como se adora a Dios ante su altar,
+Como yo te he querido... desengáñate,
+¡Así no te querrán!

--- a/poems/gustavo-adolfo-becquer/rima-054.txt
+++ b/poems/gustavo-adolfo-becquer/rima-054.txt
@@ -1,0 +1,8 @@
+Cuando volvemos las fugaces horas
+Del pasado a evocar,
+Temblando brilla en sus pestañas negras
+Una lágrima pronta a resbalar.
+Y al fin resbala, y cae como gota
+De rocío, al pensar
+Que, cual hoy por ayer, por hoy mañana,
+Volveremos los dos a suspirar.

--- a/poems/gustavo-adolfo-becquer/rima-055.txt
+++ b/poems/gustavo-adolfo-becquer/rima-055.txt
@@ -1,0 +1,12 @@
+Entre el discorde estruendo de la orgía
+Acarició mi oído,
+Como nota de música lejana,
+El eco de un suspiro.
+El eco de un suspiro que conozco,
+Formado de un aliento que he bebido,
+Perfume de una flor, que oculta crece
+En una claustro sombrío.
+Mi adorada de un día, cariñosa,
+—En qué piensas? me dijo.
+—En nada... —¿En nada, y lloras? —Es que tengo
+Alegre la tristeza y triste el vino.

--- a/poems/gustavo-adolfo-becquer/rima-056.txt
+++ b/poems/gustavo-adolfo-becquer/rima-056.txt
@@ -1,0 +1,24 @@
+Hoy como ayer, mañana como hoy,
+¡Y siempre igual!
+Un cielo gris, un horizonte eterno,
+¡Y andar... andar!
+Moviéndose a compás, como una estúpida
+Máquina, el corazón;
+La torpe inteligencia, del cerebro
+Dormida en un rincón.
+El alma, que ambiciona un paraíso,
+Buscándole sin fe;
+Fatiga sin objeto, ola que rueda
+Ignorando por qué.
+Voz que incesante con el mismo tono
+Canta el mismo cantar;
+Gota de agua monótona que cae,
+Y cae sin cesar.
+Así van deslizándose los días
+Unos de otros en pos,
+Hoy lo mismo que ayer... y todos ellos
+Sin goce ni dolor.
+¡Ay! a veces me acuerdo suspirando
+Del antiguo sufrir....
+Amargo es el dolor; pero siquiera,
+¡Padecer es vivir!

--- a/poems/gustavo-adolfo-becquer/rima-057.txt
+++ b/poems/gustavo-adolfo-becquer/rima-057.txt
@@ -1,0 +1,16 @@
+Este armazón de huesos y pellejo,
+De pasear una cabeza loca
+Cansado se halla al fin, y no lo extraño;
+Pues, aunque es la verdad que no soy viejo,
+De la parte de vida que me toca
+En la vida del mundo, por mi daño
+He hecho un uso tal, que juraría
+Que he condensado un siglo en cada día.
+Así, aunque ahora muriera,
+No podría decir que no he vivido;
+Que el sayo, al parecer nuevo por fuera,
+Conozco que por dentro ha envejecido.
+Ha envejecido, sí; ¡pese a mi estrella!
+Harto lo dice ya mi afán doliente;
+Que hay dolor que al pasar, su horrible huella
+Graba en el corazón, si no en la frente.

--- a/poems/gustavo-adolfo-becquer/rima-058.txt
+++ b/poems/gustavo-adolfo-becquer/rima-058.txt
@@ -1,0 +1,8 @@
+¿Quieres que de ese néctar delicioso
+No te amargue la hez?
+Pues aspírale, acércale a tus labios,
+Y déjale después.
+¿Quieres que conservemos una dules
+Memoria de este amor?
+Pues amémonos hoy mucho, y mañana
+Digámonos ¡adiós!

--- a/poems/gustavo-adolfo-becquer/rima-059.txt
+++ b/poems/gustavo-adolfo-becquer/rima-059.txt
@@ -1,0 +1,24 @@
+Yo sé cuál el objeto
+De tus suspiros es;
+Yo conozco la causa de tu dulce
+Secreta languidez.
+¿Te ríes?... Algún día
+Sabrás, niña, por qué;
+Tú acaso lo sospechas,
+Y yo lo sé.
+Yo sé lo que tú sueñas,
+Y lo que en sueños ves;
+Como en un libro, puedo lo que callas
+En tu frente leer.
+¿Te ríes?... Algún día
+Sabrás, niña, por qué;
+Tú acaso lo sospechas,
+Y yo lo sé.
+Yo sé por qué sonríes
+Y lloras a la vez;
+Yo penetro en los senos misteriosos
+De tu alma de mujer.
+¿Te ríes?... Algún día
+Sabrás, niña, por qué;
+Mientras tú sientes mucho y nada sabes,
+Yo, que no siento ya, todo lo sé.

--- a/poems/gustavo-adolfo-becquer/rima-060.txt
+++ b/poems/gustavo-adolfo-becquer/rima-060.txt
@@ -1,0 +1,5 @@
+Mi vida es un erial:
+Flor que toco se deshoja;
+Que en mi camino fatal,
+Alguien va sembrando el mal
+Para que yo lo recoja.

--- a/poems/gustavo-adolfo-becquer/rima-061.txt
+++ b/poems/gustavo-adolfo-becquer/rima-061.txt
@@ -1,0 +1,24 @@
+Al ver mis horas de fiebre
+E insomnio lentas pasar,
+A la orilla de mi lecho,
+¿Quién se sentará?
+Cuando la trémula mano
+Tienda, próximo a expirar,
+Buscando una mano amiga,
+¿Quién la estrechará?
+Cuando la muerte vidrie
+De mis ojos el cristal,
+Mis párpados aun abiertos,
+¿Quién los cerrará?
+Cuando la campana suene
+(Si suena en mi funeral),
+Una oración al oirla,
+¿Quién murmurará?
+Cuando mis pálidos restos
+Oprima la tierra ya,
+Sobre la olvidada fosa,
+¿Quién vendrá a llorar?
+¿Quién, en fin, al otro día,
+Cuando el sol vuelva a brillar,
+De que pasé por el mundo,
+¿Quién se acordará?

--- a/poems/gustavo-adolfo-becquer/rima-062.txt
+++ b/poems/gustavo-adolfo-becquer/rima-062.txt
@@ -1,0 +1,8 @@
+Primero es un albor trémulo y vago,
+Raya de inquieta luz que corta el mar;
+Luego chispea y crece y se dilata
+En ardiente explosión de claridad.
+La brilladora luz es la alegría,
+La temerosa sombra es el pesar:
+¡Ay! en la oscura noche de mi alma,
+¿Cuándo amanecerá?

--- a/poems/gustavo-adolfo-becquer/rima-063.txt
+++ b/poems/gustavo-adolfo-becquer/rima-063.txt
@@ -1,0 +1,8 @@
+Como enjambre de abejas irritadas,
+De un oscuro rincón de la memoria
+Salen a perseguirme los recuerdos
+De las pasadas horas.
+Yo los quiero ahuyentar. ¡Esfuerzo inútil!
+Me rodean, me acosan,
+¡Y unos tras otros a clavarme vienen
+El agudo aguijón que el alma encona!

--- a/poems/gustavo-adolfo-becquer/rima-064.txt
+++ b/poems/gustavo-adolfo-becquer/rima-064.txt
@@ -1,0 +1,8 @@
+Como el avaro su tesoro,
+Guardaba mi dolor;
+Yo quería probar que hay algo eterno
+A la que eterno me juró su amor.
+Mas hoy le llamo en vano, y oigo al Tiempo
+Que le agotó, decir:
+¡Ah, barro miserable, eternamente
+No podrás ni aun sufrir!

--- a/poems/gustavo-adolfo-becquer/rima-065.txt
+++ b/poems/gustavo-adolfo-becquer/rima-065.txt
@@ -1,0 +1,8 @@
+Llegó la noche y no encontré un asilo;
+¡Y tuve sed!... Mis lágrimas bebí;
+¡Y tuve hambre! ¡Los hinchados ojos
+Cerré para morir!
+¡Estaba en un desierto! Aunque a mi oído
+De las turbas llegaba el ronco hervir,
+Yo era huérfano y pobre... ¡El mundo estaba
+Desierto... para mí!

--- a/poems/gustavo-adolfo-becquer/rima-066.txt
+++ b/poems/gustavo-adolfo-becquer/rima-066.txt
@@ -1,0 +1,16 @@
+¿De dónde vengo?... El más horrible y áspero
+De los senderos busca;
+Las huellas de unos piés ensangrentados
+Sobre la roca dura;
+Los despojos de un alma hecha jirones
+En las zarzas agudas,
+Te dirán el camino
+Que conduce a mi cuna.
+¿A dónde voy? El más sombrio y triste
+De los páramos cruza;
+Valle de eternas nieves y de eternas
+Melancóliens brumas.
+En donde esté una piedra solitaria
+Sin inscripción alguna,
+Donde habite el olvido,
+Allí estará mi tumba.

--- a/poems/gustavo-adolfo-becquer/rima-067.txt
+++ b/poems/gustavo-adolfo-becquer/rima-067.txt
@@ -1,0 +1,16 @@
+¡Qué hermoso es ver el día
+Coronado de fuego levantarse,
+Y a su beso de lumbre
+Brillar las olas y encenderse el aire!
+¡Qué hermoso es tras la lluvia
+Del triste otoño en la azulada tarde,
+De las húmedas flores
+El perfume aspirar hasta saciarse!
+¡Qué hermoso es cuando en copos
+La blanca nieve silenciosa cae,
+De las inquietas llamas
+Ver las rojizas lenguas agitarse!
+¡Qué hermoso es, cuando hay sueño,
+Dormir hien... y roncar como un sochantre...
+Y comer... y engordar!... ¡y qué desgracia
+Que esto solo no baste!

--- a/poems/gustavo-adolfo-becquer/rima-068.txt
+++ b/poems/gustavo-adolfo-becquer/rima-068.txt
@@ -1,0 +1,12 @@
+No sé lo que he soñado
+En la noche pasada;
+Triste, muy triste debió ser el sueño,
+Pues despierto la angustia me duraba.
+Noté, al incorporarme,
+Húmeda la almohada,
+Y por primera vez sentí, al notarlo,
+De un amargo placer henchirse el alma.
+Triste cosa es el sueño
+Que llanto nos arranca;
+Mas tengo en mi tristeza una alegría...
+¡Sé que aún me quedan lágrimas!

--- a/poems/gustavo-adolfo-becquer/rima-069.txt
+++ b/poems/gustavo-adolfo-becquer/rima-069.txt
@@ -1,0 +1,6 @@
+Al brillar un relámpago nacemos,
+Y aun dura su fulgor cuando morimos:
+¡Tan corto es el vivir!
+La gloria y el amor tras que corremos,
+Sombras de un sueño son que perseguimos:
+¡Despertar es morir!

--- a/poems/gustavo-adolfo-becquer/rima-070.txt
+++ b/poems/gustavo-adolfo-becquer/rima-070.txt
@@ -1,0 +1,36 @@
+¡Cuántas veces al pie de las musgosas
+Paredes que la guardan,
+Oi la esquila que al mediar la noche
+A los maitines llama!
+¡Cuántas veces trazó mi triste sombra
+La luna plateada,
+Junto a la del ciprés, que de su huerto
+Se asoma por las tapias!
+Cuando en sombras la iglesia se envolvía,
+De su ojiva calada,
+¡Cuántas veces temblar sobre los vidrios
+Vi el fulgor de la lámpara!
+Aunque el viento en los ángulos oscuros
+De la torre silbara,
+Del coro entre las voces percibía
+Su voz vibrante y clara.
+En las noches de invierno, si un medroso
+Por la desierta plaza
+Se atrevía a cruzar, al divisarme
+El paso aceleraba.
+Y no faltó una vieja que en el torno
+Dijese a la mañana,
+Que de algún sacristán muerto en pecado
+Acaso era yo el alma.
+A oscuras conocía los rincones
+Del atrio y la portada;
+De mis pies las ortigas que allí crecen
+las huellas tal vez guardan.
+Los buhos que espantados me seguían
+Con sus ojos de llamas,
+Llegaron a mirarme con el tiempo
+Como a un buen camarada.
+A mi lado sin miedo los reptiles
+Se movían a rastras;
+¡Hasta los mudos santos de granito
+Vi que me saludaban!

--- a/poems/gustavo-adolfo-becquer/rima-071.txt
+++ b/poems/gustavo-adolfo-becquer/rima-071.txt
@@ -1,0 +1,25 @@
+No dormía; vagaba en ese limbo
+En que cambian de forma los objetos,
+Misteriosos espacios que separan
+La vigilia del sueño.
+Las ideas, que en ronda silenciosa
+Daban vueltas en torno a mi cerebro,
+Poco a poco en su danza se movían
+Con un compás más lento.
+De la luz que entra al alma por los ojos
+Los párpados velaban el reflejo,
+Mas otra luz el mundo de visiones
+Alumbraba por dentro.
+En este punto resonó en mi oído
+Un rumor semejante al que en el templo
+Vaga confuso, al terminar los fieles
+Con un amén sus rezos.
+Y oí como una voz delgada y triste
+Que por mi nombre me llamó a lo lejos
+Y sentí olor de cirios apagados,
+De humedad y de incionso.
+... ... ... ... ... ... ... ...
+Entró la noche, y del olvido en brazos
+Caí, cual piedra, en su profundo seno:
+Doriní, y al despertar exclamé: "¡Alguno
+Que yo quería ha muerto!"

--- a/poems/gustavo-adolfo-becquer/rima-072.txt
+++ b/poems/gustavo-adolfo-becquer/rima-072.txt
@@ -1,0 +1,30 @@
+PRIMERA VOZ
+—Las ondas tienen vaga armonía,
+Las violetas suave olor,
+Brumas de plata la noche fría,
+Luz y oro el día,
+Yo algo mejor:
+¡Yo tengo Amor!
+SEGUNDA VOZ
+—Aura de aplausos, nube radiosa,
+Ola de envidia que besa el pie,
+Isla de sueños donde reposa
+El alma ansiosa,
+¡Dulce embriaguez
+La Gloria es!
+TERCERA VOZ
+—Ascua encendida es el tesoro,
+Sombra que huye la vanidad.
+Todo es mentira: la gloria, el oro.
+Lo que yo adoro
+Sólo es verdad:
+¡La Libertad!
+.. .. .. .. .. .. .. .. .. .. .. .. .. .. .. .. ..
+Así los barqueros pasaban cantando
+La eterna canción,
+Y al golpe del remo saltaba la espuma
+Y heríala el sol.
+¿Te embareas? gritaban; y yo sonriendo
+Le dije al pasar:
+—Ha tiempo lo hice; por cierto que aun tengo
+La ropa en la playa tendida a secar!

--- a/poems/gustavo-adolfo-becquer/rima-073.txt
+++ b/poems/gustavo-adolfo-becquer/rima-073.txt
@@ -1,0 +1,105 @@
+Cerraron sus ojos
+Que aun tenía abiertos;
+Taparon su cara
+Con un blanco lienzo;
+Y unos sollozando,
+Otros en silencio,
+De la triste alcoba
+Todos se salieron.
+La luz, que en un vaso
+Ardía en el suelo,
+Al muro arrojaba
+La sombra del lecho;
+Y entre aquella sombra
+Veiase a intérvalos,
+Dibujarse rígida
+La forma del cuerpo.
+Despertaba el día,
+Y a su albor primero,
+Con sus mil ruidos
+Despertaba el pueblo.
+Ante aquel contraste
+De vida y misterios,
+De luz y tinieblas,
+Medité un momento:
+"Dios mío, qué solos
+Se quedan los muertos!"
+De la casa en hombros
+Lleváronla al templo,
+Y en una capilla
+Dejaron el féretro.
+Allí rodearon
+Sus pálidos restos
+De amarillas velas
+Y de paños negros.
+Al dar de las ánimas
+El toque postrero,
+Acabó una vieja
+Sus últimos rezos;
+Cruzó la ancha nave,
+Las puertas gimieron,
+Y el santo recinto
+Quedóse desierto.
+De un reloj se oía
+Compasado el péndulo,
+Y de algunos cirios
+El chisporroteo.
+Tan medroso y triste,
+Tan oscuro y yerto
+Todo se encontraba...
+Que pensé un momento:
+"¡Dios mío, qué solos
+Se quedan los muertos!"
+De la alta campana
+La lengua de hierro,
+Le dió, volteando,
+Su adiós lastimero.
+El luto en las ropas,
+Amigos y deudos
+Cruzaron en fila,
+Formando el cortejo.
+Del último asilo,
+Oscuro y estrecho,
+Abrió la piqueta
+El nicho a un extremo.
+Allí la acostaron,
+apiáronle luego,
+Y con un saludo
+Despidióse el duelo.
+La piqueta al hombro,
+El sepulturero,
+Cantando entre dientes,
+Se perdió a lo lejos.
+La noche se entraba,
+Reinaba el silencio;
+Perdido en las sombras,
+Medité un momento:
+"¡Dios mío, qué solos
+Se quedan los muertos!"
+En las largas noches
+Del helado invierno,
+Cuando las maderas
+Crujir hace el viento
+Y azota los vidrios
+El fuerte aguacero,
+De la pobre niña
+A solas me acuerdo.
+Allí cae la lluvia
+Con un son eterno;
+Allí la combate
+El soplo del cierzo.
+Del húmedo muro
+Tendida en el hueco,
+¡Acaso de frío
+Se hielan sus huesos!...
+... ... ... ... ... ... ...
+¿Vuelve el polvo al polvo?
+¿Vuela el alma al cielo?
+¿Todo es vil materia,
+Podredumbre y cieno?
+¡No sé; pero hay algo
+Que explicar no puedo,
+Que al par nos infunde
+Repugnancia y duelo,
+Al dejar tan tristes,
+Tan solos los muertos!

--- a/poems/gustavo-adolfo-becquer/rima-074.txt
+++ b/poems/gustavo-adolfo-becquer/rima-074.txt
@@ -1,0 +1,20 @@
+Las ropas desceñidas,
+Desnudas las espadas,
+Bajo el dintel de oro de la puerta
+Dos ángeles velaban.
+Me aproximé a los hierros.
+Que defienden la entrada,
+Y de las dobles rejas en el fondo
+La vi confusa y blanca.
+La ví como la imagen
+Que en leve ensueño pasa,
+Como rayo de luz, tenue y difuso,
+Que entre tinieblas nada.
+Me sentí de un ardiente
+Deseo llena el alma:
+¡Como atrae un abismo, aquel misterio
+Hacia sí me arrastraba!
+Mas ¡ay! que de los ángeles
+Parecían decirme las miradas:
+—¡El umbral de esta puerta
+Sólo Dios lo traspasa!

--- a/poems/gustavo-adolfo-becquer/rima-075.txt
+++ b/poems/gustavo-adolfo-becquer/rima-075.txt
@@ -1,0 +1,20 @@
+¿Será verdad que cuando toca el sueño
+Con sus dedos de rosa nuestros ojos,
+De la cárcel que habita huye el espíritu
+En vuelo presuroso?
+¿Será verdad que, huésped de las nieblas
+De la brisa nocturna al tenue soplo,
+Alado sube a la región vacía
+A encontrarse con otros?
+¿Y allí, desnudo de la humana forma,
+Allí, los lazos terrenales rotos,
+Breves horas habita de la idea
+El mundo silencioso?
+¿Y ríe y llora y aborrece y ama,
+Y guarda un rastro del dolor y el gozo,
+Semejante al que deja cuando cruza
+El cielo un meteoro?
+¡Yo no sé si ese mundo de visiones
+Vive fuera, o va dentro de nosotros;
+Pero sé que conozco a muchas gentes
+A quienes no conozco!

--- a/poems/gustavo-adolfo-becquer/rima-076.txt
+++ b/poems/gustavo-adolfo-becquer/rima-076.txt
@@ -1,0 +1,45 @@
+En la imponente nave
+Del templo bizantino,
+Vi la gótica tumba, a la indecisa
+Luz que temblaba en los pintados vidrios.
+Las manos sobre el pecho,
+Y en las manos un libro,
+Una mujer hermosa reposaba
+Sobre la urna, del cincel prodigio.
+Del cuerpo abandonado
+Al dulce peso hundido,
+Cual si de blanda pluma y raso fuera,
+Se plegaba su lecho de granito.
+De la postrer sonrisa,
+El resplandor divino
+Guardaba el rostro, como el cielo guarda
+Del sol que muere el rayo fugitivo
+Del cabezal de piedra
+Sentados en el filo,
+Dos ángeles, el dedo sobre el labio,
+Imponían silencio en el recinto.
+No parecía muerta;
+De les arcos macizos
+Parecia de mir en la penumbra,
+Y que en sueños veía el paraso.
+Me acerqué de la nave
+Al ángulo sombrío,
+Como quien llega con callada planta
+Junto a la cuna donde duerme un niño.
+La contemplé un momento,
+Y aquel resplandor tibio,
+Aquel lecho de piedra que ofrecía
+Próximo al muro otro lugar vacío,
+En el alma avivaron
+La sed de lo infinito,
+El ansia de esa vida de la muerte
+Para la que un instante son los siglos...
+... ... ... ... ... ... ... ... ... ...
+Cansado del combate
+En que luchando vivo,
+Alguna vez recuerdo con envidia
+Aquel rincón oscuro y escondido.
+De aqulla muda y pálida
+Mujer, me acuerdo y digo:
+¡Oh, qué amor tan callado el de la muerte!
+¡Qué sueño el del sepulcro tan tranquilo!

--- a/poems/louise-labe/elegie-01.txt
+++ b/poems/louise-labe/elegie-01.txt
@@ -1,0 +1,123 @@
+Av tems qu’Amour, d’hommes et Dieus vainqueur,
+Faisoit bruler de sa flamme mon cœur,
+En embrassant de sa cruelle rage
+Mon sang, mes os, mon esprit et courage :
+Encore lors ie n’auois la puissance
+De lamenter ma peine et ma souffrance.
+Eucor Phebus, amis des Lauriers vers,
+N’auoit permis que ie fisse des vers :
+
+Mais meintenant que sa fureur diuine
+Remplit d’ardeur ma hardie poitrine,
+Chanter me fait, non les bruians tonnerres
+De Iupiter, ou les cruelles guerres,
+Dont trouble Mars, quand il veut, l’Uniuers.
+Il m’a donné la lyre, qui les vers
+Souloit chanter de l’Amour Lesbienne ;
+Et à ce coup pleurera de la mienne.
+Ô dous archet, adouci moy la voix,
+Qui pourroit feindre et aigrir quelquefois,
+En recitant tant d’ennuis et douleurs.
+Tant de despits, fortunes et malheurs.
+Trempe l’ardeur, dont iadis mon cœur tendre
+Fut en brulant demi reduit en cendre.
+Ie sen déſia un piteus souvenir,
+Qui me contreint la larme à l’œil venir.
+Il m’est avis que ie sen les alarmes,
+Que premiers i’u d’Amour, ie voy les armes,
+Dont il s’arma en venant m’assaillir.
+C’estoit mes yeus, dont tant faisois saillir
+De traits, à ceus qui trop me regardoient,
+Et de mon arc assez ne se gardoient,
+
+Mais ces miens traits ces miens yeux me defirent
+Et de vengeance estre exemple me firent.
+Et me moquant, et voyant l’un aymer,
+L’autre bruler et d’Amour consommer :
+En voyant tant de larmes espandues,
+Tant de souspirs et prieres perdues,
+Ie n’aperçu que soudein me vint prendre
+Le mesme mal que ie soulois reprendre :
+Qui me persa d’une telle furie,
+Qu’encor n’en suis apres long tems guerie :
+Et meintenant me suis encore contreinte
+De rafreschir d’une nouuelle pleinte
+Mes maus passez. Dames, qui les lirez,
+De mes regrets auec moy soupirez.
+Possible, un iour le feray le semblable,
+Et ayderay votre voix pitoyable
+À vos trauaus et peines raconter,
+Au tems perdu vainement lamenter.
+Quelque rigueur qui loge en votre cœur,
+Amour s’en peut un iour rendre vainqueur.
+Et plus aurez lui esté ennemies,
+Pis vous fera, vous sentant asseruies,
+
+N’estimez point que lon doiue blâmer
+Celles qu’a fait Cupidon enflamer.
+Autres que nous, nonobstant leur hautesse,
+Ont enduré l’amoureuse rudesse :
+Leur cœur hautein, leur beauté, leur lignage,
+Ne les ont su preseruer du seruage
+De dur Amour : les plus nobles esprits
+En sont plus fort et plus soudein espris.
+Semiramis, Royne tant renommee.
+Qui mit en route auecques son armee
+Les noirs squadrons des Ethiopiens,
+Et en montrant louable exemple aus siens
+Faisoit couler de son furieus branc
+Des ennemis les plus braues le sang,
+Ayant encor enuie de conquerre
+Tous ses voisins, ou leur mener la guerre,
+Trouua Amour, qui si fort la pressa,
+Qu’armes et loix vaincue elle laissa.
+Ne meritoit sa Royalle grandeur
+Au moins auoir un moins fascheus malheur
+Qu’aymer son fils ? Royne de Babylonne,
+Ou est ton cœur qui es combaz resonne ?
+
+Qu’est deuenu ce fer et cet escu,
+Dont tu rendois le plus braue veincu ?
+Ou as tu mis la Marciale creste,
+Qui obombroit le blond or de ta teste ?
+Ou est l’espée, ou est cette cuirasse.
+Dont tu rompois des ennemis l’audace ?
+Ou sont fuiz tes coursiers furieus,
+Lesquels trainoient ton char victorieus ?
+T’a pù si tot un foible ennemi rompre ?
+Ha pù si tot ton cœur viril corrompre,
+Que le plaisir d’armes plus ne te touche :
+Mais seulement languis en une couche ?
+Tu as laissé les aigreurs Marciales,
+Pour recouurer les douceurs geniales.
+Ainsi Amour de toy t’a estrangee,
+Qu’on te diroit en une autre changee,
+Donques celui lequel d’amour esprise
+Pleindre me voit, que point il ne mesprise
+Mon triste deuil : Amour peut estre, en brief
+En son endroit n’aparoitra moins grief.
+Telle i’ay vù qui auoit en jeunesse
+Blamé Amour : apres en sa vieillesse
+
+Bruler d’ardeur, et pleindre tendrement
+L’apre rigueur de son tardif tourment.
+Alors de fard et eau continuelle
+Elle essayoit se faire venir belle,
+Voulant chasser le ridé labourage.
+Que l’aage avoit graué sur son visage.
+Sur son chef gris elle avait empruntee
+Quelque perruque, et assez mal antee :
+Et plus estoit à son gré bien fardee.
+De son Ami moins estoit regardee :
+Lequel ailleurs fuiant n’en tenoit conte,
+Tant lui sembloit laide, et auoit grand’honte
+D’estre aymé d’elle. Ainsi la poure vieille
+Receuoit bien pareille pour pareille.
+De maints en vain un temps fut reclamee,
+Ores quelle ayme, elle n’est point aymee.
+Ainsi Amour prend son plaisir, à faire
+Que le veuil d’un sait à l’autre contraire.
+Tel n’ayme point, qu’une Dame aymera :
+Tel ayme aussi, qui aymé ne sera :
+Et entretient, neanmoins, sa puissance
+Et sa rigueur d’une vaine esperance.

--- a/poems/louise-labe/elegie-02.txt
+++ b/poems/louise-labe/elegie-02.txt
@@ -1,0 +1,109 @@
+D’vn tel vouloir le serf point ne désire
+La liberté, ou son port le nauire,
+Comme i’attens, helas, de iour en iour
+De toy, Ami, le gracieus retour.
+La, i’auois mis le but de ma douleur,
+Qui fineroit, quand i’aurois ce bon heur
+De te reuoir : mais de la longue atente,
+Helas, en vain mon désir se lamente.
+Cruel, Cruel, qui te faisoit promettre
+Ton brief retour en ta premiere lettre ?
+As tu si peu de memoire de moy,
+Que de m’auoir si tot rompu la foy ?
+
+Comme ose tu ainsi abuser celle
+Qui de tout tems t’a esté si fidelle ?
+Or que tu es aupres de ce riuage
+Du Pau cornu, peut estre ton courage
+S’est embrasé d’une nouuelle flame,
+En me changeant pour prendre une autre Dame :
+Ià en oubli inconstamment est mise
+La loyauté, que tu m’auois promise.
+S’il est ainsi, et que desia la foy
+Et la bonté se retirent de toy :
+Il ne me faut emerueiller si ores
+Toute pitié tu as perdu encores.
+Ô combien ha de pensee et de creinte,
+Tout à par soy, l’ame d’Amour esteinte !
+Ores ie croy, vù notre amour passee,
+Qu’impossible est, que tu m’aies laissee :
+Et de nouuel ta foy ie me fiance,
+Et plus qu’humeine estime ta constance.
+Tu es, peut estre, en chemin inconnu
+Outre ton gré malade retenu.
+Ie croy que non : car tant suis coutumiere
+De faire aus Dieus pour ta santé priere,
+
+Que plus cruels que tigres ils seroient,
+Quand maladie ils te prochasseroient :
+Bien que ta fole et volage inconstance
+Meriteroit auoir quelque soufrance.
+Telle est mo foy, qu’elle pourra sufire
+À te garder d’auoir mal et martire.
+Celui qui tient au haut Ciel son Empire
+Ne me sauroit, ce me semble, desdire :
+Mais quand mes pleurs et larmes entendroit
+Pour toy prians, son ire il retiendroit.
+I’ay de tout tems vescu en son seruice,
+Sans me sentir coulpable d’autre vice
+Que de t’auoir bien souuent en son lieu
+D’amour forcé, adoré comme Dieu.
+Desia deus fois depuis le promis terme
+De ton retour, Phebe ses cornes ferme,
+Sans que de bonne ou mauuaise fortune
+De toy, Ami, i’aye nouuelle aucune.
+Si toutefois, pour estre enamouré
+En autre lieu, tu as tant demeuré,
+Si s’ay ie bien que t’amie nouuelle
+À peine aura le renom d’estre telle,
+
+Soit en beauté, vertu, grace et faconde,
+Comme plusieurs gens sauuans par le monde
+M’ont fait à tort, ce croy ie, estre estimee.
+Mais qui pourra garder la renommee ?
+Non seulement en France suis flatee,
+Et beaucoup plus, que ne veus, exaltee.
+La terre aussi que Calpe et Pyrenee
+Auec la mer tiennent enuironnee,
+Du large Rhin les roulantes areines,
+Le beau païs auquel or’ te promeines,
+Ont entendu (tu me l’as fait à croire)
+Que gens d’esprit me donnent quelque gloire.
+Goute le bien que tant d’hommes desirent :
+Demeure au but ou tant d’autres aspirent :
+Et croy qu’ailleurs n’en auras une telle.
+Ie ne dy pas qu’elle ne soit plus belle :
+Mais que iamais femme ne t’aymera,
+Ne plus que moy d’honneur te portera.
+Maints grans Signeurs à mon amour pretendent,
+Et à me plaire et seruir prets se rendent,
+Ioutes et ieus, maintes belles deuises
+En ma faueur sont par eux entreprises :
+
+Et neanmoins tant peu ie m’en soucie,
+Que seulement ne les en remercie :
+Tu es tout seul, tout mon mal et mon bien :
+Avec toy tout, et sans toy ie n’ay rien :
+Et n’ayant rien qui plaise à ma pensee,
+De tout plaisir me treuue delaissee,
+Et pour plaisir, ennui saisir me vient.
+Le regretter et plorer me conuient,
+Et sur ce point entre en tel desconfort,
+Que mile fois ie souhaite la mort.
+Ainsi, Ami, ton absence lointeine
+Depuis deus mois me tient en cette peine.
+Ne viuant pas, mais mourant d’un Amour
+Lequel m’occit dix mile fois le iour.
+Reuien donq tot, si tu as quelque enuie
+De me reuoir encor’ un coup en vie.
+Et si la mort auant ton arriuee
+Ha de mon corps l’aymante ame priuee.
+Au moins un iour vien, habillé de deuil,
+Enuironner le tour de mon cercueil.
+Que plust à Dieu que lors fussent trouuez
+Ces quatre vers en blanc marbre engrauez.
+
+Par toy, Amy, tant vesqvi enflamee
+Qv’en langvissant par fev svis consvmmee,
+Qvi covve encor sovs ma cendre embrazee,
+Si ne la rends de tes plevrs apaizee.

--- a/poems/louise-labe/elegie-03.txt
+++ b/poems/louise-labe/elegie-03.txt
@@ -1,0 +1,111 @@
+Qvand lirez, ô Dames Lionnoises,
+Ces miens escrits pleins d’amoureuses noises,
+Quand mes regrets, ennuis, despirs et larmes
+M’orrez chanter en pitoyables carmes,
+Ne veuillez point condamner ma simplesse,
+Et ieune erreur de ma fole ieunesse,
+Si c’est erreur : mais qui dessous les Cieus
+Se peut vanter de n’estre vicieus ?
+L’un n’est content de sa sorte de vie,
+Et toujours porte à ses voisins enuie :
+L’un forcenant de voir la paix en terre,
+Par tous moyens tache y mettre la guerre :
+
+L’autre croyant pureté estre vice,
+À autre Dieu qu’Or, ne fait sacrifice :
+L’autre sa foy pariure il emploira
+À deceuoir quelcun qui le croira :
+L’un en mentant de sa langue lezarde,
+Mile brocars sur l’un et l’autre darde :
+Ie ne suis point sous ces planettes nee,
+Qui m’ussent pù tant faire infortunee.
+Onques ne fut mon œil marri, de voir
+Chez mon voisin mieux que chez moi pleuuoir.
+Onq ne mis noise ou discord entre amis :
+À faire gain iamais ne me soumis.
+Mentir, tromper, et abuser autrui,
+Tant m’a desplu, que mesdire de lui.
+Mais si en moy rien y ha d’imparfait,
+Qu’on blame Amour : c’est lui seul qui l’a fait.
+Sur mon verd aage en ses laqs il me prit,
+Lors qu’exerçoi mon corps et mon esprit
+En mile et mile euures ingenieuses,
+Qu’en peu de tems me rendit ennuieuses.
+Pour bien sauoir avec l’esguille peindre
+I’eusse entrepris la renommee esteindre
+
+De celle là, qui plus docte que sage,
+Auec Pallas comparoit son ouvrage.
+Qui m’ust vu lors en armes fiere aller,
+Porter la lance et bois faire voler,
+Le deuoir faire en l’estour furieus,
+Piquer, volter le cheval glorieus,
+Pour Bradamante, ou la haute Marphise,
+Seur de Roger, il m’ust, possible, prise.
+Mais quoy ? Amour ne put longuement voir.
+Mon cœur n’aymant que Mars et le sauoir :
+En me voulant donner autre souci.
+En souriant, il me disoit ainsi :
+Tu penses donq, ô Lionnaise Dame,
+Pouuoir fuir par ce moyen ma flame :
+Mais non feras, i’ai subiugué les Dieus
+Es bas Enfers, en la Mer et es Cieus.
+Et penses tu que n’aye tel pouuoir
+Sur les humeins, de leur faire savoir
+Qu’il n’y ha rien qui de ma main eschape ?
+Plus fort se pense et plus tot ie le frape.
+De me blamer quelquefois tu n’as honte.
+En te fiant en Mars, dont tu fais conte :
+
+Mais meintenant, voy si pour persister
+En le suiuant me pourras resister.
+Ainsi parloit, et tout eschaufé d’ire
+Hors de sa trousse une sagette il tire,
+Et decochant de son extrême force,
+Droit la tira contre ma tendre escorce :
+Foible harnois, pour bien couurir le cœur,
+Contre l’Archer qui toujours est vainqueur.
+La bresche faite, entre Amour en la place,
+Dont le repos premierement il chasse :
+Et de trauail qui me donne sans cesse,
+Boire, manger, et dormir ne me laisse.
+Il ne me chaut de soleil ne d’ombrage :
+Ie n’ay qu’Amour et feu en mon courage,
+Qui me desguise, et fait autre paroitre,
+Tant que ne peu moymesme me connoitre.
+Ie n’auois vu encore seize Hivers,
+Lors que i’entray en ces ennuis diuers :
+Et ià voici le treiziéme Esté
+Que mon cœur fut par Amour arresté.
+Le tems met fin aus hautes Pyramides,
+Le tems met fin ans fonteines humides :
+
+Il ne pardonne aus braues Colisees,
+Il met à fin les viles plus prisees :
+Finir aussi il ha acoutumé
+Le feu d’Amour tant soit il allumé :
+Mais, las ! en moy il semble qu’il augmente
+Avec le tems, et que plus me tourmente.
+Paris ayma Oenone ardamment,
+Mais son amour ne dura longuement :
+Medee fut aymee de Iason,
+Qui tôt après la mit hors sa maison.
+Si meritoient elles estre estimees,
+Et pour aymer leurs Amis, estre aymees.
+S’estant aymé on peut Amour laisser,
+N’est il raison, ne l’estant, se lasser ?
+N’est il raison te prier de permettre.
+Amour, que puisse à mes tourmens fin mettre ?
+Ne permets point que de Mort face espreuue,
+Et plus que toy pitoyable la treuue :
+Mais si tu veus que i’ayme iusqu’au bout,
+Fay que celui que i’estime mon tout,
+Qui seul me peut faire plorer et rire,
+Et pour lequel si souuent ie soupire,
+
+Sente en ses os, en son sang, en son ame,
+Ou plus ardente, ou bien égale flame
+Alors ton faix plus aisé me sera,
+Quand auec moy quelcun le portera.
+
+FIN DES ÉLÉGIES.

--- a/poems/louise-labe/sonnet-01.txt
+++ b/poems/louise-labe/sonnet-01.txt
@@ -1,0 +1,17 @@
+Non hauria Ulysse o qualunqu’altro mai
+Piu accorto fui, da quel diuino aspetto
+Pien di gratie, d’honor et di rispetto
+Sperato qual i sento affanni e guai.
+
+Pur, Amor, co i begli ochi tu fatt’ hai
+Tal piaga dentro al mio innocente petto,
+Di cibo et di calor gia tuo ricetto,
+Che rimedio non v’e si tu nol’ dai.
+
+O forte dura, che mi fa esser quale
+Punta d’un Scorpio, et domandar riparo
+Contr’ el velen’ d’all’ istesso animale.
+
+Chieggio li fol’ ancida questa noia,
+Non estingua el desir a me si caro,
+Che mancar non potra ch’ i non mi muoia.

--- a/poems/louise-labe/sonnet-02.txt
+++ b/poems/louise-labe/sonnet-02.txt
@@ -1,0 +1,17 @@
+Ô beaus yeus bruns, ô regards destournez,
+Ô chaus soupirs, ô larmes espandues,
+Ô noires nuits vainement attendues,
+Ô jours luisans vainement retournez :
+
+Ô tristes pleins, ô desirs obstinez,
+Ô tems perdu, ô peines despendues,
+Ô mile morts en mile rets tendues,
+Ô pires maus contre moi destinez.
+
+Ô ris, ô front, cheueus, bras, mains et doits :
+Ô lut pleintif, viole, archet et vois :
+Tant de flambeaus pour ardre une femelle !
+
+De toy me plein, que tant de feus portant,
+En tant d’endrois d’iceus mon cœur tatant,
+N’en est sur toy volé quelque estincelle.

--- a/poems/louise-labe/sonnet-03.txt
+++ b/poems/louise-labe/sonnet-03.txt
@@ -1,0 +1,17 @@
+Ô longs desirs, ô esperances vaines,
+Tristes soupirs et larmes coutumieres
+A engendrer de moy maintes riuieres,
+Dont mes deus yeus sont sources et fontaines :
+
+Ô cruautez, ô durtez inhumaines,
+Piteus regars des celestes lumieres :
+Du cœur transi ô passions premieres,
+Estimez-vous croitre encore mes peines ?
+
+Qu’encor Amour sur moy son arc essaie,
+Que nouueaus feus me gette et nouueaus dars :
+Qu’il se despite, et pis qu’il pourra face :
+
+Car ie suis tant nauree en toutes part,
+Que plus en moy une nouuelle plaie,
+Pour m’empirer ne pourroit trouuer place.

--- a/poems/louise-labe/sonnet-04.txt
+++ b/poems/louise-labe/sonnet-04.txt
@@ -1,0 +1,17 @@
+Depuis qu’Amour cruel empoisonna
+Premierement de son feu ma poitrine,
+Tousiours brulay de sa fureur diuine,
+Qui un seul iour mon cœur n’abandonna.
+
+Quelque trauail, dont assez me donna,
+Quelque menasse et procheine ruine :
+Quelque penser de mort qui tout termine,
+De rien mon cœur ardent ne s’estonna.
+
+Tant plus qu’Amour nous vient fort assaillir,
+Plus il nous fait nos forces recueillir,
+Et tousiours frais en ses combats fait estre :
+
+Mais ce n’est pas qu’en rien nous fauorise,
+Cil qui les Dieus et les hommes mesprise :
+Mais pour plus fort contre les fors paroitre.

--- a/poems/louise-labe/sonnet-05.txt
+++ b/poems/louise-labe/sonnet-05.txt
@@ -1,0 +1,17 @@
+Clere Venus, qui erres par les Cieus,
+Entens ma voix qui en pleins chantera,
+Tant que ta face au haut du Ciel luira,
+Son long travail et souci ennuieus.
+
+Mon œil veillant s’atendrira bien mieus,
+Et plus de pleurs te voyant gettera.
+Mieus mon lit mol de larmes baignera,
+De ses travaus voyant témoins tes yeus.
+
+Donq des humains sont les lassez esprits
+De dous repos et de sommeil espris.
+I’endure mal tant que le Soleil luit :
+
+Et quand ie suis quasi toute cassee,
+Et que me ſuis mise en mon lit lassee,
+Crier me faut mon mal toute la nuit.

--- a/poems/louise-labe/sonnet-06.txt
+++ b/poems/louise-labe/sonnet-06.txt
@@ -1,0 +1,17 @@
+Deus ou trois fois bienheureus le retour
+De ce cler Astre, et plus heureus encore
+Ce que son œil de regarder honore.
+Que celle là receuroit un bon iour,
+
+Qu’elle pourroit se vanter d’un bon tour
+Qui baiseroit le plus beau don de Flore,
+Le mieus sentant que iamais vid Aurore,
+Et y feroit sur ses leures seiour !
+
+C’est à moi seule à qui ce bien est du,
+Pour tant de pleurs et tant de tems perdu :
+Mais le voyant, tant luy feray de feste,
+
+Tant emploiray de mes yeus le pouuoir,
+Pour dessus lui plus de credit auoir,
+Qu’en peu de tems feroy grande conqueste.

--- a/poems/louise-labe/sonnet-07.txt
+++ b/poems/louise-labe/sonnet-07.txt
@@ -1,0 +1,17 @@
+On voit mourir toute chose animee,
+Lors que du corps l’ame sutile part :
+Ie suis le corps, toy la meilleure part :
+Ou es tu donq, ô ame bien aymee ?
+
+Ne me laissez pas si long tems pamee,
+Pour me sauuer après viendrois trop tard.
+Las, ne mets point ton corps en ce hazart :
+Rens lui sa part et moitié estimee.
+
+Mais fais, Ami, que ne soit dangereuse
+Cette rencontre et reuuë amoureuse,
+L’acompagnant, non de seuerite.
+
+Non de rigueur : mais de grace amiable,
+Qui doucement me rende ta beaute,
+Iadis cruelle, à present favorable.

--- a/poems/louise-labe/sonnet-08.txt
+++ b/poems/louise-labe/sonnet-08.txt
@@ -1,0 +1,17 @@
+Ie vis, ie meurs : ie me brule et me noye.
+I’ay chaut estreme en endurant froidure :
+La vie m’est et trop molle et trop dure.
+I’ay grans ennuis entremeslez de ioye :
+
+Tout à un coup ie ris et ie larmoye,
+Et en plaisir maint grief tourment i’endure :
+Mon bien s’en va, et à iamais il dure :
+Tout en un coup ie seiche et ie verdoye.
+
+Ainsi Amour inconstamment me meine :
+Et quand ie pense avoir plus de douleur,
+Sans y penser ie me treuue hors de peine.
+
+Puis quand ie croy ma ioye estre certeine,
+Et estre au haut de mon desiré heur,
+Il me remet en mon premier malheur.

--- a/poems/louise-labe/sonnet-09.txt
+++ b/poems/louise-labe/sonnet-09.txt
@@ -1,0 +1,17 @@
+Tout aussi tot que ie commence à prendre
+Dens le mol lit le repos desiré,
+Mon triste esprit hors de moy retiré
+S’en va vers toy incontinent se rendre.
+
+Lors m’est auis que dedens mon sein tendre
+Ie tiens le bien, ou i’ay tant aspiré,
+Et pour lequel i’ay si haut souspiré ;
+Que de sanglots ay souuent cuidé fendre.
+
+Ô dous sommeil, ô nuit à moy heureuse !
+Plaisant repos, plein de tranquilité,
+Continuez toutes les nuiz mon songe :
+
+Et si iamais ma poure ame amoureuse
+Ne doit auoir de bien en vérité.
+Faites au moins qu’elle en ait en mensonge.

--- a/poems/louise-labe/sonnet-10.txt
+++ b/poems/louise-labe/sonnet-10.txt
@@ -1,0 +1,17 @@
+Quand i’aperçoy ton blond chef couronné
+D’un laurier verd, faire un Lut si bien pleindre,
+Que tu pourrois à te suiure contreindre
+Arbres et rocs : quand ie te vois orné,
+
+Et de vertus dix mile enuironné,
+Au chef d’honneur plus haut que nul atteindre :
+Et des plus hauts les louenges esteindre :
+Lors dit mon cœur en soy passionné :
+
+Tant de vertus qui le font estre aymé,
+Qui de chacun te font estre estimé,
+Ne te pourroient aussi bien faire aymer ?
+
+Et aioutant à ta vertu louable
+Ce nom encor de m’estre pitoyable,
+De mon amour doucement t’enflamer ?

--- a/poems/louise-labe/sonnet-11.txt
+++ b/poems/louise-labe/sonnet-11.txt
@@ -1,0 +1,17 @@
+Ô dous regars, ô yeus pleins de beauté,
+Petis iardins, pleins de fleurs amoureuses
+Ou sont d’Amour les flesches dangereuses,
+Tant à vous voir mon œil s’est arresté !
+
+Ô cœur félon, ô rude cruauté,
+Tant tu me tiens de façons rigoureuses,
+Tant i’ay coulé de larmes langoureuses,
+Sentant l’ardeur de mon cœur tourmenté !
+
+Donques, mes yeus, tant de plaisir auez,
+Tant de bons tours par ses yeux receuez :
+Mais toy, mon cœur, plus les vois s’y complaire,
+
+Plus tu languiz, plus en as de souci,
+Or deuinez si ie suis aise aussi,
+Sentant mon œil estre à mon cœur contraire.

--- a/poems/louise-labe/sonnet-12.txt
+++ b/poems/louise-labe/sonnet-12.txt
@@ -1,0 +1,17 @@
+Lut, compagnon de ma calamité,
+De mes soupirs témoin irreprochable,
+De mes ennuis controlleur veritable,
+Tu as souuent avec moy lamenté :
+
+Et tant le pleur piteus t’a molesté,
+Que commençant quelque son delectable,
+Tu le rendois tout soudein lamentable,
+Feingnant le ton que plein auoit chanté.
+
+Et si tu veux efforcer au contraire,
+Tu te destens et si me contreins taire :
+Mais me voyant tendrement soupirer,
+
+Donnant fauueur à ma tant triste pleinte,
+En mes ennuis me plaire suis contreinte,
+Et dous mal douce fin espérer.

--- a/poems/louise-labe/sonnet-13.txt
+++ b/poems/louise-labe/sonnet-13.txt
@@ -1,0 +1,17 @@
+Oh si i’estois en ce beau sein rauie
+De celui là pour lequel vois mourant :
+Si auec lui viure le demeurant
+De mes cours iours ne m’empeschoit enuie,
+
+Si m’acollant me disoit, chere Amie,
+Contentons nous l’un l’autre, s’asseurant
+Que ia tempeste, Euripe, ne Courant
+Ne nous pourra desioindre en notre vie :
+
+Si de mes bras le tenant acollé,
+Comme du Lierre est l’arbre encercelé,
+La mort venoit, de mon aise enuieuse :
+
+Lors que souef il me baiseroit,
+Et mon esprit sur ses leures fuiroit,
+Bien ie mourrois, plus que viuante, heureuse.

--- a/poems/louise-labe/sonnet-14.txt
+++ b/poems/louise-labe/sonnet-14.txt
@@ -1,0 +1,17 @@
+Tant que mes yeus pourront larmes espandre,
+À leur passé auec toy regretter ;
+Et qu’aus sanglots et soupirs resister
+Pourra ma voix, et un peu faire entendre :
+
+Tant que ma main pourra les cordes tendre
+Du mignart Lut, pour ces graces chanter :
+Tant que l’esprit se voudra contenter
+De ne vouloir rien fors que toy comprendre :
+
+Ie ne souhaitte encore point mourir.
+Mais quand mes yeus ie sentiray tarir,
+Ma voix cassee, et ma main impuissante,
+
+Et mon esprit en ce mortel seiour
+Ne pouuant plus montrer signe d’amante :
+Priray la mort noircir mon plus cler iour.

--- a/poems/louise-labe/sonnet-15.txt
+++ b/poems/louise-labe/sonnet-15.txt
@@ -1,0 +1,17 @@
+Pour le retour du Soleil honorer,
+Le Zéphir, l’air serein lui apareille :
+Et du sommeil l’eau et la terre esueille,
+Qui les gardoit l’une de murmurer
+
+En dous coulant, l’autre de se parer
+De mainte fleur de couleur nompareille.
+Ia les oiseaus es arbres font merveille,
+Et aus passans font l’ennui moderer :
+
+Les Nymfes ia en mille ieus s’esbatent
+Au cler de Lune, et dansans l’herbe abatent :
+Veus tu Zéphir de ton heur me donner,
+
+Et que par toy toute me renouuelle ?
+Fay mon Soleil deuers moy retourner,
+Et tu verras s’il ne me rend plus belle.

--- a/poems/louise-labe/sonnet-16.txt
+++ b/poems/louise-labe/sonnet-16.txt
@@ -1,0 +1,17 @@
+Apres qu’un tems la gresle et le tonnerre
+Ont le haut mont de Caucase batu,
+Le beau iour vient, de lueur reuétu.
+Quand Phebus ha son cerne fait en terre,
+
+Et l’Ocean il regaigne à grand erre
+Sa seur se montre avec son chef pointu.
+Quand quelque tems le Parthe ha combatu,
+Il prent la fuite et son arc il desserre.
+
+Un tems t’ay vù et consolé pleintif,
+Et defiant de mon feu peu hatif :
+Mais maintenant que tu m’as embrassee,
+
+Et fuis au point auquel tu me voulois,
+Tu as ta flame en quelque eau arrosee,
+Et es plus froit qu’estre ie ne soulois.

--- a/poems/louise-labe/sonnet-17.txt
+++ b/poems/louise-labe/sonnet-17.txt
@@ -1,0 +1,17 @@
+Ie fuis la vile, et temples et tous lieus,
+Esquels prenant plaisir à t’ouir pleindre,
+Tu peus, et non sans force, me contreindre
+De te donner ce qu’estimois le mieus.
+
+Masques, tournois, ieus me sont ennuieus,
+Et rien sans toy de beau ne me puis peindre :
+Tant que tachant à ce désir esteindre,
+Et un nouuel obget faire à mes yeus,
+
+Et des pensers amoureus me distraire,
+Des bois espais sui le plus solitaire :
+Mais i’aperçoy, ayant erré maint tour,
+
+Que si ie veus de toy estre deliure,
+Il me conuient hors de moymesme viure.
+Ou fais encor que loin sois en seiour.

--- a/poems/louise-labe/sonnet-18.txt
+++ b/poems/louise-labe/sonnet-18.txt
@@ -1,0 +1,17 @@
+Baise m’encor, rebaise moy et baise :
+Donne m’en un de tes plus sauoureus,
+Donne m’en un de tes plus amoureus :
+Ie t’en rendray quatre plus chaus que braise.
+
+Las, te pleins tu ? ça que ce mal i’apaise,
+En t’en donnant dix autres doucereus.
+Ainsi meslans nos baisers tant heureus
+Iouissons nous l’un de l’autre à notre aise.
+
+Lors double vie à chacun en suiura.
+Chacun en soy et son ami viura.
+Permets m’Amour penser quelque folie :
+
+Tousiours suis mal, viuant discrettement
+Et ne me puis donner contentement.
+Si hors de moy ne fay quelque saillie.

--- a/poems/louise-labe/sonnet-19.txt
+++ b/poems/louise-labe/sonnet-19.txt
@@ -1,0 +1,17 @@
+Diane estant en l’espesseur d’un bois,
+Apres avoir mainte beste assenee,
+Prenait le frais, de Nynfes couronnee :
+I’allois resuant comme fay maintefois,
+
+Sans y penser : quand i’ouy une vois,
+Qui m’apela, disant, Nymfe estonnee,
+Que ne t’es tu vers Diane tournee ?
+Et me voyant sans arc et sans carquois,
+
+Qu’as tu trouué, ô campagne, en ta voye,
+Qui de ton arc et flesches ait fait proye ?
+Ie m’animay, respons ie, à un passant,
+
+Et lui getay en vain toutes mes flesches
+Et l’arc apres : mais lui les ramassant
+Et les tirant me fit cent et cent bresches.

--- a/poems/louise-labe/sonnet-20.txt
+++ b/poems/louise-labe/sonnet-20.txt
@@ -1,0 +1,17 @@
+Prédit me fut, que deuoit fermement
+Un iour aymer celui dont la figure
+Me fut descrite : et sans autre peinture
+Le reconnu quand vy premierement :
+
+Puis le voyant aymer fatalement,
+Pitié ie pris de sa triste auenture :
+Et tellement ie forçay ma nature,
+Qu’autant que lui aymay ardentement.
+
+Qui n’ust pensé qu’en faueur deuoit croitre
+Ce que le Ciel et destins firent naitre ?
+Mais quand ie voy si nubileus aprets,
+
+Vents si cruels et tant horrible orage :
+Ie croy qu’estoient les infernaus arrets,
+Qui de si loin m’ourdissoient ce naufrage.

--- a/poems/louise-labe/sonnet-21.txt
+++ b/poems/louise-labe/sonnet-21.txt
@@ -1,0 +1,17 @@
+Quelle grandeur rend l’homme venerable ?
+Quelle grosseur ? quel poil ? quelle couleur ?
+Qui est des yeux le plus emmieleur ?
+Qui fait plus tot une playe incurable ?
+
+Quel chant est plus à l’homme conuenable ?
+Qui plus penetre en chantant sa douleur ?
+Qui un dous lut fait encore meilleur ?
+Quel naturel est le plus amiable ?
+
+Ie ne voudrois le dire assurément,
+Ayant Amour forcé mon iugement :
+Mais ie fay bien et de tant ie m’assure,
+
+Que tout le beau que lon pourroit choisir,
+Et que tout l’art qui ayde la Nature,
+Ne me sauroient acroitre mon desir.

--- a/poems/louise-labe/sonnet-22.txt
+++ b/poems/louise-labe/sonnet-22.txt
@@ -1,0 +1,17 @@
+Luisant Soleil, que tu es bien heureus,
+De voir tousiours de t’Amie la face :
+Et toy, sa seur, qu’Endimion embrasse,
+Tant te repais de miel amoureus.
+
+Mars voit Venus : Mercure auentureus
+De Ciel en Ciel, de lieu en lieu se glasse :
+Et Iupiter remarque en mainte place
+Ses premiers ans plus gays et chaleureus.
+
+Voilà du Ciel la puissante harmonie,
+Qui les esprits diuins ensemble lie :
+Mais s’ils auoient ce qu’ils ayment lointein,
+
+Leur harmonie et ordre irreuocable
+Se tourneroit en erreur variable,
+Et comme moy travailleroient en vain.

--- a/poems/louise-labe/sonnet-23.txt
+++ b/poems/louise-labe/sonnet-23.txt
@@ -1,0 +1,17 @@
+Las ! que me sert, que si parfaitement
+Louas iadis et ma tresse doree,
+Et de mes yeux la beauté comparee
+À deus Soleils, dont Amour finement
+
+Tira les trets causez de ton tourment ?
+Ou estes vous, pleurs de peu de duree ?
+Et Mort par qui deuoit estre honoree
+Ta ferme amour et iteré serment ?
+
+Donques c’estoit le but de ta malice
+De m’asseruir sous ombre de seruice ?
+Pardonne moy Ami, à cette fois,
+
+Estant outree et de despit et d’ire :
+Mais ie m’assure, quelque part que tu sois,
+Qu’autant que moy tu soufres de martire.

--- a/poems/louise-labe/sonnet-24.txt
+++ b/poems/louise-labe/sonnet-24.txt
@@ -1,0 +1,17 @@
+Ne reprenez, Dames, si i’ay aymé :
+Si i’ay senti mile torches ardantes,
+Mile trauaus, mile douleurs mordantes :
+Si en pleurant i’ay mon temps consumé,
+
+Las que mon nom n’en soit par vous blamé.
+Si i’ai failli, les peines sont presentes.
+N’aigrissez point leurs pointes violentes :
+Mais estimez qu’Amour, à point nommé,
+
+Sans votre ardeur d’un Vulcan excuser,
+Sans la beauté d’Adonis acuser,
+Pourra, s’il veut, plus vous rendre amoureuses.
+
+En ayant moins que moy d’ocasion,
+Et plus d’estrange et forte passion.
+Et gardez vous d’estre plus malheureuses.

--- a/scripts/ingest-wikisource-becquer-rimas.mjs
+++ b/scripts/ingest-wikisource-becquer-rimas.mjs
@@ -1,0 +1,204 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const AUTHOR = {
+  author: "Gustavo Adolfo Bécquer",
+  author_slug: "gustavo-adolfo-becquer",
+  century: 19,
+  collection_title: "Rimas (1925)",
+  collection_source_url: "https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)",
+  published_year: 1925,
+  text_locale: "es",
+  original_language: "es",
+  text_direction: "ltr",
+};
+
+function toRoman(value) {
+  const map = [
+    [1000, "M"],
+    [900, "CM"],
+    [500, "D"],
+    [400, "CD"],
+    [100, "C"],
+    [90, "XC"],
+    [50, "L"],
+    [40, "XL"],
+    [10, "X"],
+    [9, "IX"],
+    [5, "V"],
+    [4, "IV"],
+    [1, "I"],
+  ];
+
+  let remaining = value;
+  let result = "";
+  for (const [n, symbol] of map) {
+    while (remaining >= n) {
+      result += symbol;
+      remaining -= n;
+    }
+  }
+  return result;
+}
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#8195;/g, "")
+    .replace(/&#91;/g, "[")
+    .replace(/&#93;/g, "]")
+    .replace(/&#95;/g, "_")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…");
+}
+
+function cleanRenderedText(html) {
+  let body = html.includes('<div class="prp-pages-output"')
+    ? html.slice(html.indexOf('<div class="prp-pages-output"'))
+    : html;
+  const referencesIndex = body.indexOf('<div class="mw-references-wrap');
+  if (referencesIndex !== -1) body = body.slice(0, referencesIndex);
+
+  body = body.replace(/<style[\s\S]*?<\/style>/g, "");
+  body = body.replace(/<link[^>]*>/g, "");
+  body = body.replace(/<sup[^>]*>.*?<\/sup>/gs, "");
+  body = body.replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+  body = body.replace(/<span[^>]*class="wst-gap[^"]*"[^>]*><\/span>/g, "    ");
+  body = body.replace(/<br\s*\/?>\n?/g, "\n");
+  body = body.replace(/<\/p>\s*<p>/g, "\n\n");
+  body = body.replace(/<[^>]+>/g, "");
+
+  return decodeHtml(body)
+    .replace(/\u00a0/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchText(url) {
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync("curl", ["-L", "--fail", "--silent", url], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return stdout;
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      }
+    }
+  }
+  throw lastError;
+}
+
+async function fetchRenderedText(pageTitle) {
+  const url =
+    "https://es.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  const stdout = await fetchText(url);
+  const json = JSON.parse(stdout);
+  if (!json.parse?.text) throw new Error(`Wikisource parse failed for ${pageTitle}`);
+  return cleanRenderedText(json.parse.text);
+}
+
+async function listPoemNumbers() {
+  const html = await fetchText(AUTHOR.collection_source_url);
+  const matches = html.match(/href="\/wiki\/Rimas_\([^)]+,_1925\)\/Rima_(\d+)"/g) || [];
+  const numbers = new Set();
+  for (const match of matches) {
+    const num = Number(match.match(/Rima_(\d+)"/)?.[1]);
+    if (Number.isFinite(num)) numbers.add(num);
+  }
+  return Array.from(numbers).sort((a, b) => a - b);
+}
+
+function extractPoem(text, numeral) {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  const numeralIndex = lines.findIndex((line) => line.trim() === numeral);
+  if (numeralIndex === -1) throw new Error(`Heading ${numeral} not found`);
+
+  return lines
+    .slice(numeralIndex + 1)
+    .filter(Boolean)
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function buildMeta(number, numeral) {
+  const slug = `rima-${String(number).padStart(3, "0")}`;
+  return yaml.dump(
+    {
+      id: `${AUTHOR.author_slug}/${slug}`,
+      slug,
+      author: AUTHOR.author,
+      author_slug: AUTHOR.author_slug,
+      title: `Rima ${numeral}`,
+      century: AUTHOR.century,
+      text_locale: AUTHOR.text_locale,
+      original_language: AUTHOR.original_language,
+      text_direction: AUTHOR.text_direction,
+      text_path: `poems/${AUTHOR.author_slug}/${slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: `https://es.wikisource.org/wiki/Rimas_(B%C3%A9cquer,_1925)/Rima_${number}`,
+      public_domain_rationale:
+        "Public domain in the United States: this edition was published in 1925 (pre-1929) and the author died in 1870; text via Spanish Wikisource.",
+      collection_title: AUTHOR.collection_title,
+      collection_source_url: AUTHOR.collection_source_url,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  const poemsDir = path.join("poems", AUTHOR.author_slug);
+  const metaDir = path.join("meta", AUTHOR.author_slug);
+  await fs.mkdir(poemsDir, { recursive: true });
+  await fs.mkdir(metaDir, { recursive: true });
+
+  const poemNumbers = await listPoemNumbers();
+  if (poemNumbers.length !== 76) {
+    throw new Error(`Expected 76 rimas, found ${poemNumbers.length}`);
+  }
+
+  for (const number of poemNumbers) {
+    const numeral = toRoman(number);
+    const pageTitle = `Rimas (Bécquer, 1925)/Rima ${number}`;
+    const rendered = await fetchRenderedText(pageTitle);
+    const text = extractPoem(rendered, numeral);
+    const slug = `rima-${String(number).padStart(3, "0")}`;
+
+    await fs.writeFile(path.join(poemsDir, `${slug}.txt`), `${text}\n`, "utf8");
+    await fs.writeFile(path.join(metaDir, `${slug}.yml`), buildMeta(number, numeral), "utf8");
+    console.log(`${AUTHOR.author}: created ${slug}`);
+  }
+
+  console.log(`Total created: ${poemNumbers.length}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/scripts/ingest-wikisource-louise-labe.mjs
+++ b/scripts/ingest-wikisource-louise-labe.mjs
@@ -1,0 +1,278 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const AUTHOR = {
+  author: "Louise Labé",
+  author_slug: "louise-labe",
+  century: 16,
+  collection_title: "Élégies et Sonnets",
+  collection_source_url: "https://fr.wikisource.org/wiki/%C3%89l%C3%A9gies_et_Sonnets",
+  published_year: 1555,
+  text_locale: "fr",
+  original_language: "fr",
+  text_direction: "ltr",
+};
+
+const SONNET_ONE_TEXT = `Non hauria Ulysse o qualunqu’altro mai
+Piu accorto fui, da quel diuino aspetto
+Pien di gratie, d’honor et di rispetto
+Sperato qual i sento affanni e guai.
+
+Pur, Amor, co i begli ochi tu fatt’ hai
+Tal piaga dentro al mio innocente petto,
+Di cibo et di calor gia tuo ricetto,
+Che rimedio non v’e si tu nol’ dai.
+
+O forte dura, che mi fa esser quale
+Punta d’un Scorpio, et domandar riparo
+Contr’ el velen’ d’all’ istesso animale.
+
+Chieggio li fol’ ancida questa noia,
+Non estingua el desir a me si caro,
+Che mancar non potra ch’ i non mi muoia.`;
+
+function toRoman(value) {
+  const map = [
+    [1000, "M"],
+    [900, "CM"],
+    [500, "D"],
+    [400, "CD"],
+    [100, "C"],
+    [90, "XC"],
+    [50, "L"],
+    [40, "XL"],
+    [10, "X"],
+    [9, "IX"],
+    [5, "V"],
+    [4, "IV"],
+    [1, "I"],
+  ];
+
+  let remaining = value;
+  let result = "";
+  for (const [n, symbol] of map) {
+    while (remaining >= n) {
+      result += symbol;
+      remaining -= n;
+    }
+  }
+  return result;
+}
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#8195;/g, "")
+    .replace(/&#91;/g, "[")
+    .replace(/&#93;/g, "]")
+    .replace(/&#95;/g, "_")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…")
+    .replace(/&#x25c4;/gi, "")
+    .replace(/&#x25ba;/gi, "");
+}
+
+function cleanRenderedText(html) {
+  let body = html.includes('<div class="prp-pages-output"')
+    ? html.slice(html.indexOf('<div class="prp-pages-output"'))
+    : html;
+  const referencesIndex = body.indexOf('<div class="mw-references-wrap');
+  if (referencesIndex !== -1) body = body.slice(0, referencesIndex);
+
+  body = body.replace(/<style[\s\S]*?<\/style>/g, "");
+  body = body.replace(/<link[^>]*>/g, "");
+  body = body.replace(/<sup[^>]*>.*?<\/sup>/gs, "");
+  body = body.replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+  body = body.replace(/<span[^>]*class="wst-gap[^"]*"[^>]*><\/span>/g, "    ");
+  body = body.replace(/<br\s*\/?>\n?/g, "\n");
+  body = body.replace(/<\/p>\s*<p>/g, "\n\n");
+  body = body.replace(/<[^>]+>/g, "");
+
+  return decodeHtml(body)
+    .replace(/\u00a0/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchText(url) {
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync("curl", ["-L", "--fail", "--silent", url], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return stdout;
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      }
+    }
+  }
+  throw lastError;
+}
+
+async function fetchRenderedText(pageTitle = "Élégies et Sonnets/Texte_entier") {
+  const url =
+    "https://fr.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  const stdout = await fetchText(url);
+  const json = JSON.parse(stdout);
+  if (!json.parse?.text) throw new Error(`Wikisource parse failed for ${pageTitle}`);
+  return cleanRenderedText(json.parse.text);
+}
+
+function extractPoems(text) {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  const start = lines.findIndex(
+    (line, index) =>
+      line.trim() === "ÉLÉGIES" &&
+      lines[index + 1]?.trim() === "ÉLÉGIES" &&
+      /^[IVXLCDM]+$/.test(lines[index + 3]?.trim() || ""),
+  );
+  if (start === -1) throw new Error("Poem section start not found");
+
+  const end = lines.findIndex((line, index) => index > start && line.trim() === "fin des evvres de lovïze labe lionnoize");
+  if (end === -1) throw new Error("Poem section end not found");
+
+  let currentKind = "elegie";
+  let currentLines = [];
+  let elegyIndex = 0;
+  let sonnetIndex = 0;
+  const poems = [];
+
+  const flush = () => {
+    if (currentLines.length === 0) return;
+    if (currentKind === "elegie") elegyIndex += 1;
+    else sonnetIndex += 1;
+
+    const index = currentKind === "elegie" ? elegyIndex : sonnetIndex;
+    poems.push({
+      kind: currentKind,
+      index,
+      text: currentLines.join("\n").replace(/\n{3,}/g, "\n\n").trim(),
+    });
+    currentLines = [];
+  };
+
+  for (const line of lines.slice(start + 2, end)) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      if (currentLines.length > 0) currentLines.push("");
+      continue;
+    }
+    if (trimmed === "ÉLÉGIES" || trimmed === "LES ÉLÉGIES") continue;
+    if (trimmed === "SONNETS") {
+      flush();
+      currentKind = "sonnet";
+      continue;
+    }
+    if (/^[IVXLCDM]+$/.test(trimmed)) {
+      flush();
+      continue;
+    }
+    currentLines.push(line);
+  }
+
+  flush();
+
+  if (poems.length !== 26) {
+    throw new Error(`Expected 26 poems from full text, found ${poems.length}`);
+  }
+
+  for (const poem of poems) {
+    if (poem.kind === "sonnet") poem.index += 1;
+  }
+
+  return poems;
+}
+
+function buildMeta(kind, index, overrides = {}) {
+  const numeral = toRoman(index);
+  const slug = `${kind}-${String(index).padStart(2, "0")}`;
+  const title = `${kind === "elegie" ? "Élégie" : "Sonnet"} ${numeral}`;
+  return yaml.dump(
+    {
+      id: `${AUTHOR.author_slug}/${slug}`,
+      slug,
+      author: AUTHOR.author,
+      author_slug: AUTHOR.author_slug,
+      title,
+      century: AUTHOR.century,
+      text_locale: overrides.text_locale ?? AUTHOR.text_locale,
+      original_language: overrides.original_language ?? AUTHOR.original_language,
+      text_direction: overrides.text_direction ?? AUTHOR.text_direction,
+      text_path: `poems/${AUTHOR.author_slug}/${slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: AUTHOR.collection_source_url,
+      public_domain_rationale:
+        "Public domain in the United States: first published in 1555 (pre-1929); text via French Wikisource.",
+      collection_title: AUTHOR.collection_title,
+      collection_source_url: AUTHOR.collection_source_url,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function writePoem(poem) {
+  const poemsDir = path.join("poems", AUTHOR.author_slug);
+  const metaDir = path.join("meta", AUTHOR.author_slug);
+  await fs.mkdir(poemsDir, { recursive: true });
+  await fs.mkdir(metaDir, { recursive: true });
+
+  const slug = `${poem.kind}-${String(poem.index).padStart(2, "0")}`;
+  await fs.writeFile(path.join(poemsDir, `${slug}.txt`), `${poem.text}\n`, "utf8");
+  await fs.writeFile(
+    path.join(metaDir, `${slug}.yml`),
+    buildMeta(poem.kind, poem.index, poem),
+    "utf8",
+  );
+  console.log(`${AUTHOR.author}: created ${slug}`);
+}
+
+async function main() {
+  const collectionRendered = await fetchRenderedText();
+  const poems = extractPoems(collectionRendered);
+  poems.unshift({
+    kind: "sonnet",
+    index: 1,
+    text: SONNET_ONE_TEXT,
+    text_locale: "it",
+    original_language: "it",
+  });
+
+  if (poems.length !== 27) {
+    throw new Error(`Expected 27 poems total, found ${poems.length}`);
+  }
+
+  for (const poem of poems) {
+    await writePoem(poem);
+  }
+  console.log(`Total created: ${poems.length}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/site/scripts/build-search-index.mjs
+++ b/site/scripts/build-search-index.mjs
@@ -118,6 +118,8 @@ async function main() {
       title: poem.title,
       author: poem.author,
       century: poem.century,
+      text_locale: poem.text_locale,
+      original_language: poem.original_language,
       excerpt,
       collections: collections.map((collection) => collection.title),
       themes,
@@ -127,6 +129,8 @@ async function main() {
         [
           poem.title,
           poem.author,
+          poem.text_locale,
+          poem.original_language,
           excerpt,
           collections.map((collection) => `${collection.title} ${collection.description}`).join(" "),
           themes.join(" "),

--- a/site/src/lib/authors.ts
+++ b/site/src/lib/authors.ts
@@ -239,4 +239,18 @@ export const AUTHOR_INFO: Record<string, AuthorInfo> = {
     source_label: "Wikipedia",
     source_url: "https://en.wikipedia.org/wiki/John_Greenleaf_Whittier",
   },
+  "gustavo-adolfo-becquer": {
+    birth_year: 1836,
+    death_year: 1870,
+    bio: "Spanish poet and writer whose posthumously collected 'Rimas' became a foundational lyric sequence for modern Spanish poetry.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Gustavo_Adolfo_B%C3%A9cquer",
+  },
+  "louise-labe": {
+    birth_year: 1524,
+    death_year: 1566,
+    bio: "French Renaissance poet from Lyon celebrated for her elegies and sonnets of desire, absence, and emotional contradiction.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Louise_Lab%C3%A9",
+  },
 };

--- a/site/src/lib/search-taxonomy.mjs
+++ b/site/src/lib/search-taxonomy.mjs
@@ -83,12 +83,14 @@ const THEME_LOOKUP = new Map(
 
 export function normalizeSearchText(value) {
   return value
+    .normalize("NFKD")
     .toLowerCase()
     .replace(/\r\n?/g, "\n")
+    .replace(/\p{M}+/gu, "")
     .replace(/[‘’]/g, "'")
     .replace(/[“”]/g, '"')
     .replace(/[—–]/g, "-")
-    .replace(/[^a-z0-9\s-]/g, " ")
+    .replace(/[^\p{L}\p{N}\s-]/gu, " ")
     .replace(/\s+/g, " ")
     .trim();
 }


### PR DESCRIPTION
## Summary
- add complete public-domain lyric corpora for Gustavo Adolfo Bécquer and Louise Labé from approved Wikisource sources
- register both authors in the site author registry
- make search normalization Unicode-aware and carry poem locale metadata into the search index

## Validation
- `cd site && npm run build`
- poem index: 488 poems
- duplicate clusters: 0
- near-variant candidates: 0

## Copyright
- sources limited to Wikisource
- all texts are public domain in the United States
- Louise Labé Sonnet I was transcribed from the linked Wikisource scan page for the same pre-1929 edition because the collection transclusion omitted that poem in API output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added 76 poems from Gustavo Adolfo Bécquer's *Rimas* collection (1925 edition)
  * Added 24 poems from Louise Labé's *Élégies et Sonnets* collection
  * Introduced author profiles for both Bécquer and Labé with biographical information

* **Improvements**
  * Enhanced search functionality with improved Unicode character handling for better multilingual support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->