### PR TITLE
Add Paul Verlaine poems

### DIFF
--- a/meta/paul-verlaine/a-une-femme.yml
+++ b/meta/paul-verlaine/a-une-femme.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/a-une-femme
+slug: a-une-femme
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: À une femme
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/a-une-femme.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/%C3%80_une_femme
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/apres-trois-ans.yml
+++ b/meta/paul-verlaine/apres-trois-ans.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/apres-trois-ans
+slug: apres-trois-ans
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Après trois ans
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/apres-trois-ans.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Apr%C3%A8s_trois_ans
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/cauchemar.yml
+++ b/meta/paul-verlaine/cauchemar.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/cauchemar
+slug: cauchemar
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Cauchemar
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/cauchemar.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Cauchemar
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/cavitri.yml
+++ b/meta/paul-verlaine/cavitri.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/cavitri
+slug: cavitri
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Çavitri
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/cavitri.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/%C3%87avitri
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/cesar-borgia.yml
+++ b/meta/paul-verlaine/cesar-borgia.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/cesar-borgia
+slug: cesar-borgia
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: César Borgia
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/cesar-borgia.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/C%C3%A9sar_Borgia
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/chanson-dautomne.yml
+++ b/meta/paul-verlaine/chanson-dautomne.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/chanson-dautomne
+slug: chanson-dautomne
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Chanson d’automne
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/chanson-dautomne.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Chanson_d%E2%80%99automne
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/crepuscule-du-soir-mystique.yml
+++ b/meta/paul-verlaine/crepuscule-du-soir-mystique.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/crepuscule-du-soir-mystique
+slug: crepuscule-du-soir-mystique
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Crépuscule du soir mystique
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/crepuscule-du-soir-mystique.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Cr%C3%A9puscule_du_soir_mystique
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/croquis-parisien.yml
+++ b/meta/paul-verlaine/croquis-parisien.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/croquis-parisien
+slug: croquis-parisien
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Croquis parisien
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/croquis-parisien.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Croquis_parisien
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/dans-les-bois.yml
+++ b/meta/paul-verlaine/dans-les-bois.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/dans-les-bois
+slug: dans-les-bois
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Dans les bois
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/dans-les-bois.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Dans_les_bois
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/effet-de-nuit.yml
+++ b/meta/paul-verlaine/effet-de-nuit.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/effet-de-nuit
+slug: effet-de-nuit
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Effet de nuit
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/effet-de-nuit.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Effet_de_nuit
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/epilogue.yml
+++ b/meta/paul-verlaine/epilogue.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/epilogue
+slug: epilogue
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Épilogue
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/epilogue.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/%C3%89pilogue
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/femme-et-chatte.yml
+++ b/meta/paul-verlaine/femme-et-chatte.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/femme-et-chatte
+slug: femme-et-chatte
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Femme et Chatte
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/femme-et-chatte.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Femme_et_Chatte
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/grotesques.yml
+++ b/meta/paul-verlaine/grotesques.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/grotesques
+slug: grotesques
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Grotesques
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/grotesques.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Grotesques
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/il-bacio.yml
+++ b/meta/paul-verlaine/il-bacio.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/il-bacio
+slug: il-bacio
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Il bacio
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/il-bacio.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Il_bacio
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/initium.yml
+++ b/meta/paul-verlaine/initium.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/initium
+slug: initium
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Initium
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/initium.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Initium
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/jesuitisme.yml
+++ b/meta/paul-verlaine/jesuitisme.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/jesuitisme
+slug: jesuitisme
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Jésuitisme
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/jesuitisme.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/J%C3%A9suitisme
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/la-chanson-des-ingenues.yml
+++ b/meta/paul-verlaine/la-chanson-des-ingenues.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/la-chanson-des-ingenues
+slug: la-chanson-des-ingenues
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: La Chanson des Ingénues
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/la-chanson-des-ingenues.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/La_Chanson_des_Ing%C3%A9nues
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/la-mort-de-philippe-ii.yml
+++ b/meta/paul-verlaine/la-mort-de-philippe-ii.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/la-mort-de-philippe-ii
+slug: la-mort-de-philippe-ii
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: La Mort de Philippe II
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/la-mort-de-philippe-ii.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/La_Mort_de_Philippe_II
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/langoisse.yml
+++ b/meta/paul-verlaine/langoisse.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/langoisse
+slug: langoisse
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: L’Angoisse
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/langoisse.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/L%E2%80%99Angoisse
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/lassitude.yml
+++ b/meta/paul-verlaine/lassitude.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/lassitude
+slug: lassitude
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Lassitude
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/lassitude.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Lassitude
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/le-rossignol.yml
+++ b/meta/paul-verlaine/le-rossignol.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/le-rossignol
+slug: le-rossignol
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Le Rossignol
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/le-rossignol.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Le_Rossignol
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/les-sages-dautrefois.yml
+++ b/meta/paul-verlaine/les-sages-dautrefois.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/les-sages-dautrefois
+slug: les-sages-dautrefois
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Les sages d’autrefois
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/les-sages-dautrefois.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Les_sages_d%E2%80%99autrefois
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/lheure-du-berger.yml
+++ b/meta/paul-verlaine/lheure-du-berger.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/lheure-du-berger
+slug: lheure-du-berger
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: L’Heure du berger
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/lheure-du-berger.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/L%E2%80%99Heure_du_berger
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/marco.yml
+++ b/meta/paul-verlaine/marco.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/marco
+slug: marco
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Marco
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/marco.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Marco
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/marine.yml
+++ b/meta/paul-verlaine/marine.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/marine
+slug: marine
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Marine
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/marine.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Marine
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/mon-reve-familier.yml
+++ b/meta/paul-verlaine/mon-reve-familier.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/mon-reve-familier
+slug: mon-reve-familier
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Mon rêve familier
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/mon-reve-familier.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Mon_r%C3%AAve_familier
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/monsieur-prudhomme.yml
+++ b/meta/paul-verlaine/monsieur-prudhomme.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/monsieur-prudhomme
+slug: monsieur-prudhomme
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Monsieur Prudhomme
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/monsieur-prudhomme.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Monsieur_Prudhomme
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/nevermore-1.yml
+++ b/meta/paul-verlaine/nevermore-1.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/nevermore-1
+slug: nevermore-1
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Nevermore
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/nevermore-1.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Nevermore_(1)
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/nevermore-2.yml
+++ b/meta/paul-verlaine/nevermore-2.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/nevermore-2
+slug: nevermore-2
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Nevermore
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/nevermore-2.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Nevermore_(2)
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/nocturne-parisien.yml
+++ b/meta/paul-verlaine/nocturne-parisien.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/nocturne-parisien
+slug: nocturne-parisien
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Nocturne parisien
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/nocturne-parisien.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Nocturne_parisien
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/nuit-du-walpurgis-classique.yml
+++ b/meta/paul-verlaine/nuit-du-walpurgis-classique.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/nuit-du-walpurgis-classique
+slug: nuit-du-walpurgis-classique
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Nuit du Walpurgis classique
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/nuit-du-walpurgis-classique.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Nuit_du_Walpurgis_classique
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/prologue.yml
+++ b/meta/paul-verlaine/prologue.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/prologue
+slug: prologue
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Prologue
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/prologue.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Prologue
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/promenade-sentimentale.yml
+++ b/meta/paul-verlaine/promenade-sentimentale.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/promenade-sentimentale
+slug: promenade-sentimentale
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Promenade sentimentale
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/promenade-sentimentale.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Promenade_sentimentale
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/resignation.yml
+++ b/meta/paul-verlaine/resignation.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/resignation
+slug: resignation
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Résignation
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/resignation.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/R%C3%A9signation
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/serenade.yml
+++ b/meta/paul-verlaine/serenade.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/serenade
+slug: serenade
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Sérénade
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/serenade.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/S%C3%A9r%C3%A9nade
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/soleils-couchants.yml
+++ b/meta/paul-verlaine/soleils-couchants.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/soleils-couchants
+slug: soleils-couchants
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Soleils couchants
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/soleils-couchants.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Soleils_couchants
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/sub-urbe.yml
+++ b/meta/paul-verlaine/sub-urbe.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/sub-urbe
+slug: sub-urbe
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Sub urbe
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/sub-urbe.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Sub_urbe
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/un-dahlia.yml
+++ b/meta/paul-verlaine/un-dahlia.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/un-dahlia
+slug: un-dahlia
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Un Dahlia
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/un-dahlia.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Un_Dahlia
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/une-grande-dame.yml
+++ b/meta/paul-verlaine/une-grande-dame.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/une-grande-dame
+slug: une-grande-dame
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Une grande dame
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/une-grande-dame.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/Une_grande_dame
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/meta/paul-verlaine/voeu.yml
+++ b/meta/paul-verlaine/voeu.yml
@@ -1,0 +1,16 @@
+id: paul-verlaine/voeu
+slug: voeu
+author: Paul Verlaine
+author_slug: paul-verlaine
+title: Vœu
+century: 19
+text_locale: fr
+original_language: fr
+text_direction: ltr
+text_path: poems/paul-verlaine/voeu.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)/V%C5%93u
+public_domain_rationale: 'Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.'
+collection_title: Poèmes saturniens (1866)
+collection_source_url: https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)

--- a/poems/paul-verlaine/a-une-femme.txt
+++ b/poems/paul-verlaine/a-une-femme.txt
@@ -1,0 +1,17 @@
+À vous ces vers de par la grâce consolante
+De vos grands yeux où rit et pleure un rêve doux,
+De par votre âme pure et toute bonne, à vous
+Ces vers du fond de ma détresse violente.
+
+C’est qu’hélas ! le hideux cauchemar qui me hante
+N’a pas de trêve et va furieux, fou, jaloux,
+Se multipliant comme un cortège de loups
+Et se pendant après mon sort qu’il ensanglante !
+
+Oh ! je souffre, je souffre affreusement, si bien
+Que le gémissement premier du premier homme
+Chassé d’Éden n’est qu’une églogue au prix du mien !
+
+Et les soucis que vous pouvez avoir sont comme
+Des hirondelles sur un ciel d’après-midi,
+— Chère,— par un beau jour de septembre attiédi.

