### PR TITLE
Migrate site styling to Tailwind (#143)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -2,8 +2,14 @@
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 
+import tailwindcss from '@tailwindcss/vite';
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://thefreeverse.org/',
   integrations: [sitemap()],
+
+  vite: {
+    plugins: [tailwindcss()],
+  },
 });

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/sitemap": "^3.7.2",
+        "@tailwindcss/vite": "^4.2.2",
         "astro": "^5.18.1",
         "js-yaml": "^4.1.1",
-        "minisearch": "^7.2.0"
+        "minisearch": "^7.2.0",
+        "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.1",
@@ -1073,11 +1075,30 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1093,7 +1114,6 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1548,6 +1568,263 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2867,7 +3144,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2999,6 +3275,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -3179,6 +3468,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
     "node_modules/h3": {
@@ -3541,6 +3836,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -3567,6 +3871,255 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/longest-streak": {
@@ -5321,6 +5874,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tiny-inflate": {

--- a/site/package.json
+++ b/site/package.json
@@ -16,9 +16,11 @@
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.2",
+    "@tailwindcss/vite": "^4.2.2",
     "astro": "^5.18.1",
     "js-yaml": "^4.1.1",
-    "minisearch": "^7.2.0"
+    "minisearch": "^7.2.0",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.1",

--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -27,52 +27,91 @@ const normalized = (p?: string) => {
 const here = normalized(currentPath);
 ---
 
-<header class="header">
-  <div class="brand">
-    <a href={`${base}`}>
-      <div class="brand-title">Freeverse</div>
-      <div class="brand-subtitle">Public-domain poetry, pleasantly readable</div>
-      <div class="brand-motto">
-        <a href={`${base}poem/horace/odes-3-30-exegi-monumentum/#l6-l6`}>Non omnis moriar</a>
+<header class="border-b border-black/10 bg-[linear-gradient(180deg,color-mix(in_oklab,var(--paper)_72%,transparent),transparent_72%),var(--header-bg)] px-4 py-4 sm:px-6 lg:px-10">
+  <div class="flex items-start justify-between gap-4">
+    <div class="max-w-sm">
+      <a class="block no-underline" href={`${base}`}>
+        <div class="font-serif text-xl font-semibold tracking-[-0.03em] text-[var(--ink)] sm:text-2xl">Freeverse</div>
+        <div class="mt-1 max-w-[22rem] font-sans text-sm leading-5 text-[var(--muted)]">
+          Public-domain poetry, pleasantly readable.
+        </div>
+      </a>
+      <div class="mt-2 text-sm italic text-[color-mix(in_oklab,var(--muted)_92%,var(--ink))]">
+        <a class="decoration-[color-mix(in_oklab,var(--accent)_45%,transparent)]" href={`${base}poem/horace/odes-3-30-exegi-monumentum/#l6-l6`}>
+          Non omnis moriar
+        </a>
       </div>
-    </a>
-  </div>
+    </div>
 
-  <nav class="nav" aria-label="Primary">
+    <nav class="hidden flex-wrap justify-end gap-2 md:flex" aria-label="Primary">
     {nav.map((item) => (
-      <a href={item.href} aria-current={here === item.key ? "page" : undefined}>
+      <a
+        class:list={[
+          "rounded-full border px-3 py-2 text-sm font-medium no-underline transition",
+          "border-black/10 bg-[color-mix(in_oklab,var(--paper)_88%,transparent)] text-[var(--ink)] hover:border-black/20",
+          here === item.key && "border-black/25 shadow-[0_1px_0_color-mix(in_oklab,var(--ink)_8%,transparent)]",
+        ]}
+        href={item.href}
+        aria-current={here === item.key ? "page" : undefined}
+      >
         {item.label}
       </a>
     ))}
 
-    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle theme">
+    <button
+      class="rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_88%,transparent)] px-3 py-2 text-sm font-medium text-[var(--ink)] transition hover:border-black/20"
+      type="button"
+      data-theme-toggle
+      aria-label="Toggle theme"
+    >
       Theme
     </button>
-  </nav>
-
-  <button
-    class="menu-toggle"
-    type="button"
-    id="menu-toggle"
-    aria-haspopup="true"
-    aria-expanded="false"
-    aria-controls="mobile-menu"
-  >
-    Menu
-  </button>
-
-  <div class="mobile-menu" id="mobile-menu" hidden>
-    <nav class="mobile-nav" aria-label="Primary">
-      {nav.map((item) => (
-        <a href={item.href} aria-current={here === item.key ? "page" : undefined}>
-          {item.label}
-        </a>
-      ))}
     </nav>
+    <div class="md:hidden">
+      <button
+        class="inline-flex items-center rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_88%,transparent)] px-3 py-2 text-sm font-medium text-[var(--ink)]"
+        type="button"
+        id="menu-toggle"
+        aria-haspopup="true"
+        aria-expanded="false"
+        aria-controls="mobile-menu"
+      >
+        Menu
+      </button>
+    </div>
+  </div>
 
-    <button class="theme-toggle" type="button" data-theme-toggle aria-label="Toggle theme">
-      Theme
-    </button>
+  <div class="relative md:hidden">
+    <div
+      class="absolute right-0 top-3 z-20 w-[min(19rem,calc(100vw-2rem))] rounded-3xl border border-black/10 bg-[color-mix(in_oklab,var(--paper)_94%,var(--shell-bg))] p-3 shadow-[var(--shadow)] backdrop-blur-xl"
+      id="mobile-menu"
+      hidden
+    >
+      <nav class="flex flex-col gap-2" aria-label="Primary">
+        {nav.map((item) => (
+          <a
+            class:list={[
+              "rounded-2xl border px-3 py-3 text-sm font-medium no-underline transition",
+              "border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] text-[var(--ink)]",
+              here === item.key && "border-black/25",
+            ]}
+            href={item.href}
+            aria-current={here === item.key ? "page" : undefined}
+          >
+            {item.label}
+          </a>
+        ))}
+      </nav>
+
+      <button
+        class="mt-3 flex w-full items-center justify-center rounded-2xl border border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] px-3 py-3 text-sm font-medium text-[var(--ink)]"
+        type="button"
+        data-theme-toggle
+        aria-label="Toggle theme"
+      >
+        Theme
+      </button>
+    </div>
   </div>
 
   <script is:inline>

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -99,15 +99,20 @@ const jsonLdPayload = [
       <script type="application/ld+json" set:html={serializeJsonLd(jsonLdPayload)} />
     ) : null}
   </head>
-  <body>
-    <a class="skip-link" href="#main-content">Skip to main content</a>
-    <div class="container">
-      <div class="shell">
+  <body class="min-h-screen bg-transparent text-[var(--ink)] antialiased">
+    <a
+      class="skip-link fixed left-4 top-4 z-50 rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_96%,transparent)] px-4 py-2 text-sm font-medium text-[var(--ink)] no-underline shadow-[var(--shadow)] transition-transform duration-150 focus:translate-y-0"
+      href="#main-content"
+    >
+      Skip to main content
+    </a>
+    <div class="mx-auto max-w-7xl px-4 pb-10 pt-5 sm:px-6 sm:pt-7 lg:px-8 lg:pt-10">
+      <div class="overflow-hidden rounded-[28px] border border-black/10 bg-[var(--shell-bg)] shadow-[0_30px_80px_color-mix(in_oklab,var(--ink)_14%,transparent)] backdrop-blur-xl">
         <SiteHeader currentPath={currentPath} />
-        <main id="main-content" tabindex="-1">
+        <main id="main-content" tabindex="-1" class="px-4 py-6 sm:px-6 sm:py-8 lg:px-10 lg:py-10">
           <slot />
         </main>
-        <footer class="footer">
+        <footer class="border-t border-black/10 bg-[var(--footer-bg)] px-4 py-4 text-sm text-[var(--muted)] sm:px-6 lg:px-10">
           <span>
             Built by <a href="https://github.com/Pro777">Pro777</a> and{' '}
             <a href="https://www.moltbook.com/u/Rowan" target="_blank" rel="noopener noreferrer">Rowan</a><a class="easter-link" href={`${base}easter/`} aria-label="Easter egg" title="Easter egg">.</a>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -15,69 +15,139 @@ const featuredStanza = featured ? await loadFirstStanza(featured) : undefined;
   description="Public-domain poetry — a clean reader with shareable line links."
   currentPath="/"
 >
-  <section class="hero">
-    <h1>Freeverse</h1>
-    <p class="lede">Public-domain poetry. A clean reader. Shareable line links.</p>
-  </section>
+  <section class="grid gap-8 lg:grid-cols-[minmax(0,1.5fr)_minmax(20rem,0.95fr)] lg:items-start">
+    <div class="space-y-8">
+      <section class="rounded-[2rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_94%,transparent)] px-6 py-8 shadow-[var(--shadow)] sm:px-8 sm:py-10">
+        <div class="mb-4 flex flex-wrap items-center gap-3">
+          <span class="rounded-full border border-amber-950/10 bg-amber-100/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-amber-900">
+            Public Domain Poetry
+          </span>
+          <span class="text-sm text-[var(--muted)]">Readable, linkable, and built for actual reading.</span>
+        </div>
+        <h1 class="max-w-3xl font-serif text-5xl font-semibold tracking-[-0.04em] text-[var(--ink)] sm:text-6xl lg:text-7xl">
+          Poetry that reads like a page, not a screenshot.
+        </h1>
+        <p class="mt-5 max-w-2xl text-lg leading-8 text-[var(--muted)] sm:text-xl">
+          Freeverse brings public-domain poems into a clean reading surface with shareable line links,
+          author pages, editorial collections, and a growing multilingual corpus.
+        </p>
+        <div class="mt-8 flex flex-wrap gap-3">
+          <a
+            class="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-semibold text-[var(--accent-ink)] no-underline shadow-sm transition hover:brightness-105"
+            href={`${base}browse/`}
+          >
+            Explore the library
+          </a>
+          <a
+            class="rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_92%,transparent)] px-5 py-3 text-sm font-semibold text-[var(--ink)] no-underline transition hover:border-black/20"
+            href={`${base}search/`}
+          >
+            Search poems
+          </a>
+          <a
+            class="rounded-full border border-transparent px-5 py-3 text-sm font-semibold text-[var(--muted)] no-underline transition hover:text-[var(--ink)]"
+            href={`${base}authors/`}
+          >
+            Browse authors
+          </a>
+        </div>
+      </section>
 
-  <section class="grid">
-    <div class="card card-link">
-      <div class="kicker">
-        <h2>Featured</h2>
-        <span class="pill">A small daily delight</span>
-      </div>
-
-      {featured ? (
-        <>
-          <p style="margin: 0.1rem 0 0.1rem;">
-            <a class="featured-title" href={`${base}poem/${featured.id}/`}>
-              <strong>{featured.title}</strong>
-            </a>
+      <section class="grid gap-4 sm:grid-cols-3">
+        <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] p-5 shadow-[var(--shadow)]">
+          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Reader-first</div>
+          <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
+            Stable line breaks, linkable passages, and typography tuned for long reading instead of skimming.
           </p>
-          <p class="muted" style="margin: 0 0 0.6rem;">{featured.author}</p>
-          {featuredStanza ? (
-            <a class="poem-preview-link" href={`${base}poem/${featured.id}/`} aria-label={`Read featured poem: ${featured.title} by ${featured.author}`}>
-              <pre class="poem-preview">{featuredStanza}</pre>
-            </a>
-          ) : (
-            <p class="muted">(Preview unavailable.)</p>
-          )}
-          <div class="actions">
-            <a class="action primary" href={`${base}poem/${featured.id}/`}>Read poem</a>
-            <a class="action" href={`${base}browse/`}>Explore poems</a>
+        </div>
+        <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] p-5 shadow-[var(--shadow)]">
+          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Editorial Paths</div>
+          <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
+            Collections and author pages make the library navigable without turning it into a sterile database.
+          </p>
+        </div>
+        <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] p-5 shadow-[var(--shadow)]">
+          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Machine-readable</div>
+          <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
+            JSON-LD, sitemap support, and public Alcove exports make the corpus usable beyond the browser.
+          </p>
+        </div>
+      </section>
+    </div>
+
+    <section class="space-y-4">
+      <div class="rounded-[2rem] border border-black/10 bg-[linear-gradient(180deg,color-mix(in_oklab,var(--paper)_96%,transparent),color-mix(in_oklab,var(--paper)_88%,transparent))] p-6 shadow-[var(--shadow)] sm:p-7">
+        <div class="mb-5 flex items-center justify-between gap-3">
+          <div>
+            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Featured Poem</div>
+            <div class="mt-1 text-sm italic text-[var(--muted)]">A small daily delight</div>
           </div>
