### PR TITLE
Add sitemap for Freeverse

### DIFF
--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://thefreeverse.org/sitemap.xml

--- a/site/src/lib/sitemap.ts
+++ b/site/src/lib/sitemap.ts
@@ -1,0 +1,59 @@
+import type { PoemMeta } from './poems';
+import type { CollectionWithPoems } from './collections';
+
+function normalizeBaseUrl(siteUrl: string): string {
+  return siteUrl.endsWith('/') ? siteUrl : `${siteUrl}/`;
+}
+
+export function buildSitemapUrls(
+  siteUrl: string,
+  poems: PoemMeta[],
+  collections: CollectionWithPoems[],
+): string[] {
+  const base = normalizeBaseUrl(siteUrl);
+  const authors = Array.from(new Set(poems.map((poem) => poem.author_slug))).sort();
+  const poemIds = poems.map((poem) => poem.id).sort();
+  const collectionSlugs = collections.map((collection) => collection.slug).sort();
+
+  const staticPaths = [
+    '',
+    'browse/',
+    'authors/',
+    'search/',
+    'collections/',
+    'favorites/',
+    'easter/',
+    'freeversebrowse/',
+  ];
+
+  const urls = new Set(staticPaths.map((path) => `${base}${path}`));
+
+  authors.forEach((slug) => {
+    urls.add(`${base}author/${slug}/`);
+  });
+
+  poemIds.forEach((id) => {
+    urls.add(`${base}poem/${id}/`);
+    urls.add(`${base}freeversepoem/${id}/`);
+  });
+
+  collectionSlugs.forEach((slug) => {
+    urls.add(`${base}collections/${slug}/`);
+  });
+
+  return Array.from(urls).sort();
+}
+
+export function buildSitemapXml(urls: string[]): string {
+  const body = urls
+    .map((url) => `  <url>\n    <loc>${url}</loc>\n  </url>`)
+    .join('\n');
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    body,
+    '</urlset>',
+    '',
+  ].join('\n');
+}

--- a/site/src/pages/sitemap.xml.ts
+++ b/site/src/pages/sitemap.xml.ts
@@ -1,0 +1,26 @@
+import type { APIRoute } from 'astro';
+import { loadCollections } from '../lib/collections';
+import { loadPoemMetas } from '../lib/poems';
+import { buildSitemapUrls, buildSitemapXml } from '../lib/sitemap';
+
+export const prerender = true;
+
+export const GET: APIRoute = async ({ site }) => {
+  if (!site) {
+    throw new Error('Astro site URL is required to build sitemap.xml');
+  }
+
+  const [poems, collections] = await Promise.all([
+    loadPoemMetas(),
+    loadCollections(),
+  ]);
+
+  const urls = buildSitemapUrls(site.toString(), poems, collections);
+  const xml = buildSitemapXml(urls);
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+};

--- a/site/tests/unit/sitemap.test.ts
+++ b/site/tests/unit/sitemap.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildSitemapUrls, buildSitemapXml } from '../../src/lib/sitemap';
+
+describe('sitemap', () => {
+  it('builds stable urls for static and dynamic routes', () => {
+    const urls = buildSitemapUrls(
+      'https://thefreeverse.org',
+      [
+        {
+          id: 'emily-dickinson/because-i-could-not-stop-for-death',
+          slug: 'because-i-could-not-stop-for-death',
+          author: 'Emily Dickinson',
+          author_slug: 'emily-dickinson',
+          title: 'Because I could not stop for Death',
+          century: 19,
+          text_locale: 'en',
+          original_language: 'en',
+          text_direction: 'ltr',
+          text_in_repo: true,
+        },
+        {
+          id: 'walt-whitman/o-captain-my-captain',
+          slug: 'o-captain-my-captain',
+          author: 'Walt Whitman',
+          author_slug: 'walt-whitman',
+          title: 'O Captain! My Captain!',
+          century: 19,
+          text_locale: 'en',
+          original_language: 'en',
+          text_direction: 'ltr',
+          text_in_repo: true,
+        },
+      ],
+      [
+        {
+          slug: 'grief-and-mortality',
+          title: 'Grief and Mortality',
+          dek: 'Elegies and reckonings.',
+          description: 'A first curated path through grief.',
+          poemIds: [],
+          poems: [],
+        },
+      ],
+    );
+
+    expect(urls).toContain('https://thefreeverse.org/');
+    expect(urls).toContain('https://thefreeverse.org/browse/');
+    expect(urls).toContain('https://thefreeverse.org/authors/');
+    expect(urls).toContain('https://thefreeverse.org/collections/grief-and-mortality/');
+    expect(urls).toContain('https://thefreeverse.org/author/emily-dickinson/');
+    expect(urls).toContain('https://thefreeverse.org/poem/walt-whitman/o-captain-my-captain/');
+    expect(urls).toContain('https://thefreeverse.org/freeversepoem/walt-whitman/o-captain-my-captain/');
+  });
+
+  it('renders sitemap xml with url entries', () => {
+    const xml = buildSitemapXml([
+      'https://thefreeverse.org/',
+      'https://thefreeverse.org/browse/',
+    ]);
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(xml).toContain('<loc>https://thefreeverse.org/</loc>');
+    expect(xml).toContain('<loc>https://thefreeverse.org/browse/</loc>');
+  });
+});


### PR DESCRIPTION
Superseded by #134.

The built-in `@astrojs/sitemap` integration is the smaller and safer approach here:
- less custom sitemap code to maintain
- no extra route-specific test surface for generated XML
- avoids hand-curating duplicate route sets like `freeversepoem/`
- verified directly against Astro build output

Closing this duplicate PR in favor of the framework-native implementation in #134.