--- a/poems/paul-verlaine/apres-trois-ans.txt
+++ b/poems/paul-verlaine/apres-trois-ans.txt
@@ -1,0 +1,17 @@
+Ayant poussé la porte étroite qui chancelle,
+Je me suis promené dans le petit jardin
+Qu’éclairait doucement le soleil du matin,
+Pailletant chaque fleur d’une humide étincelle.
+
+Rien n’a changé. J’ai tout revu : l’humble tonnelle
+De vigne folle avec les chaises de rotin…
+Le jet d’eau fait toujours son murmure argentin
+Et le vieux tremble sa plainte sempiternelle.
+
+Les roses comme avant palpitent ; comme avant,
+Les grands lys orgueilleux se balancent au vent.
+Chaque alouette qui va et vient m’est connue.
+
+Même j’ai retrouvé debout la Velléda
+Dont le plâtre s’écaille au bout de l’avenue,
+— Grêle, parmi l’odeur fade du réséda.

--- a/poems/paul-verlaine/cauchemar.txt
+++ b/poems/paul-verlaine/cauchemar.txt
@@ -1,0 +1,35 @@
+J’ai vu passer dans mon rêve
+— Tel l’ouragan sur la grève, —
+D’une main tenant un glaive
+Et de l’autre un sablier,
+Ce cavalier
+
+Des ballades d’Allemagne
+Qu’à travers ville et campagne,
+Et du fleuve à la montagne,
+Et des forêts au vallon,
+&#65279;Un étalon
+
+Rouge-flamme et noir d’ébène,
+Sans bride, ni mors, ni rêne,
+Ni hop ! ni cravache, entraîne
+Parmi des râlements sourds
+&#65279;Toujours ! toujours !
+
+Un grand feutre à longue plume
+Ombrait son œil qui s’allume
+Et s’éteint. Tel, dans la brume,
+Eclate et meurt l’éclair bleu
+&#65279;D’une arme à feu.
+
+Comme l’aile d’une orfraie
+Qu’un subit orage effraie,
+Par l’air que la neige raie,
+Son manteau se soulevant
+Claquait au vent,
+
+Et montrait d’un air de gloire
+Un torse d’ombre et d’ivoire,
+Tandis que dans la nuit noire
+Luisaient en des cris stridents
+Trente-deux dents.

--- a/poems/paul-verlaine/cavitri.txt
+++ b/poems/paul-verlaine/cavitri.txt
@@ -1,0 +1,14 @@
+Pour sauver son époux, Çavitrî fit le vœu
+De se tenir trois jours entiers, trois nuits entières,
+Debout, sans remuer jambes, buste ou paupières :
+Rigide, ainsi que dit Vyaça, comme un pieu.
+
+Ni, Çurya, tes rais cruels, ni la langueur
+Que Tchandra vient épandre à minuit sur les cimes
+Ne firent défaillir, dans leurs efforts sublimes,
+La pensée et la chair de la femme au grand cœur.
+
+— Que nous cerne l’Oubli, noir et morne assassin,
+Ou que l’Envie aux traits amers nous ait pour cibles,
+Ainsi que Çavitrî faisons-nous impassibles,
+Mais, comme elle, dans l’âme ayons un haut dessein.

--- a/poems/paul-verlaine/cesar-borgia.txt
+++ b/poems/paul-verlaine/cesar-borgia.txt
@@ -1,0 +1,23 @@
+Sur fond sombre noyant un riche vestibule
+Où le buste d’Horace et celui de Tibulle
+Lointains et de profil rêvent en marbre blanc,
+La main gauche au poignard et la main droite au flanc,
+Tandis qu’un rire doux redresse la moustache,
+Le duc CÉSAR en grand costume se détache.
+
+Les yeux noirs, les cheveux noirs et le velours noir
+Vont contrastant, parmi l’or somptueux d’un soir,
+Avec la pâleur mate et belle du visage
+Vu de trois quarts et très-ombré, suivant l’usage
+Des Espagnols ainsi que des Vénitiens
+Dans les portraits de rois et de patriciens.
+Le nez palpite, fin et droit. La bouche, rouge,
+Est mince, et l’on dirait que la tenture bouge
+Au souffle véhément qui doit s’en exhaler.
+Et le regard errant avec laisser-aller
+Devant lui, comme il sied aux anciennes peintures,
+Fourmille de pensers énormes d’aventures.
+Et le front, large et pur, sillonné d’un grand pli,
+Sans doute de projets formidables rempli,
+Médite sous la toque où frissonne une plume
+Élancée hors d’un nœud de rubis qui s’allume.

--- a/poems/paul-verlaine/chanson-dautomne.txt
+++ b/poems/paul-verlaine/chanson-dautomne.txt
@@ -1,0 +1,20 @@
+Les sanglots longs
+Des violons
+De l’automne
+Blessent mon cœur
+D’une langueur
+Monotone.
+
+Tout suffocant
+Et blême, quand
+Sonne l’heure,
+Je me souviens
+Des jours anciens
+Et je pleure ;
+
+Et je m’en vais
+Au vent mauvais
+Qui m’emporte
+Deçà, delà,
+Pareil à la
+Feuille morte.

--- a/poems/paul-verlaine/crepuscule-du-soir-mystique.txt
+++ b/poems/paul-verlaine/crepuscule-du-soir-mystique.txt
@@ -1,0 +1,14 @@
+Le Souvenir avec le Crépuscule
+Rougeoie et tremble à l’ardent horizon
+De l’Espérance en flamme qui recule
+Et s’agrandit ainsi qu’une cloison
+
+Mystérieuse où mainte floraison
+— Dahlia, lys, tulipe et renoncule —
+S’élance autour d’un treillis, et circule
+Parmi la maladive exhalaison
+De parfums lourds et chauds, dont le poison
+— Dahlia, lys, tulipe et renoncule —
+Noyant mes sens, mon âme et ma raison,
+Mêle dans une immense pâmoison
+Le Souvenir avec le Crépuscule.

--- a/poems/paul-verlaine/croquis-parisien.txt
+++ b/poems/paul-verlaine/croquis-parisien.txt
@@ -1,0 +1,14 @@
+La lune plaquait ses teintes de zinc
+&#65279;Par angles obtus.
+Des bouts de fumée en forme de cinq
+Sortaient drus et noirs des hauts toits pointus.
+
+Le ciel était gris. La bise pleurait
+&#65279;Ainsi qu’un basson.
+Au loin, un matou frileux et discret
+Miaulait d’étrange et grêle façon.
+
+Moi, j’allais, rêvant du divin Platon
+&#65279;Et de Phidias,
+Et de Salamine et de Marathon,
+Sous l’œil clignotant des bleus becs de gaz.

--- a/poems/paul-verlaine/dans-les-bois.txt
+++ b/poems/paul-verlaine/dans-les-bois.txt
@@ -1,0 +1,29 @@
+D’autres,— des innocents ou bien des lymphatiques,—
+Ne trouvent dans les bois que charmes langoureux,
+Souffles frais et parfums tièdes. Ils sont heureux !
+D’autres s’y sentent pris — rêveurs — d’effrois mystiques.
+
+Ils sont heureux ! Pour moi, nerveux, et qu’un remords
+Épouvantable et vague affole sans relâche,
+Par les forêts je tremble à la façon d’un lâche
+Qui craindrait une embûche ou qui verrait des morts.
+
+Ces grands rameaux jamais apaisés, comme l’onde,
+D’où tombe un noir silence avec une ombre encor
+Plus noire, tout ce morne et sinistre décor
+Me remplit d’une horreur triviale et profonde.
+
+Surtout les soirs d’été : la rougeur du couchant
+Se fond dans le gris bleu des brumes qu’elle teinte
+D’incendie et de sang ; et l’angélus qui tinte
+Au lointain semble un cri plaintif se rapprochant.
+
+Le vent se lève chaud et lourd, un frisson passe
+Et repasse, toujours plus fort, dans l’épaisseur
+Toujours plus sombre des hauts chênes, obsesseur,
+Et s’éparpille, ainsi qu’un miasme, dans l’espace.
+
+La nuit vient. Le hibou s’envole. C’est l’instant
+Où l’on songe aux récits des aïeules naïves…
+Sous un fourré, là-bas, là-bas, des sources vives
+Font un bruit d’assassins postés se concertant.

--- a/poems/paul-verlaine/effet-de-nuit.txt
+++ b/poems/paul-verlaine/effet-de-nuit.txt
@@ -1,0 +1,15 @@
+La nuit. La pluie. Un ciel blafard que déchiquette
+De flèches et de tours à jour la silhouette
+D’une ville gothique éteinte au lointain gris.
+La plaine. Un gibet plein de pendus rabougris
+
+Secoués par le bec avide des corneilles
+Et dansant dans l’air noir des gigues nonpareilles,
+Tandis que leurs pieds sont la pâture des loups.
+Quelques buissons d’épine épars, et quelques houx
+Dressant l’horreur de leur feuillage à droite, à gauche,
+Sur le fuligineux fouillis d’un fond d’ébauche.
+Et puis, autour de trois livides prisonniers
+Qui vont pieds nus, deux cent vingt-cinq pertuisaniers
+En marche, et leurs fers droits, comme des fers de herse,
+Luisent à contre-sens des lances de l’averse.