-        </>
-      ) : (
-        <p class="muted">(No featured poem set.)</p>
-      )}
-    </div>
+          <span class="rounded-full border border-amber-950/10 bg-amber-100/75 px-3 py-1 text-xs font-medium text-amber-900">
+            Open the page, read the whole thing
+          </span>
+        </div>
 
-    <div class="card">
-      <div class="kicker">
-        <h2>Explore poems</h2>
-        <span class="pill">By author, title (more soon)</span>
+        {featured ? (
+          <>
+            <a class="block no-underline" href={`${base}poem/${featured.id}/`}>
+              <div class="font-serif text-3xl font-semibold tracking-[-0.03em] text-[var(--ink)]">
+                {featured.title}
+              </div>
+              <div class="mt-2 text-sm uppercase tracking-[0.18em] text-[var(--muted)]">
+                {featured.author}
+              </div>
+            </a>
+            {featuredStanza ? (
+              <a
+                class="mt-6 block rounded-[1.5rem] border border-black/10 bg-[var(--preview-bg)] p-5 no-underline transition hover:border-black/20"
+                href={`${base}poem/${featured.id}/`}
+                aria-label={`Read featured poem: ${featured.title} by ${featured.author}`}
+              >
+                <pre class="m-0 whitespace-pre-wrap font-serif text-base leading-8 text-[var(--ink)]">{featuredStanza}</pre>
+              </a>
+            ) : (
+              <p class="mt-6 text-sm text-[var(--muted)]">(Preview unavailable.)</p>
+            )}
+            <div class="mt-6 flex flex-wrap gap-3">
+              <a
+                class="rounded-full bg-[var(--accent)] px-4 py-2.5 text-sm font-semibold text-[var(--accent-ink)] no-underline transition hover:brightness-105"
+                href={`${base}poem/${featured.id}/`}
+              >
+                Read poem
+              </a>
+              <a
+                class="rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_92%,transparent)] px-4 py-2.5 text-sm font-semibold text-[var(--ink)] no-underline transition hover:border-black/20"
+                href={`${base}browse/`}
+              >
+                Explore poems
+              </a>
+            </div>
+          </>
+        ) : (
+          <p class="text-sm text-[var(--muted)]">(No featured poem set.)</p>
+        )}
       </div>
