### PR TITLE
Expose source provenance in poem JSON-LD (#130)

### DIFF
--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -53,6 +53,13 @@ const poemStructuredData = {
   isAccessibleForFree: true,
   description,
   text: excerpt || undefined,
+  isBasedOn: poem.source_url
+    ? {
+        "@type": "CreativeWork",
+        url: poem.source_url,
+        name: poem.source_label ?? undefined,
+      }
+    : undefined,
   translator: poem.translator
     ? {
         "@type": "Person",


### PR DESCRIPTION
Closes #130.

## What changed
- added `isBasedOn` to poem-page `Poem` JSON-LD when `source_url` is present
- uses upstream public-domain source URLs without exposing repo-local implementation details
- keeps the payload compact by emitting only URL and source label

## Verification
- `cd site && npm run build`
- verified built HTML for `/poem/alfred-tennyson/ulysses/` contains `isBasedOn` pointing to `https://www.gutenberg.org/ebooks/8601`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved structured metadata for poems to better represent source attribution information when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->