--- a/poems/paul-verlaine/epilogue.txt
+++ b/poems/paul-verlaine/epilogue.txt
@@ -1,0 +1,101 @@
+Le soleil, moins ardent, luit clair au ciel moins dense.
+Balancés par un vent automnal et berceur,
+Les rosiers du jardin s’inclinent en cadence.
+L’atmosphère ambiante a des baisers de sœur
+
+La Nature a quitté pour cette fois son trône
+De splendeur, d’ironie et de sérénité :
+Clémente, elle descend, par l’ampleur de l’air jaune,
+Vers l’homme, son sujet pervers et révolté.
+
+Du pan de son manteau que l’abîme constelle,
+Elle daigne essuyer les moiteurs de nos fronts,
+Et son âme éternelle et sa forme immortelle
+Donnent calme et vigueur à nos cœurs mous et prompts.
+
+Le frais balancement des ramures chenues,
+L’horizon élargi plein de vagues chansons,
+Tout, jusqu’au vol joyeux des oiseaux et des nues,
+Tout aujourd’hui console et délivre. — Pensons.
+
+Donc, c’en est fait. Ce livre est clos. Chères Idées
+Qui rayiez mon ciel gris de vos ailes de feu
+
+Dont le vent caressait mes tempes obsédées,
+Vous pouvez revoler devers l’Infini bleu !
+
+Et toi, Vers qui tintais, et toi, Rime sonore,
+Et vous, Rhythmes chanteurs, et vous, délicieux
+Ressouvenirs, et vous, Rêves, et vous encore,
+Images qu’évoquaient mes désirs anxieux,
+
+Il faut nous séparer. Jusqu’aux jours plus propices
+Où nous réunira l’Art, notre maître, adieu,
+Adieu, doux compagnons, adieu, charmants complices !
+Vous pouvez revoler devers l’Infini bleu.
+
+Aussi bien, nous avons fourni notre carrière
+Et le jeune étalon de notre bon plaisir,
+Tout affolé qu’il est de sa course première,
+A besoin d’un peu d’ombre et de quelque loisir.
+
+— Car toujours nous t’avons fixée, ô Poésie,
+
+Notre astre unique et notre unique passion,
+T’ayant seule pour guide et compagne choisie,
+Mère, et nous méfiant de l’Inspiration.
+
+Ah ! l’Inspiration superbe et souveraine,
+L’Egérie aux regards lumineux et profonds,
+Le Genium commode et l’Erato soudaine,
+L’Ange des vieux tableaux avec des ors au fond,
+
+La Muse, dont la voix est puissante sans doute,
+Puisqu’elle fait d’un coup dans les premiers cerveaux
+Comme ces pissenlits dont s’émaille la route,
+Pousser tout un jardin de poëmes nouveaux,
+
+La Colombe, le Saint-Esprit, le saint Délire,
+Les Troubles opportuns, les Transports complaisants
+Gabriel et son luth, Apollon et sa lyre,
+Ah ! l’Inspiration, on l’invoque à seize ans !
+
+Ce qu’il nous faut à nous, les Suprêmes Poëtes
+Qui vénérons les Dieux et qui n’y croyons pas,
+À nous dont nul rayon n’auréola les têtes,
+Dont nulle Béatrix n’a dirigé les pas,
+
+À nous qui ciselons les mots comme des coupes
+Et qui faisons des vers émus très-froidement,
+À nous qu’on ne voit point les soirs aller par groupes
+Harmonieux au bord des lacs et nous pâmant,
+
+Ce qu’il nous faut à nous, c’est, aux lueurs des lampes,
+La science conquise et le sommeil dompté,
+C’est le front dans les mains du vieux Faust des estampes,
+C’est l’Obstination et c’est la Volonté !
+
+C’est la Volonté sainte, absolue, éternelle,
+Cramponnée au projet comme un noble condor
+Aux flancs fumants de peur d’un bufHe, et d’un coup d’aile
+Emportant son trophée à travers les cieux d’or !
+
+Ce qu’il nous faut à nous, c’est l’étude sans trêve,
+C’est l’effort inouï, le combat nonpareil,
+C’est la nuit, l’âpre nuit du travail, d’où se lève
+Lentement, lentement, l’Œuvre, ainsi qu’un soleil !
+
+Libre à nos Inspirés, cœurs qu’une œillade enflamme
+D’abandonner leur être aux vents comme un bouleau ;
+Pauvres gens ! l’Art n’est pas d’éparpiller son âme :
+Est-elle en marbre, ou non, la Vénus de Milo ?
+
+Nous donc, sculptons avec le ciseau des Pensées
+Le bloc vierge du Beau, Paros immaculé,
+Et faisons-en surgir sous nos mains empressées
+Quelque pure statue au péplos étoilé,
+
+Afin qu’un jour, frappant de rayons gris et roses
+Le chef-d’œuvre serein, comme un nouveau Memnon,
+L’Aube-Postérité, fille des Temps moroses,
+Fasse dans l’air futur retentir notre nom !

--- a/poems/paul-verlaine/femme-et-chatte.txt
+++ b/poems/paul-verlaine/femme-et-chatte.txt
@@ -1,0 +1,17 @@
+Elle jouait avec sa chatte,
+Et c’était merveille de voir
+La main blanche et la blanche patte
+S’ébattre dans l’ombre du soir.
+
+Elle cachait — la scélérate ! —
+Sous ses mitaines de fil noir
+Ses meurtriers ongles d’agate,
+Coupants et clairs comme un rasoir.
+
+L’autre aussi faisait la sucrée
+Et rentrait sa griffe acérée,
+Mais le diable n’y perdait rien…
+
+Et dans le boudoir où, sonore,
+Tintait son rire aérien
+Brillaient quatre points de phosphore.

--- a/poems/paul-verlaine/grotesques.txt
+++ b/poems/paul-verlaine/grotesques.txt
@@ -1,0 +1,49 @@
+Leurs jambes pour toutes montures,
+Pour tous biens l’or de leurs regards,
+Par le chemin des aventures
+Ils vont haillonneux et hagards.
+
+Le sage, indigné, les harangue ;
+Le sot plaint ces fous hasardeux ;
+Les enfants leur tirent la langue
+Et les filles se moquent d’eux.
+
+C’est qu’odieux et ridicules,
+Et maléfiques en effet,
+Ils ont l’air, sur les crépuscules,
+D’un mauvais rêve que l’on fait ;
+
+C’est que, sur leurs aigres guitares
+Crispant la main des libertés,
+Ils nasillent des chants bizarres,
+Nostalgiques et révoltés ;
+
+C’est enfin que dans leurs prunelles
+Rit et pleure — fastidieux —
+L’amour des choses éternelles,
+Des vieux morts et des anciens dieux !
+
+— Donc, allez, vagabonds sans trêves,
+Errez, funestes et maudits,
+Le long des gouffres et des grèves,
+Sous l’œil fermé des paradis !
+
+La nature à l’homme s’allie
+Pour châtier comme il le faut
+L’orgueilleuse mélancolie
+Qui vous fait marcher le front haut,
+
+Et, vengeant sur vous le blasphème
+Des vastes espoirs véhéments,
+Meurtrit votre front anathème
+Au choc rude des éléments.
+
+Les juins brûlent et les décembres
+Gèlent votre chair jusqu’aux os,
+Et la fièvre envahit vos membres
+Qui se déchirent aux roseaux.
+
+Tout vous repousse et tout vous navre,
+Et quand la mort viendra pour vous,
+Maigre et froide, votre cadavre
+Sera dédaigné par les loups !

--- a/poems/paul-verlaine/il-bacio.txt
+++ b/poems/paul-verlaine/il-bacio.txt
@@ -1,0 +1,19 @@
+Baiser ! rose trémière au jardin des caresses !
+Vif accompagnement sur le clavier des dents
+Des doux refrains qu’Amour chante en les cœurs ardents
+Avec sa voix d’archange aux langueurs charmeresses !
+
+Sonore et gracieux Baiser, divin Baiser !
+Volupté nonpareille, ivresse inénarrable !
+Salut ! L’homme, penché sur ta coupe adorable,
+S’y grise d’un bonheur qu’il ne sait épuiser.
+
+Comme le vin du Rhin et comme la musique,
+Tu consoles et tu berces, et le chagrin
+Expire avec la moue en ton pli purpurin…
+Qu’un plus grand, Goëthe ou Will, te dresse un vers classique.
+
+Moi, je ne puis, chétif trouvère de Paris,
+T’offrir que ce bouquet de strophes enfantines :
+Sois bénin et, pour prix, sur les lèvres mutines
+D’Une que je connais, Baiser, descends, et ris.

--- a/poems/paul-verlaine/initium.txt
+++ b/poems/paul-verlaine/initium.txt
@@ -1,0 +1,18 @@
+Les violons mêlaient leur rire au chant des flûtes
+Et le bal tournoyait quand je la vis passer
+Avec ses cheveux blonds jouant sur les volutes
+De son oreille où mon Désir comme un baiser
+S’élançait et voulait lui parler, sans oser.
+
+Cependant elle allait, et la mazurque lente
+La portait dans son rhythme indolent comme un vers,
+— Rime mélodieuse, image étincelante, —
+Et son âme d’enfant rayonnait à travers
+La sensuelle ampleur de ses yeux gris et verts.
+
+Et depuis, ma Pensée — immobile — contemple
+Sa Splendeur évoquée, en adoration,
+Et dans son Souvenir, ainsi que dans un temple,
+Mon Amour entre, plein de superstition.
+
+Et je crois que voici venir la Passion.

--- a/poems/paul-verlaine/jesuitisme.txt
+++ b/poems/paul-verlaine/jesuitisme.txt
@@ -1,0 +1,17 @@
+Le Chagrin qui me tue est ironique, et joint
+Le sarcasme au supplice, et ne torture point
+Franchement, mais picote avec un faux sourire
+Et transforme en spectacle amusant mon martyre,
+
+Et sur la bière où gît mon Rêve mi-pourri
+Beugle un De Profundis sur l’air du Traderi.
+C’est un Tartuffe qui, tout en mettant des roses
+Pompons sur les autels des Madones moroses,
+Tout en faisant chanter à des enfants de chœur
+Ces cantiques d’eau tiède où se baigne le cœur,
+Tout en amidonnant ces guimpes amoureuses
+Qui serpentent au corps sacré des Bienheureuses,
+Tout en disant à voix basse son chapelet,
+Tout en passant la main sur son petit collet,
+Tout en parlant avec componction de l’âme,
+N’en médite pas moins ma ruine, — l’infâme !

--- a/poems/paul-verlaine/la-chanson-des-ingenues.txt
+++ b/poems/paul-verlaine/la-chanson-des-ingenues.txt
@@ -1,0 +1,39 @@
+Nous sommes les Ingénues
+Aux bandeaux plats, à l’œil bleu,
+Qui vivons, presque inconnues,
+Dans les romans qu’on lit peu.
+
+Nous allons entrelacées,
+Et le jour n’est pas plus pur
+Que le fond de nos pensées,
+Et nos rêves sont d’azur ;
+
+Et nous courons par les prées,
+Et rions et babillons
+Des aubes jusqu’aux vesprées,
+Et chassons aux papillons ;
+
+Et des chapeaux de bergères
+Défendent notre fraîcheur,
+Et nos robes — si légères —
+Sont d’une extrême blancheur ;
+
+Les Richelieux, les Caussades
+Et les chevaliers Faublas
+Nous prodiguent les œillades,
+Les saluts et les « hélas ! »
+
+Mais en vain, et leurs mimiques
+Se viennent casser le nez
+Devant les plis ironiques
+De nos jupons détournés ;
+
+Et notre candeur se raille
+Des imaginations
+De ces raseurs de muraille,
+Bien que parfois nous sentions
+
+Battre nos cœurs sous nos mantes
+À des pensers clandestins,
+En nous sachant les amantes
+Futures des libertins.