-      <p class="muted">
-        Browse the collection by author and title. (More filters and favorites soon.)
-      </p>
-      <div class="actions">
-        <a class="action primary" href={`${base}browse/`}>Explore poems</a>
-        <a class="action" href={`${base}search/`}>Search poems</a>
-        <a class="action" href="https://github.com/Pro777/freeverse">Project repo</a>
-      </div>
-    </div>
 
-    <div class="card">
-      <div class="kicker">
-        <h2>Collections</h2>
-        <span class="pill">Editorial paths</span>
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
+        <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_92%,transparent)] p-5 shadow-[var(--shadow)]">
+          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Collections</div>
+          <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
+            Follow small editorial paths through grief, mortality, Romantic intensity, and future themes.
+          </p>
+          <a class="mt-4 inline-flex rounded-full border border-black/10 px-4 py-2 text-sm font-semibold text-[var(--ink)] no-underline" href={`${base}collections/`}>
+            Browse collections
+          </a>
+        </div>
+        <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_92%,transparent)] p-5 shadow-[var(--shadow)]">
+          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Project</div>
+          <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
+            Public corpus, search index, and static machine-readable exports, all shipped from the same source.
+          </p>
+          <a class="mt-4 inline-flex rounded-full border border-black/10 px-4 py-2 text-sm font-semibold text-[var(--ink)] no-underline" href="https://github.com/Pro777/freeverse">
+            View repository
+          </a>
+        </div>
       </div>
-      <p class="muted">
-        Read a small path through grief, mortality, Romantic intensity, and other future themes.
-      </p>
-      <div class="actions">
-        <a class="action primary" href={`${base}collections/`}>Browse collections</a>
-      </div>
-    </div>
+    </section>
   </section>
 </BaseLayout>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -1,3 +1,5 @@
+@import "tailwindcss";
+
 :root {
   /* We support both; actual colors are set by theme variables below. */
   color-scheme: light dark;


### PR DESCRIPTION
## Summary
- configure Tailwind CSS for the Astro site
- migrate the shared layout, header, and homepage to Tailwind
- refresh the homepage visual hierarchy while keeping the site responsive

## Verification
- `cd site && npm run build`

Closes #143