--- a/poems/paul-verlaine/la-mort-de-philippe-ii.txt
+++ b/poems/paul-verlaine/la-mort-de-philippe-ii.txt
@@ -1,0 +1,199 @@
+Le coucher d’un soleil de septembre ensanglante
+La plaine morne et l’âpre arête des sierras
+Et de la brume au loin l’installation lente.
+
+Le Guadarrama pousse entre les sables ras
+Son flot hâtif qui va réfléchissant par places
+Quelques oliviers nains tordant leurs maigres bras.
+
+Le grand vol anguleux des éperviers rapaces
+Raye à l’ouest le ciel mat et rouge qui brunit,
+Et leur cri rauque grince à travers les espaces.
+
+Despotique, et dressant au-devant du zénith
+L’entassement brutal de ses tours octogones,
+L’Escurial étend son orgueil de granit.
+
+Les murs carrés, percés de vitraux monotones,
+Montent droits, blancs et nus, sans autres ornements
+Que quelques grils sculptés qu’alternent des couronnes.
+
+Avec des bruits pareils aux rudes hurlements
+D’un ours que des bergers navrent de coups de pioches
+Et dont l’écho redit les râles alarmants,
+
+Torrent de cris roulant ses ondes sur les roches
+Et puis s’évaporant en des murmures longs,
+Sinistrement dans l’air du soir tintent les cloches.
+
+Par les cours du palais, où l’ombre met ses plombs,
+Circule — tortueux serpent hiératique —
+Une procession de moines aux frocs blonds
+
+Qui marchent un par un, suivant l’ordre ascétique,
+Et qui, pieds nus, la corde aux reins, un cierge en main,
+Ululent d’une voix formidable un cantique.
+
+— Qui donc ici se meurt ? Pour qui sur le chemin
+Cette paille épandue et ces croix long-voilées
+Selon le rituel catholique romain ? —
+
+La chambre est haute, vaste et sombre. Niellées,
+Les portes d’acajou massif tournent sans bruit,
+Leurs serrures étant, comme leurs gonds, huilées.
+
+Une vague rougeur plus triste que la nuit
+Filtre à rais indécis par les plis des tentures
+À travers les vitraux où le couchant reluit,
+
+Et fait papilloter sur les architectures,
+À l’angle des objets, dans l’ombre du plafond,
+Ce halo singulier qu’on voit dans les peintures.
+
+Parmi le clair-obscur transparent et profond
+S’agitent effarés des hommes et des femmes
+À pas furtifs, ainsi que les hyènes font.
+
+Riches, les vêtements des seigneurs et des dames,
+Velours, panne, satin, soie, hermine et brocart,
+Chantent l’ode du luxe en chatoyantes gammes,
+
+Et, trouant par éclairs distancés avec art
+L’opaque demi-jour, les cuirasses de cuivre
+Des gardes alignés scintillent de trois quart.
+
+Un homme en robe noire, à visage de guivre,
+Se penche, en caressant de la main ses fémurs,
+Sur un lit, comme l’on se penche sur un livre.
+
+Des rideaux de drap d’or roides comme des murs
+Tombent d’un dais de bois d’ébène en droite ligne,
+Dardant à temps égaux l’œil des diamants durs.
+
+Dans le lit, un vieillard d’une maigreur insigne
+Égrène un chapelet, qu’il baise par moment,
+Entre ses doigts crochus comme des brins de vigne
+
+Ses lèvres font ce sourd et long marmottement
+Dernier signe de vie et premier d’agonie,
+— Et son haleine pue épouvantablement.
+
+Dans sa barbe couleur d’amarante ternie,
+Parmi ses cheveux blancs où luisent des tons roux
+Sous son linge bordé de dentelle jaunie,
+
+Avides, empressés, fourmillants, et jaloux
+De pomper tout le sang malsain du mourant fauve,
+En bataillons serrés vont et viennent les poux.
+
+C’est le Roi, ce mourant qu’assiste un mire chauve,
+Le Roi Philippe Deux d’Espagne, — Saluez ! —
+Et l’aigle autrichien s’effare dans l’alcôve,
+
+Et de grands écussons, aux murailles cloués,
+Brillent, et maints drapeaux où l’oiseau noir s’étale
+Pendent deçà delà, vaguement remués !…
+
+— La porte s’ouvre. Un flot de lumière brutale
+Jaillit soudain, déferle et bientôt s’établit
+Par l’ampleur de la chambre en nappe horizontale ;
+
+Porteurs de torches, roux, et que l’extase emplit,
+Entrent dix capucins qui restent en prière :
+Un d’entre eux se détache et marche droit au lit.
+
+Il est grand, jeune et maigre, et son pas est de pierre,
+Et les élancements farouches de la Foi
+Rayonnent à travers les cils de sa paupière ;
+
+Son pied ferme et pesant et lourd, comme la Loi,
+Sonne sur les tapis, régulier, emphatique ;
+Les yeux baissés en terre, il marche droit au Roi.
+
+Et tous sur son trajet dans un geste extatique
+S’agenouillent, frappant trois fois du poing leur sein ;
+Car il porte avec lui le sacré Viatique.
+
+Du lit s’écarte avec respect le matassin,
+Le médecin du corps, en pareille occurrence,
+Devant céder la place, Ame, à ton médecin.
+
+La figure du Roi, qu’étire la souffrance,
+À l’approche du fray se rassérène un peu.
+Tant la religion est grosse d’espérance !
+
+Le moine cette fois ouvrant son œil de feu
+Tout brillant de pardons mêlés à des reproches,
+S’arrête, messager des justices de Dieu.
+
+— Sinistrement dans l’air du soir tintent les cloches.
+
+Et la Confession commence. Sur le flanc
+Se retournant, le roi, d’un ton sourd, bas et grêle,
+Parle de feux, de juifs, de bûchers et de sang.
+
+— « Vous repentiriez-vous par hasard de ce zèle ?
+« Brûler des juifs, mais c’est une dilection !
+« Vous fûtes, ce faisant, orthodoxe et fidèle. » —
+
+Et se pétrifiant dans l’exaltation,
+Le Révérend, les bras en croix, tête dressée,
+Semble l’esprit sculpté de l’Inquisition.
+
+Ayant repris haleine, et d’une voix cassée,
+Péniblement, et comme arrachant par lambeaux
+Un remords douloureux du fond de sa pensée,
+
+Le Roi, dont la lueur tragique des flambeaux
+Éclaire le visage osseux et le front blême,
+Prononce ces mots : Flandre, Albe, morts, sacs, tombeau.
+
+— « Les Flamands, révoltés contre l’Église même,
+« Furent très-justement punis, à votre los,
+« Et je m’étonne, ô Roi, de ce doute suprême.
+
+« Poursuivez. » — Et le Roi parla de don Carlos.
+Et deux larmes coulaient tremblantes sur sa joue
+Palpitante et collée affreusement à l’os.
+
+— « Vous déplorez cet acte, et moi je vous en loue !
+« L’Infant, certes, était coupable au dernier point,
+« Ayant voulu tirer l’Espagne dans la boue
+
+« De l’hérésie anglaise, et de plus n’ayant point
+« Frémi de conspirer — ô ruses abhorrées ! —
+« Et contre un Père, et contre un Maître, et contre un Oint ! »
+
+Le moine ensuite dit les formules sacrées
+Par quoi tous nos péchés nous sont remis, et puis,
+Prenant l’Hostie avec ses deux mains timorées,
+
+Sur la langue du Roi la déposa. Tous bruits
+Se sont tus, et la Cour, pliant dans la détresse,
+Pria, muette et pâle, et nul n’a su depuis
+
+Si sa prière fut sincère ou bien traîtresse.
+— Qui dira les pensers obscurs que protégea
+Ce silence, brouillard complice qui se dresse ? —
+
+Ayant communié, le Roi se replongea
+Dans l’ampleur des coussins, et la béatitude
+De l’Absolution reçue ouvrant déjà
+
+L’œil de son âme au jour clair de la certitude,
+Épanouit ses traits en un sourire exquis
+Qui tenait de la fièvre et de la quiétude.
+
+Et tandis qu’alentour ducs, comtes et marquis,
+Pleins d’angoisses, fichaient leurs yeux sous la courtine,
+L’âme du Roi mourant montait aux cieux conquis.
+
+Puis le râle des morts hurla dans la poitrine
+De l’auguste malade avec des sursauts fous :
+Tel l’ouragan passe à travers une ruine.
+
+Et puis, plus rien ; et puis, sortant par mille trous,
+Ainsi que des serpents frileux de leur repaire,
+Sur le corps froid les vers se mêlèrent aux poux.
+
+— Philippe Deux était à la droite du Père.

--- a/poems/paul-verlaine/langoisse.txt
+++ b/poems/paul-verlaine/langoisse.txt
@@ -1,0 +1,17 @@
+Nature, rien de toi ne m’émeut, ni les champs
+Nourriciers, ni l’écho vermeil des pastorales
+Siciliennes, ni les pompes aurorales,
+Ni la solennité dolente des couchants.
+
+Je ris de l’Art, je ris de l’Homme aussi, des chants,
+Des vers, des temples grecs et des tours en spirales
+Qu’étirent dans le ciel vide les cathédrales,
+Et je vois du même œil les bons et les méchants.
+
+Je ne crois pas en Dieu, j’abjure et je renie
+Toute pensée, et quant à la vieille ironie,
+L’Amour, je voudrais bien qu’on ne m’en parlât plus.
+
+Lasse de vivre, ayant peur de mourir, pareille
+Au brick perdu jouet du flux et du reflux,
+Mon âme pour d’affreux naufrages appareille

--- a/poems/paul-verlaine/lassitude.txt
+++ b/poems/paul-verlaine/lassitude.txt
@@ -1,0 +1,17 @@
+De la douceur, de la douceur, de la douceur !
+Calme un peu ces transports fébriles, ma charmante.
+Même au fort du déduit parfois, vois-tu, l’amante
+Doit avoir l’abandon paisible de la sœur.
+
+Sois langoureuse, fais ta caresse endormante,
+Bien égaux tes soupirs et ton regard berceur.
+Va, l’étreinte jalouse et le spasme obsesseur
+Ne valent pas un long baiser, même qui mente !
+
+Mais dans ton cher cœur d’or, me dis-tu, mon enfant,
+La fauve passion va sonnant l’oliphant !…
+Laisse-la trompetter à son aise, la gueuse !
+
+Mets ton front sur mon front et ta main dans ma main,
+Et fais-moi des serments que tu rompras demain,
+Et pleurons jusqu’au jour, ô petite fougueuse !

--- a/poems/paul-verlaine/le-rossignol.txt
+++ b/poems/paul-verlaine/le-rossignol.txt
@@ -1,0 +1,21 @@
+Comme un vol criard d’oiseaux en émoi,
+Tous mes souvenirs s’abattent sur moi,
+S’abattent parmi le feuillage jaune
+De mon cœur mirant son tronc plié d’aune
+
+Au tain violet de l’eau des Regrets
+Qui mélancoliquement coule auprès,
+S’abattent, et puis la rumeur mauvaise
+Qu’une brise moite en montant apaise,
+S’éteint par degrés dans l’arbre, si bien
+Qu’au bout d’un instant on n’entend plus rien,
+Plus rien que la voix célébrant l’Absente,
+Plus rien que la voix — ô si languissante ! —
+De l’oiseau que fut mon Premier Amour,
+Et qui chante encor comme au premier jour ;
+Et dans la splendeur triste d’une lune
+Se levant blafarde et solennelle, une
+Nuit mélancolique et lourde d’été,
+Pleine de silence et d’obscurité,
+Berce sur l’azur qu’un vent doux effleure
+L’arbre qui frissonne et l’oiseau qui pleure.

--- a/poems/paul-verlaine/les-sages-dautrefois.txt
+++ b/poems/paul-verlaine/les-sages-dautrefois.txt
@@ -1,0 +1,20 @@
+Les Sages d’autrefois, qui valaient bien ceux-ci,
+Crurent, et c’est un point encor mal éclairci,
+Lire au ciel les bonheurs ainsi que les désastres,
+Et que chaque âme était liée à l’un des astres.
+(On a beaucoup raillé, sans penser que souvent
+Le rire est ridicule autant que décevant,
+Cette explication du mystère nocturne.)
+Or ceux là qui sont nés sous le signe SATURNE,
+Fauve planète, chère aux nécromanciens,
+Ont entre tous, d’après les grimoires anciens,
+Bonne part de malheur et bonne part de bile.
+L’Imagination, inquiète et débile,
+Vient rendre nul en eux l’effort de la Raison.
+Dans leurs veines le sang, subtil comme un poison,
+Brûlant comme une lave, et rare, coule et roule
+En grésillant leur triste Idéal qui s’écroule.
+Tels les Saturniens doivent souffrir et tels
+Mourir, — en admettant que nous soyons mortels, —
+Leur plan de vie étant dessiné ligne à ligne
+Par la logique d’une Influence maligne.

--- a/poems/paul-verlaine/lheure-du-berger.txt
+++ b/poems/paul-verlaine/lheure-du-berger.txt
@@ -1,0 +1,14 @@
+La lune est rouge au brumeux horizon ;
+Dans un brouillard qui danse la prairie
+S’endort fumeuse, et la grenouille crie
+Par les joncs verts où circule un frisson ;
+
+Les fleurs des eaux referment leurs corolles ;
+Des peupliers profilent aux lointains,
+Droits et serrés, leurs spectres incertains ;
+Vers les buissons errent les lucioles ;
+
+Les chats-huants s’éveillent, et sans bruit
+Rament l’air noir avec leurs ailes lourdes,
+Et le zénith s’emplit de lueurs sourdes.
+Blanche, Vénus émerge, et c’est la Nuit.

--- a/poems/paul-verlaine/marco.txt
+++ b/poems/paul-verlaine/marco.txt
@@ -1,0 +1,63 @@
+Quand Marco passait, tous les jeunes hommes
+Se penchaient pour voir ses yeux, des Sodomes
+Où les feux d’Amour brûlaient sans pitié
+Ta pauvre cahutte, ô froide Amitié ;
+
+Tout autour dansaient des parfums mystiques
+Où l’âme en pleurant s’anéantissait,
+Sur ses cheveux roux un charme glissait ;
+Sa robe rendait d’étranges musiques
+&#65279;Quand Marco passait.
+
+Quand Marco chantait, ses mains sur l’ivoire
+Evoquaient souvent la profondeur noire
+Des airs primitifs que nul n’a redits,
+Et sa voix montait dans les paradis
+De la symphonie immense des rêves,
+Et l’enthousiasme alors transportait
+Vers des cieux connus quiconque écoutait
+
+Ce timbre d’argent qui vibrait sans trêves
+&#65279;Quand Marco chantait.
+
+Quand Marco pleurait, ses terribles larmes
+Défiaient l’éclat des plus belles armes ;
+Ses lèvres de sang fonçaient leur carmin
+Et son désespoir n’avait rien d’humain ;
+Pareil au foyer que l’huile exaspère,
+Son courroux croissait, rouge, et l’on aurait
+Dit d’une lionne à l’âpre forêt
+Communiquant sa terrible colère
+&#65279;Quand Marco pleurait.
+
+Quand Marco dansait, sa jupe moirée
+Allait et venait comme une marée,
+Et, tel qu’un bambou flexible, son flanc
+Se tordait, faisant saillir son sein blanc :
+
+Un éclair partait. Sa jambe de marbre,
+Emphatiquement cynique, haussait
+Ses mates splendeurs, et cela faisait
+Le bruit du vent de la nuit dans un arbre
+&#65279;Quand Marco dansait.
+
+Quand Marco dormait, oh ! quels parfums d’ambre
+Et de chair mêlés opprimaient la chambre !
+Sous les draps la ligne exquise du dos
+Ondulait, et dans l’ombre des rideaux
+L’haleine montait, rhythmique et légère ;
+Un sommeil heureux et calme fermait
+Ses yeux, et ce doux mystère charmait
+Les vagues objets parmi l’étagère,
+&#65279;Quand Marco dormait.
+
+Mais quand elle aimait, des flots de luxure
+
+Débordaient, ainsi que d’une blessure
+Sort un sang vermeil qui fume et qui bout,
+De ce corps cruel que son crime absout ;
+Le torrent rompait les digues de l’âme,
+Noyait la pensée, et bouleversait
+Tout sur son passage, et rebondissait
+Souple et dévorant comme de la flamme,
+&#65279;Et puis se glaçait.

--- a/poems/paul-verlaine/marine.txt
+++ b/poems/paul-verlaine/marine.txt
@@ -1,0 +1,19 @@
+L’Océan sonore
+Palpite sous l’œil
+De la lune en deuil
+Et palpite encore,
+
+Tandis qu’un éclair
+Brutal et sinistre
+Fend le ciel de bistre
+D’un long zigzag clair,
+
+Et que chaque lame
+En bonds convulsifs
+Le long des récifs
+Va, vient, luit et clame,
+
+Et qu’au firmament,
+Où l’ouragan erre,
+Rugit le tonnerre
+Formidablement.

--- a/poems/paul-verlaine/mon-reve-familier.txt
+++ b/poems/paul-verlaine/mon-reve-familier.txt
@@ -1,0 +1,17 @@
+Je fais souvent ce rêve étrange et pénétrant
+D’une femme inconnue, et que j’aime, et qui m’aime,
+Et qui n’est, chaque fois, ni tout à fait la même
+Ni tout à fait une autre, et m’aime et me comprend.
+
+Car elle me comprend, et mon cœur, transparent
+Pour elle seule, hélas ! cesse d’être un problème
+Pour elle seule, et les moiteurs de mon front blême,
+Elle seule les sait rafraîchir, en pleurant.
+
+Est-elle brune, blonde ou rousse ? — Je l’ignore.
+Son nom ? Je me souviens qu’il est doux et sonore
+Comme ceux des aimés que la Vie exila.
+
+Son regard est pareil au regard des statues,
+Et, pour sa voix, lointaine, et calme, et grave, elle a
+L’inflexion des voix chères qui se sont tues.

--- a/poems/paul-verlaine/monsieur-prudhomme.txt
+++ b/poems/paul-verlaine/monsieur-prudhomme.txt
@@ -1,0 +1,17 @@
+Il est grave : il est maire et père de famille.
+Son faux-col engloutit son oreille. Ses yeux
+Dans un rêve sans fin flottent insoucieux,
+Et le printemps en fleurs sur ses pantoufles brille.
+
+Que lui fait l’astre d’or, que lui fait la charmille
+Où l’oiseau chante à l’ombre, et que lui font les cieux,
+Et les prés verts et les gazons silencieux ?
+Monsieur Prudhomme songe à marier sa fille
+
+Avec monsieur Machin, un jeune homme cossu.
+Il est juste-milieu, botaniste et pansu.
+Quant aux faiseurs de vers, ces vauriens, ces maroufles,
+
+Ces fainéants barbus, mal peignés, il les a
+Plus en horreur que son éternel coriza,
+Et le printemps en fleurs brille sur ses pantoufles.

--- a/poems/paul-verlaine/nevermore-1.txt
+++ b/poems/paul-verlaine/nevermore-1.txt
@@ -1,0 +1,17 @@
+Souvenir, souvenir, que me veux-tu ? L’automne
+Faisait voler la grive à travers l’air atone,
+Et le soleil dardait un rayon monotone
+Sur le bois jaunissant où la bise détone
+
+Nous étions seul à seule et marchions en rêvant,
+Elle et moi, les cheveux et la pensée au vent.
+Soudain, tournant vers moi son regard émouvant :
+« Quel fut ton plus beau jour ? » fit sa voix d’or vivant,
+
+Sa voix douce et sonore, au frais timbre angélique.
+Un sourire discret lui donna la réplique,
+Et je baisai sa main blanche, dévotement.
+
+— Ah ! les premières fleurs, qu’elles sont parfumées !
+Et qu’il bruit avec un murmure charmant
+Le premier oui qui sort de lèvres bien-aimées !

--- a/poems/paul-verlaine/nevermore-2.txt
+++ b/poems/paul-verlaine/nevermore-2.txt
@@ -1,0 +1,23 @@
+Allons, mon pauvre cœur, allons, mon vieux complice,
+Redresse et peints à neuf tous tes arcs triomphaux ;
+Brûle un encens ranci sur tes autels d’or faux ;
+Sème de fleurs les bords béants du précipice ;
+Allons, mon pauvre cœur, allons, mon vieux complice !
+
+Pousse à Dieu ton cantique, ô chantre rajeuni ;
+Entonne, orgue enroué, des Te Deum splendides ;
+Vieillard prématuré, mets du fard sur tes rides ;
+Couvre-toi de tapis mordorés, mur jauni ;
+Pousse à Dieu ton cantique, ô chantre rajeuni.
+
+Sonnez, grelots ; sonnez, clochettes ; sonnez, cloches !
+Car mon rêve impossible a pris corps, et je l’ai
+Entre mes bras pressé : le Bonheur, cet ailé
+Voyageur qui de l’Homme évite les approches,
+— Sonnez, grelots ; sonnez, clochettes ; sonnez, cloches !
+
+Le Bonheur a marché côte à côte avec moi ;
+Mais la FATALITE ne connaît point de trêve :
+Le ver est dans le fruit, le réveil dans le rêve,
+Et le remords est dans l’amour : telle est la loi.
+— Le Bonheur a marché côte à côte avec moi.

--- a/poems/paul-verlaine/nocturne-parisien.txt
+++ b/poems/paul-verlaine/nocturne-parisien.txt
@@ -1,0 +1,117 @@
+Roule, roule ton flot indolent, morne Seine. —
+Sous tes ponts qu’environne une vapeur malsaine
+Bien des corps ont passé, morts, horribles, pourris,
+Dont les âmes avaient pour meurtrier Paris.
+
+Mais tu n’en traînes pas, en tes ondes glacées,
+Autant que ton aspect m’inspire de pensées !
+
+Le Tibre a sur ses bords des ruines qui font
+Monter le voyageur vers un passé profond,
+Et qui, de lierre noir et de lichen couvertes,
+Apparaissent, tas gris, parmi les herbes vertes.
+Le gai Guadalquivir rit aux blonds orangers
+Et reflète, les soirs, des boléros légers.
+Le Pactole a son or, le Bosphore a sa rive
+Où vient faire son kief l’odalisque lascive.
+Le Rhin est un burgrave, et c’est un troubadour
+Que le Lignon, et c’est un ruffian que l’Adour.
+Le Nil, au bruit plaintif de ses eaux endormies
+Berce de rêves doux le sommeil des momies.
+Le grand Meschascébé, fier de ses joncs sacrés,
+Charrie augustement ses îlots mordorés,
+Et soudain, beau d’éclairs, de fracas et de fastes,
+Splendidement s’écroule en Niagaras vastes.
+
+L’Eurotas, où l’essaim des cygnes familiers
+Mêle sa grâce blanche au vert mat des lauriers,
+Sous son ciel clair que raie un vol de gypaète,
+Rhythmique et caressant, chante ainsi qu’un poëte.
+Enfin, Ganga, parmi les hauts palmiers tremblants
+Et les rouges padmas, marche à pas fiers et lents
+En appareil royal, tandis qu’au loin la foule
+Le long des temples va hurlant, vivante houle,
+Au claquement massif des cymbales de bois,
+Et qu’accroupi, filant ses notes de hautbois,
+Du saut de l’antilope agile attendant l’heure,
+Le tigre jaune au dos rayé s’étire et pleure.
+
+— Toi, Seine, tu n’as rien. Deux quais, et voilà tout,
+Deux quais crasseux, semés de l’un à l’autre bout
+D’affreux bouquins moisis et d’une foule insigne
+Qui fait dans l’eau des ronds et qui pêche à la ligne.
+Oui, mais quand vient le soir, raréfiant enfin
+Les passants alourdis de sommeil ou de faim,
+
+Et que le couchant met au ciel des taches rouges,
+Qu’il fait bon aux rêveurs descendre de leurs bouges
+Et, s’accoudant au pont de la Cité, devant
+Notre-Dame, songer, cœur et cheveux au vent !
+Les nuages, chassés par la brise nocturne,
+Courent, cuivreux et roux, dans l’azur taciturne.
+Sur la tête d’un roi du portail, le soleil,
+Au moment de mourir, pose un baiser vermeil.
+L’hirondelle s’enfuit à l’approche de l’ombre,
+Et l’on voit voleter la chauve-souris sombre.
+Tout bruit s’apaise autour. À peine un vague son
+Dit que la ville est là qui chante sa chanson,
+Qui lèche ses tyrans et qui mord ses victimes ;
+Et c’est l’aube des vols, des amours et des crimes.
+— Puis, tout à coup, ainsi qu’un ténor effaré
+Lançant dans l’air bruni son cri désespéré,
+Son cri qui se lamente et se prolonge, et crie,
+Éclate en quelque coin l’orgue de Barbarie :
+Il brame un de ces airs, romances ou polkas,
+
+Qu’enfants nous tapotions sur nos harmonicas
+Et qui font, lents ou vifs, réjouissants ou tristes,
+Vibrer l’âme aux proscrits, aux femmes, aux artistes.
+C’est écorché, c’est faux, c’est horrible, c’est dur,
+Et donnerait la fièvre à Rossini, pour sûr ;
+Ces rires sont traînés, ces plaintes sont hachées ;
+Sur une clef de sol impossible juchées,
+Les notes ont un rhume et les do sont des la,
+Mais qu’importe ! l’on pleure en entendant cela !
+Mais l’esprit, transporté dans le pays des rêves,
+Sent à ces vieux accords couler en lui des sèves ;
+La pitié monte au cœur et les larmes aux yeux,
+Et l’on voudrait pouvoir goûter la paix des cieux,
+Et dans une harmonie étrange et fantastique
+Qui tient de la musique et tient de la plastique,
+L’âme, les inondant de lumière et de chant,
+Mêle les sons de l’orgue aux rayons du couchant !
+
+— Et puis l’orgue s’éloigne, et puis c’est le silence,
+
+Et la nuit terne arrive, et Vénus se balance
+Sur une molle nue au fond des cieux obscurs ;
+On allume les becs de gaz le long des murs,
+Et l’astre et les flambeaux font des zigzags fantasques
+Dans le fleuve plus noir que le velours des masques ;
+Et le contemplateur sur le haut garde-fou
+Par l’air et par les ans rouillé comme un vieux sou
+Se penche, en proie aux vents néfastes de l’abîme.
+Pensée, espoir serein, ambition sublime,
+Tout, jusqu’au souvenir, tout s’envole, tout fuit,
+Et l’on est seul avec Paris, l’Onde et la Nuit !
+
+— Sinistre trinité ! De l’ombre dures portes !
+Mané-Thécel-Pharès des illusions mortes !
+Vous êtes toutes trois, ô Goules de malheur,
+Si terribles, que l’Homme, ivre de la douleur
+Que lui font en perçant sa chair vos doigts de spectre,
+L’Homme, espèce d’Oreste à qui manque une Électre,
+Sous la fatalité de votre regard creux
+
+Ne peut rien et va droit au précipice affreux ;
+Et vous êtes aussi toutes trois si jalouses
+De tuer et d’offrir au grand Ver des épouses
+Qu’on ne sait que choisir entre vos trois horreurs,
+Et si l’on craindrait moins périr par les terreurs
+Des Ténèbres que sous l’Eau sourde, l’Eau profonde,
+Ou dans tes bras fardés, Paris, reine du monde !
+
+— Et tu coules toujours, Seine, et, tout en rampant,
+Tu traînes dans Paris ton cours de vieux serpent,
+De vieux serpent boueux, emportant vers tes havres
+Tes cargaisons de bois, de houille et de cadavres !

--- a/poems/paul-verlaine/nuit-du-walpurgis-classique.txt
+++ b/poems/paul-verlaine/nuit-du-walpurgis-classique.txt
@@ -1,0 +1,54 @@
+C’est plutôt le sabbat du second Faust que l’autre.
+Un rhythmique sabbat, rhythmique, extrêmement
+Rhythmique.— Imaginez un jardin de Lenôtre,
+Correct, ridicule et charmant.
+
+Des ronds-points ; au milieu, des jets d’eau ; des allées
+Toutes droites ; sylvains de marbre ; dieux marins
+De bronze ; çà et là, des Vénus étalées ;
+Des quinconces, des boulingrins ;
+
+Des châtaigniers ; des plants de fleurs formant la dune ;
+Ici, des rosiers nains qu’un goût docte effila ;
+Plus loin, des ifs taillés en triangle. La lune
+D’un soir d’été sur tout cela.
+
+Minuit sonne, et réveille au fond du parc aulique
+Un air mélancolique, un sourd, lent et doux air
+De chasse : tel, doux, lent, sourd et mélancolique,
+L’air de chasse de Tannhauser.
+
+Des chants voilés de cors lointains où la tendresse
+Des sens étreint l’effroi de l’âme en des accords
+Harmonieusement dissonnants dans l’ivresse ;
+Et voici qu’à l’appel des cors
+
+S’entrelacent soudain des formes toutes blanches,
+Diaphanes, et que le clair de lune fait
+Opalines parmi l’ombre verte des branches,
+— Un Watteau rêvé par Raffet ! —
+
+S’entrelacent parmi l’ombre verte des arbres
+D’un geste alangui, plein d’un désespoir profond,
+Puis, autour des massifs, des bronzes et des marbres
+Très-lentement dansent en rond.
+
+— Ces spectres agités, sont-ce donc la pensée
+Du poëte ivre, ou son regret, ou son remords,
+Ces spectres agités en tourbe cadensée,
+Ou bien tout simplement des morts ?
+
+Sont-ce donc ton remords, ô révasseur qu’invite
+L’horreur, ou ton regret, ou ta pensée, — hein ? — tous
+Ces spectres qu’un vertige irrésistible agite,
+Ou bien des morts qui seraient fous ? —
+
+N’importe ! ils vont toujours, les fébriles fantômes,
+Menant leur ronde vaste et morne et tressautant
+Comme dans un rayon de soleil des atomes,
+Et s’évaporent à l’instant
+
+Humide et blême où l’aube éteint l’un après l’autre
+Les cors, en sorte qu’il ne reste absolument
+Plus rien — absolument — qu’un jardin de Lenôtre,
+Correct, ridicule et charmant.

--- a/poems/paul-verlaine/prologue.txt
+++ b/poems/paul-verlaine/prologue.txt
@@ -1,0 +1,113 @@
+Dans ces temps fabuleux, les limbes de l’histoire,
+Où les fils de Raghû, beaux de fard et de gloire,
+Vers la Ganga régnaient leur règne étincelant,
+Et, par l’intensité de leur vertu troublant
+Les Dieux et les Démons et Bhagavat lui-même,
+Augustes, s’élevaient jusqu’au Néant suprême,
+
+Ah ! la terre et la mer et le ciel, purs encor
+Et jeunes, qu’arrosait une lumière d’or
+Frémissante, entendaient, apaisant leurs murmures
+De tonnerres, de flots heurtés, de moissons mûres,
+Et retenant le vol obstiné des essaims,
+Les Poëtes sacrés chanter les Guerriers saints,
+Cependant que le ciel et la mer et la terre
+Voyaient, — rouges et las de leur travail austère,
+S’incliner, pénitents fauves et timorés,
+Les Guerriers saints devant les Poëtes sacrés !
+Une connexité grandiosement alme
+Liait le Kçhatrya serein au Chanteur calme,
+Valmiki l’excellent à l’excellent Rama :
+Telles sur un étang deux touffes de padma.
+
+— Et sous tes cieux dorés et clairs, Hellas antique,
+De Spartè la sévère à la rieuse Attique,
+Les Aèdes, Orpheus, Alkaïos, étaient
+Encore des héros altiers, et combattaient.
+
+Homéros, s’il n’a pas, lui, manié le glaive,
+Fait retentir, clameur immense qui s’élève,
+Vos échos jamais las, vastes postérités,
+D’Hektôr, et d’Odysseus, et d’Akhilleus chantés.
+Les héros à leur tour, après les luttes vastes,
+Pieux, sacrifiaient aux neuf Déesses chastes,
+Et non moins que de l’art d’Arès furent épris
+De l’Art dont une Palme immortelle est le prix,
+Akhilleus entre tous ! Et le Laërtiade
+Dompta, parole d’or qui charme et persuade,
+Les esprits et les cœurs et les âmes toujours,
+Ainsi qu’Orpheus domptait les tigres et les ours.
+
+— Plus tard, vers des climats plus rudes, en des ères
+Barbares, chez les Francs tumultueux, nos pères,
+Est-ce que le Trouvère héroïque n’eut pas
+Comme le Preux sa part auguste des combats ?
+Est-ce que, Théroldus ayant dit Charlemagne,
+Et son neveu Roland resté dans la montagne,
+
+Et le bon Olivier et Turpin au grand cœur,
+En beaux couplets et sur un rhythme âpre et vainqueur,
+Est-ce que, cinquante ans après, dans les batailles,
+Les durs Leudes perdant leur sang par vingt entailles,
+Ne chantaient pas le chant de geste sans rivaux
+De Roland et de ceux qui virent Roncevaux
+Et furent de l’énorme et suprême tuerie,
+Du temps de l’Empereur à la barbe fleurie ?…
+
+— Aujourd’hui, l’Action et le Rêve ont brisé
+Le pacte primitif par les siècles usé,
+Et plusieurs ont trouvé funeste ce divorce
+De l’Harmonie immense et bleue et de la Force.
+La Force, qu’autrefois le Poëte tenait
+En bride, blanc cheval ailé qui rayonnait,
+La Force, maintenant, la Force, c’est la Bête
+Féroce bondissante et folle et toujours prête
+À tout carnage, à tout dévastement, à tout
+Égorgement, d’un bout du monde à l’autre bout !
+
+L’Action qu’autrefois réglait le chant des lyres,
+Trouble, enivrée, en proie aux cent mille délires
+Fuligineux d’un siècle en ébullition,
+L’Action à présent, — ô pitié ! — l’Action,
+C’est l’ouragan, c’est la tempête, c’est la houle
+Marine dans la nuit sans étoiles, qui roule
+Et déroule parmi des bruits sourds l’effroi vert
+Et rouge des éclairs sur le ciel entrouvert !
+
+— Cependant, orgueilleux et doux, loin des vacarmes
+De la vie et du choc désordonné des armes
+Mercenaires, voyez, gravissant les hauteurs
+Ineffables, voici le groupe des Chanteurs
+Vêtus de blanc, et des lueurs d’apothéoses
+Empourprent la fierté sereine de leurs poses :
+Tous beaux, tous purs, avec des rayons dans les yeux,
+Et sous leur front le rêve inachevé des Dieux !
+Le monde, que troublait leur parole profonde,
+Les exile. À leur tour ils exilent le monde !
+
+C’est qu’ils ont à la fin compris qu’il ne faut plus
+Mêler leur note pure aux cris irrésolus
+Que va poussant la foule obscène et violente,
+Et que l’isolement sied à leur marche lente.
+Le Poëte, l’amour du Beau, voilà sa foi,
+L’Azur, son étendard, et l’Idéal, sa loi !
+Ne lui demandez rien de plus, car ses prunelles,
+Où le rayonnement des choses éternelles
+A mis des visions qu’il suit avidement,
+Ne sauraient s’abaisser une heure seulement
+Sur le honteux conflit des besognes vulgaires
+Et sur vos vanités plates ; et si naguères
+On le vit au milieu des hommes, épousant
+Leurs querelles, pleurant avec eux, les poussant
+Aux guerres, célébrant l’orgueil des Républiques
+Et l’éclat militaire et les splendeurs auliques
+Sur la kithare, sur la harpe et sur le luth,
+S’il honorait parfois le présent d’un salut
+Et daignait consentir à ce rôle de prêtre
+
+D’aimer et de bénir, et s’il voulait bien être
+La voix qui rit ou pleure alors qu’on pleure ou rit,
+S’il inclinait vers l’âme humaine son esprit,
+C’est qu’il se méprenait alors sur l’âme humaine.
+
+— Maintenant, va, mon Livre, où le hasard te mène !

--- a/poems/paul-verlaine/promenade-sentimentale.txt
+++ b/poems/paul-verlaine/promenade-sentimentale.txt
@@ -1,0 +1,17 @@
+Le couchant dardait ses rayons suprêmes
+Et le vent berçait les nénuphars blêmes ;
+Les grands nénuphars entre les roseaux
+Tristement luisaient sur les calmes eaux.
+
+Moi j’errais tout seul, promenant ma plaie
+Au long de l’étang, parmi la saulaie
+Où la brume vague évoquait un grand
+Fantôme laiteux se désespérant
+Et pleurant avec la voix des sarcelles
+Qui se rappelaient en battant des ailes
+Parmi la saulaie où j’errais tout seul
+Promenant ma plaie ; et l’épais linceul
+Des ténèbres vint noyer les suprêmes
+Rayons du couchant dans ses ondes blêmes
+Et des nénuphars, parmi les roseaux,
+Des grands nénuphars sur les calmes eaux.

--- a/poems/paul-verlaine/resignation.txt
+++ b/poems/paul-verlaine/resignation.txt
@@ -1,0 +1,17 @@
+Tout enfant, j’allais rêvant Ko-Hinnor,
+Somptuosité persane et papale,
+Héliogabale et Sardanapale !
+
+Mon désir créait sous des toits en or,
+Parmi les parfums, au son des musiques,
+Des harems sans fin, paradis physiques !
+
+Aujourd’hui, plus calme et non moins ardent,
+Mais sachant la vie et qu’il faut qu’on plie,
+J’ai dû refréner ma belle folie,
+Sans me résigner par trop cependant.
+
+Soit ! le grandiose échappe à ma dent,
+Mais, fi de l’aimable et fi de la lie !
+Et je hais toujours la femme jolie,
+La rime assonante et l’ami prudent.

--- a/poems/paul-verlaine/serenade.txt
+++ b/poems/paul-verlaine/serenade.txt
@@ -1,0 +1,34 @@
+Comme la voix d’un mort qui chanterait
+&#65279;Du fond de sa fosse,
+Maîtresse, entends monter vers ton retrait
+&#65279;Ma voix aigre et fausse.
+
+Ouvre ton âme et ton oreille au son
+&#65279;De ma mandoline :
+Pour toi j’ai fait, pour toi, cette chanson
+&#65279;Cruelle et câline.
+
+Je chanterai tes yeux d’or et d’onyx
+&#65279;Purs de toutes ombres,
+Puis le Léthé de ton sein, puis le Styx
+&#65279;De tes cheveux sombres.
+
+Comme la voix d’un mort qui chanterait
+&#65279;Du fond de sa fosse,
+Maîtresse, entends monter vers ton retrait
+&#65279;Ma voix aigre et fausse.
+
+Puis je louerai beaucoup, comme il convient,
+&#65279;Cette chair bénie
+Dont le parfum opulent me revient
+&#65279;Les nuits d’insomnie.
+
+Et pour finir, je dirai le baiser
+&#65279;De ta lèvre rouge,
+Et ta douceur à me martyriser,
+&#65279;— Mon Ange ! — ma Gouge !
+
+Ouvre ton âme et ton oreille au son
+&#65279;De ma mandoline :
+Pour toi j’ai fait, pour toi, cette chanson
+&#65279;Cruelle et câline.

--- a/poems/paul-verlaine/soleils-couchants.txt
+++ b/poems/paul-verlaine/soleils-couchants.txt
@@ -1,0 +1,17 @@
+Une aube affaiblie
+Verse par les champs
+La mélancolie
+Des soleils couchants.
+
+La mélancolie
+Berce de doux chants
+Mon cœur qui s’oublie
+Aux soleils couchants.
+Et d’étranges rêves,
+Comme des soleils
+Couchants sur les grèves,
+Fantômes vermeils,
+Défilent sans trêves,
+Défilent, pareils
+À des grands soleils
+Couchants sur les grèves.

--- a/poems/paul-verlaine/sub-urbe.txt
+++ b/poems/paul-verlaine/sub-urbe.txt
@@ -1,0 +1,41 @@
+Les petits ifs du cimetière
+Frémissent au vent hiémal,
+Dans la glaciale lumière.
+
+Avec des bruits sourds qui font mal,
+Les croix de bois des tombes neuves
+Vibrent sur un ton anormal.
+
+Silencieux comme des fleuves,
+Mais gros de pleurs comme eux de flots,
+Les fils, les mères et les veuves
+
+Par les détours du triste enclos
+S’écoulent, — lente théorie, —
+Au rhythme heurté des sanglots.
+
+Le sol sous les pieds glisse et crie,
+Là-haut de grands nuages tors
+S’échevèlent avec furie.
+
+Pénétrant comme le remords,
+Tombe un froid lourd qui vous écœure
+Et qui doit filtrer chez les morts,
+
+Chez les pauvres morts, à toute heure
+Seuls, et sans cesse grelottants,
+— Qu’on les oublie ou qu’on les pleure ! —
+
+Ah ! vienne vite le Printemps,
+Et son clair soleil qui caresse,
+Et ses doux oiseaux caquetants !
+
+Refleurisse l’enchanteresse
+Gloire des jardins et des champs
+Que l’âpre hiver tient en détresse !
+
+Et que, — des levers aux couchants, —
+L’or dilaté d’un ciel sans bornes
+Berce de parfums et de chants,
+
+Chers endormis, vos sommeils mornes !

--- a/poems/paul-verlaine/un-dahlia.txt
+++ b/poems/paul-verlaine/un-dahlia.txt
@@ -1,0 +1,15 @@
+Courtisane au sein dur, à l’œil opaque et brun
+S’ouvrant avec lenteur comme celui d’un bœuf,
+Ton grand torse reluit ainsi qu’un marbre neuf.
+
+Fleur grasse et riche, autour de toi ne flotte aucun
+Arôme, et la beauté sereine de ton corps
+Déroule, mate, ses impeccables accords.
+
+Tu ne sens même pas la chair, ce goût qu’au moins
+Exhalent celles-là qui vont fanant les foins,
+Et tu trônes, Idole insensible à l’encens.
+
+— Ainsi le Dahlia, roi vêtu de splendeur,
+Élève sans orgueil sa tête sans odeur,
+Irritant au milieu des jasmins agaçants !

--- a/poems/paul-verlaine/une-grande-dame.txt
+++ b/poems/paul-verlaine/une-grande-dame.txt
@@ -1,0 +1,17 @@
+Belle « à damner les saints », à troubler sous l’aumusse
+Un vieux juge ! Elle marche impérialement.
+Elle parle — et ses dents font un miroitement —
+Italien, avec un léger accent russe.
+
+Ses yeux froids où l’émail sertit le bleu de Prusse
+Ont leclat insolent et dur du diamant.
+Pour la splendeur du sein, pour le rayonnement
+De la peau, nulle reine ou courtisane, fût-ce
+
+Cléopâtre la lynce ou la chatte Ninon,
+N’égale sa beauté patricienne, non !
+Vois, ô bon Buridan : « C’est une grande dame ! »
+
+Il faut — pas de milieu ! — l’adorer à genoux,
+Plat, n’ayant d’astre aux cieux que ses lourds cheveux roux
+Ou bien lui cravacher la face, à cette femme !

--- a/poems/paul-verlaine/voeu.txt
+++ b/poems/paul-verlaine/voeu.txt
@@ -1,0 +1,17 @@
+Ah ! les oarystis ! les premières maîtresses !
+L’or des cheveux, l’azur des yeux, la fleur des chairs,
+Et puis, parmi l’odeur des corps jeunes et chers,
+La spontanéité craintive des caresses !
+
+Sont-elles assez loin toutes ces allégresses
+Et toutes ces candeurs ! Hélas ! toutes devers
+Le printemps des regrets ont fui les noirs hivers
+De mes ennuis, de mes dégoûts, de mes détresses !
+
+Si que me voilà seul à présent, morne et seul,
+Morne et désespéré, plus glacé qu’un aïeul,
+Et tel qu’un orphelin pauvre sans sœur aînée.
+
+Ô la femme à l’amour câlin et réchauffant,
+Douce, pensive et brune, et jamais étonnée,
+Et qui parfois vous baise au front, comme un enfant !

--- a/scripts/ingest-wikisource-verlaine-poemes-saturniens.mjs
+++ b/scripts/ingest-wikisource-verlaine-poemes-saturniens.mjs
@@ -1,0 +1,200 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const AUTHOR = {
+  author: "Paul Verlaine",
+  author_slug: "paul-verlaine",
+  century: 19,
+  collection_title: "Poèmes saturniens (1866)",
+  collection_source_url: "https://fr.wikisource.org/wiki/Po%C3%A8mes_saturniens_(1866)",
+  text_locale: "fr",
+  original_language: "fr",
+  text_direction: "ltr",
+};
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#8195;/g, "")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…");
+}
+
+function stripTags(value) {
+  return decodeHtml(value.replace(/<[^>]+>/g, ""))
+    .replace(/\u00a0/g, " ")
+    .replace(/\r/g, "")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+}
+
+function normalizePoemParagraph(value) {
+  return value.replace(/\n{3,}/g, "\u0000").replace(/\n{2}/g, "\n").replace(/\u0000/g, "\n\n");
+}
+
+function slugify(value) {
+  return value
+    .replace(/œ/g, "oe")
+    .replace(/Œ/g, "oe")
+    .replace(/æ/g, "ae")
+    .replace(/Æ/g, "ae")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[()]/g, " ")
+    .replace(/[’']/g, "")
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+}
+
+async function fetchText(url) {
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync(
+        "curl",
+        ["-L", "--fail", "--silent", "-A", "Mozilla/5.0", url],
+        { maxBuffer: 10 * 1024 * 1024 },
+      );
+      return stdout;
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      }
+    }
+  }
+  throw lastError;
+}
+
+async function fetchRenderedText(pageTitle) {
+  const url =
+    "https://fr.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  const stdout = await fetchText(url);
+  const json = JSON.parse(stdout);
+  if (!json.parse?.text) throw new Error(`Wikisource parse failed for ${pageTitle}`);
+  return json.parse.text;
+}
+
+async function listPoems() {
+  const rendered = await fetchRenderedText("Poèmes saturniens (1866)");
+  const matches = [
+    ...rendered.matchAll(
+      /href="\/wiki\/(Po%C3%A8mes_saturniens_\(1866\)\/[^"#?]+)"[^>]*>([^<]+)<\/a>/g,
+    ),
+  ];
+
+  const poems = [];
+  for (const match of matches) {
+    const pagePath = decodeURIComponent(match[1]);
+    const title = stripTags(match[2]);
+    const slug = slugify(pagePath.replace("Poèmes_saturniens_(1866)/", ""));
+    poems.push({
+      page_title: pagePath.replace(/_/g, " "),
+      title,
+      slug,
+      source_url: `https://fr.wikisource.org/wiki/${match[1]}`,
+    });
+  }
+
+  return poems;
+}
+
+function extractBody(rendered, pageTitle) {
+  const poemBlocks = [...rendered.matchAll(/<div class="poem verse">([\s\S]*?)<\/div>/g)];
+  if (!poemBlocks.length) throw new Error(`No poem blocks found for ${pageTitle}`);
+
+  const stanzas = poemBlocks
+    .map((match) => {
+      const html = match[1].replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+      const paragraphs = [...html.matchAll(/<p>([\s\S]*?)<\/p>/g)];
+      const stanza = paragraphs
+        .map((paragraph) =>
+          normalizePoemParagraph(
+            stripTags(
+              paragraph[1]
+                .replace(/<br\s*\/?>/g, "\n")
+                .replace(/^\s*\n+/, ""),
+            ),
+          ),
+        )
+        .filter(Boolean)
+        .join("\n\n");
+      return stanza;
+    })
+    .filter(Boolean);
+
+  return stanzas.join("\n\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function buildMeta(poem) {
+  return yaml.dump(
+    {
+      id: `${AUTHOR.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: AUTHOR.author,
+      author_slug: AUTHOR.author_slug,
+      title: poem.title,
+      century: AUTHOR.century,
+      text_locale: AUTHOR.text_locale,
+      original_language: AUTHOR.original_language,
+      text_direction: AUTHOR.text_direction,
+      text_path: `poems/${AUTHOR.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: poem.source_url,
+      public_domain_rationale:
+        "Public domain in the United States: first published in 1866 (pre-1929) and the author died in 1896; text via French Wikisource.",
+      collection_title: AUTHOR.collection_title,
+      collection_source_url: AUTHOR.collection_source_url,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  const poemsDir = path.join("poems", AUTHOR.author_slug);
+  const metaDir = path.join("meta", AUTHOR.author_slug);
+  await fs.mkdir(poemsDir, { recursive: true });
+  await fs.mkdir(metaDir, { recursive: true });
+
+  const poems = await listPoems();
+  if (poems.length !== 40) {
+    throw new Error(`Expected 40 poems, found ${poems.length}`);
+  }
+
+  for (const poem of poems) {
+    const rendered = await fetchRenderedText(poem.page_title);
+    const text = extractBody(rendered, poem.page_title);
+    await fs.writeFile(path.join(poemsDir, `${poem.slug}.txt`), `${text}\n`, "utf8");
+    await fs.writeFile(path.join(metaDir, `${poem.slug}.yml`), buildMeta(poem), "utf8");
+    console.log(`${AUTHOR.author}: created ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${poems.length}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/site/src/lib/authors.ts
+++ b/site/src/lib/authors.ts
@@ -78,6 +78,13 @@ export const AUTHOR_INFO: Record<string, AuthorInfo> = {
     source_label: "Wikipedia",
     source_url: "https://en.wikipedia.org/wiki/Emma_Lazarus",
   },
+  "paul-verlaine": {
+    birth_year: 1844,
+    death_year: 1896,
+    bio: "French Symbolist poet whose musical, suggestive lyrics helped define fin-de-siecle verse and influenced modern poetry across Europe.",
+    source_label: "Wikipedia",
+    source_url: "https://en.wikipedia.org/wiki/Paul_Verlaine",
+  },
   "george-gordon-byron": {
     birth_year: 1788,
     death_year: 1824,


### PR DESCRIPTION
Closes #137

## Summary
- add Paul Verlaine to the author registry
- ingest 40 poems from `Poèmes saturniens (1866)` on French Wikisource
- add a repeatable Wikisource ingest script for this collection

## Verification
- `cd site && npm run build`

## Notes
- `Nevermore` appears twice in the source collection as distinct poems, so the ingest preserves them as `nevermore-1` and `nevermore-2`.