### PR TITLE
Publish locale-aware UI routes (#146)

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -8,6 +8,14 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
   site: 'https://thefreeverse.org/',
   integrations: [sitemap()],
+  i18n: {
+    locales: ['en', 'es', 'fr'],
+    defaultLocale: 'en',
+    routing: {
+      prefixDefaultLocale: false,
+      redirectToDefaultLocale: false,
+    },
+  },
 
   vite: {
     plugins: [tailwindcss()],

--- a/site/src/components/SiteHeader.astro
+++ b/site/src/components/SiteHeader.astro
@@ -1,20 +1,38 @@
 ---
+import {
+  DEFAULT_UI_LOCALE,
+  UI_LOCALES,
+  UI_MESSAGES,
+  type UILocale,
+  authorsPath,
+  browsePath,
+  collectionsPath,
+  favoritesPath,
+  homePath,
+  localizedPath,
+  normalizeUILocale,
+  searchPath,
+} from "../lib/i18n";
+
 type Props = {
   currentPath?: string;
+  locale?: UILocale;
 };
 
 const { currentPath } = Astro.props;
+const locale = normalizeUILocale(Astro.props.locale);
+const messages = UI_MESSAGES[locale];
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
 
 const nav = [
-  { href: `${base}`, label: "Home", key: "/" },
-  { href: `${base}browse/`, label: "Explore poems", key: "/browse" },
-  { href: `${base}collections/`, label: "Collections", key: "/collections" },
-  { href: `${base}authors/`, label: "Authors", key: "/authors" },
-  { href: `${base}search/`, label: "Search", key: "/search" },
-  { href: `${base}favorites/`, label: "Favorites", key: "/favorites" },
+  { href: homePath(base, locale), label: messages.header.nav.home, key: "/" },
+  { href: browsePath(base, locale), label: messages.header.nav.browse, key: "/browse" },
+  { href: collectionsPath(base, locale), label: messages.header.nav.collections, key: "/collections" },
+  { href: authorsPath(base, locale), label: messages.header.nav.authors, key: "/authors" },
+  { href: searchPath(base, locale), label: messages.header.nav.search, key: "/search" },
+  { href: favoritesPath(base, locale), label: messages.header.nav.favorites, key: "/favorites" },
 ];
 
 const normalized = (p?: string) => {
@@ -30,14 +48,14 @@ const here = normalized(currentPath);
 <header class="border-b border-black/10 bg-[linear-gradient(180deg,color-mix(in_oklab,var(--paper)_72%,transparent),transparent_72%),var(--header-bg)] px-4 py-4 sm:px-6 lg:px-10">
   <div class="flex items-start justify-between gap-4">
     <div class="max-w-sm">
-      <a class="block no-underline" href={`${base}`}>
+      <a class="block no-underline" href={homePath(base, locale)}>
         <div class="font-serif text-xl font-semibold tracking-[-0.03em] text-[var(--ink)] sm:text-2xl">Freeverse</div>
         <div class="mt-1 max-w-[22rem] font-sans text-sm leading-5 text-[var(--muted)]">
-          Public-domain poetry, pleasantly readable.
+          {messages.header.tagline}
         </div>
       </a>
       <div class="mt-2 text-sm italic text-[color-mix(in_oklab,var(--muted)_92%,var(--ink))]">
-        <a class="decoration-[color-mix(in_oklab,var(--accent)_45%,transparent)]" href={`${base}poem/horace/odes-3-30-exegi-monumentum/#l6-l6`}>
+        <a class="decoration-[color-mix(in_oklab,var(--accent)_45%,transparent)]" href={localizedPath(base, locale, "/poem/horace/odes-3-30-exegi-monumentum/#l6-l6")}>
           Non omnis moriar
         </a>
       </div>
@@ -62,10 +80,27 @@ const here = normalized(currentPath);
       class="rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_88%,transparent)] px-3 py-2 text-sm font-medium text-[var(--ink)] transition hover:border-black/20"
       type="button"
       data-theme-toggle
-      aria-label="Toggle theme"
+      aria-label={messages.header.theme}
     >
-      Theme
+      {messages.header.theme}
     </button>
+    <div class="flex items-center gap-1 rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_88%,transparent)] p-1">
+      {UI_LOCALES.map((altLocale) => (
+        <a
+          class:list={[
+            "rounded-full px-2.5 py-1 text-xs font-medium no-underline transition",
+            altLocale === locale
+              ? "bg-[var(--accent)] text-[var(--accent-ink)]"
+              : "text-[var(--muted)] hover:text-[var(--ink)]",
+          ]}
+          href={localizedPath(base, altLocale, currentPath ?? "/")}
+          hreflang={altLocale}
+          lang={altLocale}
+        >
+          {UI_MESSAGES[altLocale].languageName}
+        </a>
+      ))}
+    </div>
     </nav>
     <div class="md:hidden">
       <button
@@ -76,7 +111,7 @@ const here = normalized(currentPath);
         aria-expanded="false"
         aria-controls="mobile-menu"
       >
-        Menu
+        {messages.header.menu}
       </button>
     </div>
   </div>
@@ -107,14 +142,31 @@ const here = normalized(currentPath);
         class="mt-3 flex w-full items-center justify-center rounded-2xl border border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] px-3 py-3 text-sm font-medium text-[var(--ink)]"
         type="button"
         data-theme-toggle
-        aria-label="Toggle theme"
+        aria-label={messages.header.theme}
       >
-        Theme
+        {messages.header.theme}
       </button>
+      <div class="mt-3 grid grid-cols-3 gap-2">
+        {UI_LOCALES.map((altLocale) => (
+          <a
+            class:list={[
+              "rounded-2xl border px-3 py-3 text-center text-sm font-medium no-underline transition",
+              altLocale === locale
+                ? "border-transparent bg-[var(--accent)] text-[var(--accent-ink)]"
+                : "border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] text-[var(--ink)]",
+            ]}
+            href={localizedPath(base, altLocale, currentPath ?? "/")}
+            hreflang={altLocale}
+            lang={altLocale}
+          >
+            {UI_MESSAGES[altLocale].languageName}
+          </a>
+        ))}
+      </div>
     </div>
   </div>
 
-  <script is:inline>
+  <script is:inline define:vars={{ locale, messages }}>
     (() => {
       const STORAGE_KEY = 'freeverse-theme';
 
@@ -127,8 +179,13 @@ const here = normalized(currentPath);
         if (mode === 'light' || mode === 'dark') root.dataset.theme = mode;
         else delete root.dataset.theme;
 
-        const label = mode === 'system' ? 'System' : mode[0].toUpperCase() + mode.slice(1);
-        for (const btn of toggleButtons) btn.textContent = `Theme: ${label}`;
+        const themeLabels = {
+          system: messages.header.system,
+          light: messages.header.light,
+          dark: messages.header.dark,
+        };
+        const label = themeLabels[mode] ?? themeLabels.system;
+        for (const btn of toggleButtons) btn.textContent = `${messages.header.theme}: ${label}`;
       };
 
       const getStored = () => {

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -1,23 +1,43 @@
 ---
 import "../styles/global.css";
 import SiteHeader from "../components/SiteHeader.astro";
+import {
+  DEFAULT_UI_LOCALE,
+  UI_LOCALES,
+  type UILocale,
+  localizedPath,
+  normalizeUILocale,
+  UI_MESSAGES,
+} from "../lib/i18n";
 
 type Props = {
   title: string;
   description?: string;
   currentPath?: string;
+  locale?: UILocale;
+  canonicalPath?: string;
   structuredData?: Record<string, unknown> | Record<string, unknown>[];
 };
 
-const { title, description, currentPath, structuredData } = Astro.props;
+const { title, description, currentPath = "/", structuredData, canonicalPath } = Astro.props;
+const locale = normalizeUILocale(Astro.props.locale);
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
 
 const site = Astro.site;
-const canonicalUrl = site ? new URL(Astro.url.pathname, site).toString() : undefined;
+const canonicalUrl = site
+  ? new URL(canonicalPath ?? Astro.url.pathname, site).toString()
+  : undefined;
 const ogImageUrl = site ? new URL(`${base}og.png`, site).toString() : undefined;
 const websiteUrl = site ? new URL(base, site).toString() : undefined;
+const localeMessages = UI_MESSAGES[locale];
+const alternateUrls = site
+  ? UI_LOCALES.map((altLocale) => ({
+      locale: altLocale,
+      href: new URL(localizedPath(base, altLocale, currentPath), site).toString(),
+    }))
+  : [];
 
 function serializeJsonLd(value: Record<string, unknown> | Record<string, unknown>[]) {
   return JSON.stringify(value)
@@ -48,7 +68,7 @@ const jsonLdPayload = [
 ];
 ---
 
-<html lang="en">
+<html lang={locale}>
   <head>
     <meta charset="utf-8" />
     <script is:inline>
@@ -80,6 +100,20 @@ const jsonLdPayload = [
     {description ? <meta name="description" content={description} /> : null}
 
     {canonicalUrl ? <link rel="canonical" href={canonicalUrl} /> : null}
+    {alternateUrls.map((alternate) => (
+      <link
+        rel="alternate"
+        hreflang={alternate.locale}
+        href={alternate.href}
+      />
+    ))}
+    {site ? (
+      <link
+        rel="alternate"
+        hreflang="x-default"
+        href={new URL(localizedPath(base, DEFAULT_UI_LOCALE, currentPath), site).toString()}
+      />
+    ) : null}
 
     {/* Social previews (site-level default; poem pages override title/description via props). */}
     <meta property="og:site_name" content="Freeverse" />
@@ -108,15 +142,15 @@ const jsonLdPayload = [
     </a>
     <div class="mx-auto max-w-7xl px-4 pb-10 pt-5 sm:px-6 sm:pt-7 lg:px-8 lg:pt-10">
       <div class="overflow-hidden rounded-[28px] border border-black/10 bg-[var(--shell-bg)] shadow-[0_30px_80px_color-mix(in_oklab,var(--ink)_14%,transparent)] backdrop-blur-xl">
-        <SiteHeader currentPath={currentPath} />
+        <SiteHeader currentPath={currentPath} locale={locale} />
         <main id="main-content" tabindex="-1" class="px-4 py-6 sm:px-6 sm:py-8 lg:px-10 lg:py-10">
           <slot />
         </main>
         <footer class="border-t border-black/10 bg-[var(--footer-bg)] px-4 py-4 text-sm text-[var(--muted)] sm:px-6 lg:px-10">
           <span>
-            Built by <a href="https://github.com/Pro777">Pro777</a> and{' '}
+            {localeMessages.footer.builtBy} <a href="https://github.com/Pro777">Pro777</a> and{' '}
             <a href="https://www.moltbook.com/u/Rowan" target="_blank" rel="noopener noreferrer">Rowan</a><a class="easter-link" href={`${base}easter/`} aria-label="Easter egg" title="Easter egg">.</a>
-            {' '}Source on <a href="https://github.com/Pro777/freeverse">GitHub</a>.
+            {' '}{localeMessages.footer.sourceOn} <a href="https://github.com/Pro777/freeverse">GitHub</a>.
           </span>
         </footer>
       </div>

--- a/site/src/lib/i18n.ts
+++ b/site/src/lib/i18n.ts
@@ -1,0 +1,161 @@
+export const UI_LOCALES = ["en", "es", "fr"] as const;
+export const DEFAULT_UI_LOCALE = "en";
+export const NON_DEFAULT_UI_LOCALES = UI_LOCALES.filter((locale) => locale !== DEFAULT_UI_LOCALE);
+
+export type UILocale = (typeof UI_LOCALES)[number];
+
+type LocaleMessages = {
+  languageName: string;
+  header: {
+    tagline: string;
+    menu: string;
+    theme: string;
+    system: string;
+    light: string;
+    dark: string;
+    language: string;
+    nav: {
+      home: string;
+      browse: string;
+      collections: string;
+      authors: string;
+      search: string;
+      favorites: string;
+    };
+  };
+  footer: {
+    builtBy: string;
+    sourceOn: string;
+  };
+};
+
+export const UI_MESSAGES: Record<UILocale, LocaleMessages> = {
+  en: {
+    languageName: "English",
+    header: {
+      tagline: "Public-domain poetry, pleasantly readable.",
+      menu: "Menu",
+      theme: "Theme",
+      system: "System",
+      light: "Light",
+      dark: "Dark",
+      language: "Language",
+      nav: {
+        home: "Home",
+        browse: "Explore poems",
+        collections: "Collections",
+        authors: "Authors",
+        search: "Search",
+        favorites: "Favorites",
+      },
+    },
+    footer: {
+      builtBy: "Built by",
+      sourceOn: "Source on",
+    },
+  },
+  es: {
+    languageName: "Espanol",
+    header: {
+      tagline: "Poesia de dominio publico, hecha para leerse bien.",
+      menu: "Menu",
+      theme: "Tema",
+      system: "Sistema",
+      light: "Claro",
+      dark: "Oscuro",
+      language: "Idioma",
+      nav: {
+        home: "Inicio",
+        browse: "Explorar poemas",
+        collections: "Colecciones",
+        authors: "Autores",
+        search: "Buscar",
+        favorites: "Favoritos",
+      },
+    },
+    footer: {
+      builtBy: "Creado por",
+      sourceOn: "Codigo en",
+    },
+  },
+  fr: {
+    languageName: "Francais",
+    header: {
+      tagline: "Poesie du domaine public, faite pour etre lue.",
+      menu: "Menu",
+      theme: "Theme",
+      system: "Systeme",
+      light: "Clair",
+      dark: "Sombre",
+      language: "Langue",
+      nav: {
+        home: "Accueil",
+        browse: "Explorer les poemes",
+        collections: "Collections",
+        authors: "Auteurs",
+        search: "Recherche",
+        favorites: "Favoris",
+      },
+    },
+    footer: {
+      builtBy: "Construit par",
+      sourceOn: "Code source sur",
+    },
+  },
+};
+
+export function isUILocale(value: string | undefined): value is UILocale {
+  return Boolean(value && UI_LOCALES.includes(value as UILocale));
+}
+
+export function normalizeUILocale(value: string | undefined): UILocale {
+  return isUILocale(value) ? value : DEFAULT_UI_LOCALE;
+}
+
+export function localizedPath(base: string, locale: UILocale, pathname = "/"): string {
+  const normalizedBase = base.endsWith("/") ? base : `${base}/`;
+  const [pathWithoutHash, hash = ""] = pathname.split("#");
+  const [pathWithoutQuery, query = ""] = pathWithoutHash.split("?");
+  const normalizedPath = pathWithoutQuery === "/" ? "" : pathWithoutQuery.replace(/^\/+|\/+$/g, "");
+  const localized = [locale === DEFAULT_UI_LOCALE ? "" : locale, normalizedPath]
+    .filter(Boolean)
+    .join("/");
+  const suffix = `${query ? `?${query}` : ""}${hash ? `#${hash}` : ""}`;
+  return `${normalizedBase}${localized}${localized ? "/" : ""}${suffix}`;
+}
+
+export function authorPath(base: string, slug: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, `/author/${encodeURIComponent(slug)}/`);
+}
+
+export function poemPath(base: string, id: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, `/poem/${encodeURIComponent(id)}/`);
+}
+
+export function browsePath(base: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, "/browse/");
+}
+
+export function collectionsPath(base: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, "/collections/");
+}
+
+export function collectionPath(base: string, slug: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, `/collections/${encodeURIComponent(slug)}/`);
+}
+
+export function authorsPath(base: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, "/authors/");
+}
+
+export function searchPath(base: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, "/search/");
+}
+
+export function favoritesPath(base: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, "/favorites/");
+}
+
+export function homePath(base: string, locale: UILocale = DEFAULT_UI_LOCALE): string {
+  return localizedPath(base, locale, "/");
+}

--- a/site/src/lib/url.ts
+++ b/site/src/lib/url.ts
@@ -1,8 +1,12 @@
-export function q(s: string): string {
-  return encodeURIComponent(s);
-}
-
-export function authorPath(base: string, slug: string): string {
-  const normalizedBase = base.endsWith("/") ? base : `${base}/`;
-  return `${normalizedBase}author/${q(slug)}/`;
-}
+export {
+  authorPath,
+  authorsPath,
+  browsePath,
+  collectionPath,
+  collectionsPath,
+  favoritesPath,
+  homePath,
+  localizedPath,
+  poemPath,
+  searchPath,
+} from "./i18n";

--- a/site/src/pages/[locale]/author/[slug].astro
+++ b/site/src/pages/[locale]/author/[slug].astro
@@ -1,0 +1,37 @@
+---
+import AuthorPage from "../../author/[slug].astro";
+import { loadPoemMetas, type PoemMeta } from "../../../lib/poems";
+import { NON_DEFAULT_UI_LOCALES } from "../../../lib/i18n";
+
+type AuthorPageProps = {
+  author: string;
+  authorSlug: string;
+  poems: PoemMeta[];
+};
+
+export async function getStaticPaths() {
+  const poems = await loadPoemMetas();
+  const byAuthor = new Map<string, { author: string; poems: PoemMeta[] }>();
+
+  for (const poem of poems) {
+    const entry = byAuthor.get(poem.author_slug);
+    if (entry) entry.poems.push(poem);
+    else byAuthor.set(poem.author_slug, { author: poem.author, poems: [poem] });
+  }
+
+  return NON_DEFAULT_UI_LOCALES.flatMap((locale) =>
+    Array.from(byAuthor.entries()).map(([slug, group]) => ({
+      params: { locale, slug },
+      props: {
+        author: group.author,
+        authorSlug: slug,
+        poems: [...group.poems].sort((a, b) => a.title.localeCompare(b.title)),
+      },
+    })),
+  );
+}
+
+const props = Astro.props as AuthorPageProps;
+---
+
+<AuthorPage {...props} locale={Astro.params.locale} />

--- a/site/src/pages/[locale]/authors/index.astro
+++ b/site/src/pages/[locale]/authors/index.astro
@@ -1,0 +1,12 @@
+---
+import AuthorsPage from "../../authors/index.astro";
+import { NON_DEFAULT_UI_LOCALES } from "../../../lib/i18n";
+
+export function getStaticPaths() {
+  return NON_DEFAULT_UI_LOCALES.map((locale) => ({
+    params: { locale },
+  }));
+}
+---
+
+<AuthorsPage locale={Astro.params.locale} />

--- a/site/src/pages/[locale]/browse/index.astro
+++ b/site/src/pages/[locale]/browse/index.astro
@@ -1,0 +1,12 @@
+---
+import BrowsePage from "../../browse/index.astro";
+import { NON_DEFAULT_UI_LOCALES } from "../../../lib/i18n";
+
+export function getStaticPaths() {
+  return NON_DEFAULT_UI_LOCALES.map((locale) => ({
+    params: { locale },
+  }));
+}
+---
+
+<BrowsePage locale={Astro.params.locale} />

--- a/site/src/pages/[locale]/collections/[slug].astro
+++ b/site/src/pages/[locale]/collections/[slug].astro
@@ -1,0 +1,17 @@
+---
+import CollectionPage from "../../collections/[slug].astro";
+import { loadCollections } from "../../../lib/collections";
+import { NON_DEFAULT_UI_LOCALES } from "../../../lib/i18n";
+
+export async function getStaticPaths() {
+  const collections = await loadCollections();
+  return NON_DEFAULT_UI_LOCALES.flatMap((locale) =>
+    collections.map((collection) => ({
+      params: { locale, slug: collection.slug },
+      props: { collection },
+    })),
+  );
+}
+---
+
+<CollectionPage {...Astro.props} locale={Astro.params.locale} />

--- a/site/src/pages/[locale]/collections/index.astro
+++ b/site/src/pages/[locale]/collections/index.astro
@@ -1,0 +1,12 @@
+---
+import CollectionsPage from "../../collections/index.astro";
+import { NON_DEFAULT_UI_LOCALES } from "../../../lib/i18n";
+
+export function getStaticPaths() {
+  return NON_DEFAULT_UI_LOCALES.map((locale) => ({
+    params: { locale },
+  }));
+}
+---
+
+<CollectionsPage locale={Astro.params.locale} />

--- a/site/src/pages/[locale]/favorites/index.astro
+++ b/site/src/pages/[locale]/favorites/index.astro
@@ -1,0 +1,12 @@
+---
+import FavoritesPage from "../../favorites/index.astro";
+import { NON_DEFAULT_UI_LOCALES } from "../../../lib/i18n";
+
+export function getStaticPaths() {
+  return NON_DEFAULT_UI_LOCALES.map((locale) => ({
+    params: { locale },
+  }));
+}
+---
+
+<FavoritesPage locale={Astro.params.locale} />

--- a/site/src/pages/[locale]/index.astro
+++ b/site/src/pages/[locale]/index.astro
@@ -1,0 +1,12 @@
+---
+import HomePage from "../index.astro";
+import { NON_DEFAULT_UI_LOCALES } from "../../lib/i18n";
+
+export function getStaticPaths() {
+  return NON_DEFAULT_UI_LOCALES.map((locale) => ({
+    params: { locale },
+  }));
+}
+---
+
+<HomePage locale={Astro.params.locale} />

--- a/site/src/pages/[locale]/poem/[...id].astro
+++ b/site/src/pages/[locale]/poem/[...id].astro
@@ -1,0 +1,17 @@
+---
+import PoemPage from "../../poem/[...id].astro";
+import { loadPoemMetas } from "../../../lib/poems";
+import { NON_DEFAULT_UI_LOCALES } from "../../../lib/i18n";
+
+export async function getStaticPaths() {
+  const poems = await loadPoemMetas();
+  return NON_DEFAULT_UI_LOCALES.flatMap((locale) =>
+    poems.map((poem) => ({
+      params: { locale, id: poem.id },
+      props: { poem },
+    })),
+  );
+}
+---
+
+<PoemPage {...Astro.props} locale={Astro.params.locale} />

--- a/site/src/pages/[locale]/search.astro
+++ b/site/src/pages/[locale]/search.astro
@@ -1,0 +1,12 @@
+---
+import SearchPage from "../search.astro";
+import { NON_DEFAULT_UI_LOCALES } from "../../lib/i18n";
+
+export function getStaticPaths() {
+  return NON_DEFAULT_UI_LOCALES.map((locale) => ({
+    params: { locale },
+  }));
+}
+---
+
+<SearchPage locale={Astro.params.locale} />

--- a/site/src/pages/author/[slug].astro
+++ b/site/src/pages/author/[slug].astro
@@ -2,6 +2,8 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { loadPoemMetas, type PoemMeta } from "../../lib/poems";
 import { AUTHOR_INFO, formatAuthorYears, formatCenturyLabel } from "../../lib/authors";
+import { authorsPath, browsePath, poemPath, searchPath } from "../../lib/url";
+import { normalizeUILocale } from "../../lib/i18n";
 
 type AuthorPageProps = {
   author: string;
@@ -12,6 +14,7 @@ type AuthorPageProps = {
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
 
 export async function getStaticPaths() {
   const poems = await loadPoemMetas();
@@ -71,7 +74,8 @@ const authorPageStructuredData = {
 <BaseLayout
   title={title}
   description={description}
-  currentPath={""}
+  currentPath={`/author/${authorSlug}/`}
+  locale={locale}
   structuredData={[personStructuredData, authorPageStructuredData]}
 >
   <section class="hero">
@@ -103,7 +107,7 @@ const authorPageStructuredData = {
     <ul class="list">
       {poems.map((p) => (
         <li>
-          <a class="list-title" href={`${base}poem/${p.id}/`}>
+          <a class="list-title" href={poemPath(base, p.id, locale)}>
             <strong>{p.title}</strong>
           </a>
           <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">
@@ -114,9 +118,9 @@ const authorPageStructuredData = {
     </ul>
 
     <div class="actions" style="margin-top:1rem;">
-      <a class="action" href={`${base}browse/`}>Back to Browse</a>
-      <a class="action" href={`${base}authors/`}>All authors</a>
-      <a class="action" href={`${base}search/`}>Search</a>
+      <a class="action" href={browsePath(base, locale)}>Back to Browse</a>
+      <a class="action" href={authorsPath(base, locale)}>All authors</a>
+      <a class="action" href={searchPath(base, locale)}>Search</a>
     </div>
   </div>
 </BaseLayout>

--- a/site/src/pages/authors/index.astro
+++ b/site/src/pages/authors/index.astro
@@ -3,11 +3,12 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { loadPoemMetas } from "../../lib/poems";
 import { authorPath } from "../../lib/url";
 import { AUTHOR_INFO, formatAuthorYears } from "../../lib/authors";
-import { AUTHOR_INFO } from "../../lib/authors";
+import { normalizeUILocale } from "../../lib/i18n";
 
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
 
 const poems = await loadPoemMetas();
 const authors = Array.from(
@@ -25,7 +26,7 @@ const authors = Array.from(
 authors.sort((a, b) => a.name.localeCompare(b.name));
 ---
 
-<BaseLayout title="Authors · Freeverse" description="Browse poets in the Freeverse collection." currentPath={""}>
+<BaseLayout title="Authors · Freeverse" description="Browse poets in the Freeverse collection." currentPath="/authors/" locale={locale}>
   <section class="hero">
     <h1>Authors</h1>
     <p class="lede">Alphabetical index of poets in Freeverse.</p>
@@ -42,7 +43,7 @@ authors.sort((a, b) => a.name.localeCompare(b.name));
         const info = AUTHOR_INFO[a.slug];
         return (
           <li>
-            <a class="list-title" href={authorPath(base, a.slug)}>
+            <a class="list-title" href={authorPath(base, a.slug, locale)}>
               <strong>{a.name}</strong>
             </a>
             <div class="muted" style="margin-top:0.25rem; font-family: var(--sans); font-size: 0.92rem;">

--- a/site/src/pages/browse/index.astro
+++ b/site/src/pages/browse/index.astro
@@ -2,7 +2,8 @@
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { formatCenturyLabel } from "../../lib/authors";
 import { loadPoemMetas } from "../../lib/poems";
-import { authorPath } from "../../lib/url";
+import { authorPath, poemPath } from "../../lib/url";
+import { normalizeUILocale } from "../../lib/i18n";
 
 type AuthorGroup = {
   name: string;
@@ -13,6 +14,7 @@ type AuthorGroup = {
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
 
 const poemsAll = await loadPoemMetas();
 
@@ -42,7 +44,7 @@ const statsLabel = `${poemsAll.length} poems across ${authorGroups.length} autho
 const defaultStatus = `Showing ${statsLabel}. All author groups start collapsed.`;
 ---
 
-<BaseLayout title="Explore poems - Freeverse" description="Explore public-domain poems." currentPath="/browse">
+<BaseLayout title="Explore poems - Freeverse" description="Explore public-domain poems." currentPath="/browse/" locale={locale}>
   <section class="hero">
     <h1>Explore poems</h1>
     <p class="lede">
@@ -111,7 +113,7 @@ const defaultStatus = `Showing ${statsLabel}. All author groups start collapsed.
 
         <div class="browse-group-body">
           <div class="browse-group-meta">
-            <a class="muted" href={authorPath(base, group.slug)}>
+            <a class="muted" href={authorPath(base, group.slug, locale)}>
               View author page
             </a>
           </div>
@@ -125,7 +127,7 @@ const defaultStatus = `Showing ${statsLabel}. All author groups start collapsed.
                 data-search-text={`${group.name} ${poem.title}`.toLowerCase()}
               >
                 <div class="browse-poem-row">
-                  <a class="list-title" href={`${base}poem/${poem.id}/`}>
+                  <a class="list-title" href={poemPath(base, poem.id, locale)}>
                     <strong>{poem.title}</strong>
                   </a>
                   <span class="muted browse-poem-century">

--- a/site/src/pages/collections/[slug].astro
+++ b/site/src/pages/collections/[slug].astro
@@ -1,6 +1,8 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { loadCollections } from '../../lib/collections';
+import { collectionsPath, poemPath, browsePath } from '../../lib/url';
+import { normalizeUILocale } from '../../lib/i18n';
 
 export async function getStaticPaths() {
   const collections = await loadCollections();
@@ -13,6 +15,7 @@ export async function getStaticPaths() {
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
 
 const { collection } = Astro.props;
 ---
@@ -20,7 +23,8 @@ const { collection } = Astro.props;
 <BaseLayout
   title={`${collection.title} - Freeverse`}
   description={collection.description}
-  currentPath="/collections"
+  currentPath={`/collections/${collection.slug}/`}
+  locale={locale}
 >
   <section class="hero">
     <h1>{collection.title}</h1>
@@ -34,7 +38,7 @@ const { collection } = Astro.props;
         <li>
           <p style="margin: 0;">
             <span class="muted">#{index + 1}</span>{' '}
-            <a class="list-title" href={`${base}poem/${poem.id}/`}>
+            <a class="list-title" href={poemPath(base, poem.id, locale)}>
               <strong>{poem.title}</strong>
             </a>
           </p>
@@ -43,8 +47,8 @@ const { collection } = Astro.props;
       ))}
     </ul>
     <div class="actions" style="margin-top: 1rem;">
-      <a class="action" href={`${base}collections/`}>All collections</a>
-      <a class="action" href={`${base}browse/`}>Explore poems</a>
+      <a class="action" href={collectionsPath(base, locale)}>All collections</a>
+      <a class="action" href={browsePath(base, locale)}>Explore poems</a>
     </div>
   </section>
 </BaseLayout>

--- a/site/src/pages/collections/index.astro
+++ b/site/src/pages/collections/index.astro
@@ -1,10 +1,12 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { loadCollections } from '../../lib/collections';
+import { collectionPath, normalizeUILocale } from '../../lib/i18n';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
 
 const collections = await loadCollections();
 ---
@@ -12,7 +14,8 @@ const collections = await loadCollections();
 <BaseLayout
   title="Collections - Freeverse"
   description="Curated reading paths through the Freeverse poetry library."
-  currentPath="/collections"
+  currentPath="/collections/"
+  locale={locale}
 >
   <section class="hero">
     <h1>Collections</h1>
@@ -31,7 +34,7 @@ const collections = await loadCollections();
         <p><strong>{collection.dek}</strong></p>
         <p class="muted">{collection.description}</p>
         <div class="actions">
-          <a class="action primary" href={`${base}collections/${collection.slug}/`}>Open collection</a>
+          <a class="action primary" href={collectionPath(base, collection.slug, locale)}>Open collection</a>
         </div>
       </article>
     ))}

--- a/site/src/pages/favorites/index.astro
+++ b/site/src/pages/favorites/index.astro
@@ -1,11 +1,12 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import { loadPoemMetas } from "../../lib/poems";
-import { authorPath } from "../../lib/url";
+import { normalizeUILocale } from "../../lib/i18n";
 
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
 
 // We need poem metadata on the client side so we can render the favorites list.
 // Serialize the minimal fields required into a JSON data island.
@@ -18,7 +19,7 @@ const poemData = poemsAll.map((p) => ({
 }));
 ---
 
-<BaseLayout title="My favorites · Freeverse" description="Your starred poems." currentPath="/favorites">
+<BaseLayout title="My favorites · Freeverse" description="Your starred poems." currentPath="/favorites/" locale={locale}>
   <section class="hero">
     <h1>My favorites</h1>
     <p class="lede" id="fav-lede">
@@ -39,7 +40,7 @@ const poemData = poemsAll.map((p) => ({
     <ul class="list" id="fav-list" hidden></ul>
   </div>
 
-  <script is:inline define:vars={{ poemData, base }}>
+  <script is:inline define:vars={{ poemData, base, locale }}>
     (() => {
       const STORAGE_KEY = 'freeverse-favorites';
 
@@ -81,8 +82,9 @@ const poemData = poemsAll.map((p) => ({
 
         listEl.innerHTML = '';
         found.forEach(p => {
-          const poemHref = `${base}poem/${p.id}/`;
-          const authorHref = `${base}author/${p.author_slug}/`;
+          const prefix = locale === 'en' ? '' : `${locale}/`;
+          const poemHref = `${base}${prefix}poem/${p.id}/`;
+          const authorHref = `${base}${prefix}author/${p.author_slug}/`;
 
           const li = document.createElement('li');
           li.dataset.poemId = p.id;

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,18 +1,113 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
 import { loadFeaturedPoem, loadFirstStanza } from "../lib/poems";
+import { browsePath, authorsPath, collectionsPath, homePath, poemPath, searchPath, normalizeUILocale } from "../lib/i18n";
 
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
+const copy = {
+  en: {
+    title: "Freeverse",
+    description: "Public-domain poetry — a clean reader with shareable line links.",
+    badge: "Public Domain Poetry",
+    kicker: "Readable, linkable, and built for actual reading.",
+    heading: "Poetry that reads like a page, not a screenshot.",
+    lede:
+      "Freeverse brings public-domain poems into a clean reading surface with shareable line links, author pages, editorial collections, and a growing multilingual corpus.",
+    explore: "Explore the library",
+    search: "Search poems",
+    authors: "Browse authors",
+    cards: [
+      ["Reader-first", "Stable line breaks, linkable passages, and typography tuned for long reading instead of skimming."],
+      ["Editorial Paths", "Collections and author pages make the library navigable without turning it into a sterile database."],
+      ["Machine-readable", "JSON-LD, sitemap support, and public Alcove exports make the corpus usable beyond the browser."],
+    ],
+    featured: "Featured Poem",
+    featuredSub: "A small daily delight",
+    featuredBadge: "Open the page, read the whole thing",
+    read: "Read poem",
+    explorePoems: "Explore poems",
+    previewUnavailable: "(Preview unavailable.)",
+    noFeatured: "(No featured poem set.)",
+    collections: "Collections",
+    collectionsBody: "Follow small editorial paths through grief, mortality, Romantic intensity, and future themes.",
+    collectionsAction: "Browse collections",
+    project: "Project",
+    projectBody: "Public corpus, search index, and static machine-readable exports, all shipped from the same source.",
+    projectAction: "View repository",
+  },
+  es: {
+    title: "Freeverse",
+    description: "Poesia de dominio publico en una interfaz limpia y enlazable.",
+    badge: "Poesia de Dominio Publico",
+    kicker: "Legible, enlazable y hecha para leer de verdad.",
+    heading: "Poesia que se lee como una pagina, no como una captura.",
+    lede:
+      "Freeverse lleva poemas de dominio publico a una superficie limpia de lectura con enlaces por linea, paginas de autor, colecciones editoriales y un corpus multilingue en crecimiento.",
+    explore: "Explorar biblioteca",
+    search: "Buscar poemas",
+    authors: "Ver autores",
+    cards: [
+      ["Pensado para leer", "Saltos de linea estables, pasajes enlazables y tipografia ajustada para lectura larga."],
+      ["Caminos editoriales", "Las colecciones y paginas de autor vuelven navegable la biblioteca sin convertirla en una base de datos esteril."],
+      ["Legible por maquinas", "JSON-LD, sitemap y exportaciones publicas de Alcove hacen util el corpus mas alla del navegador."],
+    ],
+    featured: "Poema destacado",
+    featuredSub: "Un pequeno deleite diario",
+    featuredBadge: "Abre la pagina y lee el poema entero",
+    read: "Leer poema",
+    explorePoems: "Explorar poemas",
+    previewUnavailable: "(Vista previa no disponible.)",
+    noFeatured: "(No hay poema destacado.)",
+    collections: "Colecciones",
+    collectionsBody: "Sigue pequenos caminos editoriales por el duelo, la mortalidad, la intensidad romantica y otros temas.",
+    collectionsAction: "Ver colecciones",
+    project: "Proyecto",
+    projectBody: "Corpus publico, indice de busqueda y exportaciones estaticas para maquinas, todo desde la misma fuente.",
+    projectAction: "Ver repositorio",
+  },
+  fr: {
+    title: "Freeverse",
+    description: "Poesie du domaine public dans un lecteur net avec liens partageables.",
+    badge: "Poesie du Domaine Public",
+    kicker: "Lisible, partageable, et concue pour la lecture.",
+    heading: "Une poesie qui se lit comme une page, pas comme une capture d'ecran.",
+    lede:
+      "Freeverse apporte les poemes du domaine public dans un espace de lecture propre avec liens par ligne, pages d'auteur, collections editoriales et un corpus multilingue en croissance.",
+    explore: "Explorer la bibliotheque",
+    search: "Chercher des poemes",
+    authors: "Voir les auteurs",
+    cards: [
+      ["Concu pour lire", "Retours de ligne stables, passages partageables et typographie faite pour la lecture longue."],
+      ["Parcours editoriaux", "Les collections et pages d'auteur rendent la bibliotheque navigable sans en faire une base sterile."],
+      ["Lisible par machine", "JSON-LD, sitemap et export Alcove public rendent le corpus utile au-dela du navigateur."],
+    ],
+    featured: "Poeme mis en avant",
+    featuredSub: "Un petit plaisir du jour",
+    featuredBadge: "Ouvrez la page et lisez le poeme entier",
+    read: "Lire le poeme",
+    explorePoems: "Explorer les poemes",
+    previewUnavailable: "(Apercu indisponible.)",
+    noFeatured: "(Aucun poeme mis en avant.)",
+    collections: "Collections",
+    collectionsBody: "Suivez de petits parcours editoriaux autour du deuil, de la mortalite, de l'intensite romantique et d'autres themes.",
+    collectionsAction: "Voir les collections",
+    project: "Projet",
+    projectBody: "Corpus public, index de recherche et exports statiques pour les machines, livres depuis la meme source.",
+    projectAction: "Voir le depot",
+  },
+}[locale];
 
 const featured = await loadFeaturedPoem();
 const featuredStanza = featured ? await loadFirstStanza(featured) : undefined;
 ---
 
 <BaseLayout
-  title="Freeverse"
-  description="Public-domain poetry — a clean reader with shareable line links."
+  title={copy.title}
+  description={copy.description}
+  locale={locale}
   currentPath="/"
 >
   <section class="grid gap-8 lg:grid-cols-[minmax(0,1.5fr)_minmax(20rem,0.95fr)] lg:items-start">
@@ -20,58 +115,47 @@ const featuredStanza = featured ? await loadFirstStanza(featured) : undefined;
       <section class="rounded-[2rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_94%,transparent)] px-6 py-8 shadow-[var(--shadow)] sm:px-8 sm:py-10">
         <div class="mb-4 flex flex-wrap items-center gap-3">
           <span class="rounded-full border border-amber-950/10 bg-amber-100/70 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-amber-900">
-            Public Domain Poetry
+            {copy.badge}
           </span>
-          <span class="text-sm text-[var(--muted)]">Readable, linkable, and built for actual reading.</span>
+          <span class="text-sm text-[var(--muted)]">{copy.kicker}</span>
         </div>
         <h1 class="max-w-3xl font-serif text-5xl font-semibold tracking-[-0.04em] text-[var(--ink)] sm:text-6xl lg:text-7xl">
-          Poetry that reads like a page, not a screenshot.
+          {copy.heading}
         </h1>
         <p class="mt-5 max-w-2xl text-lg leading-8 text-[var(--muted)] sm:text-xl">
-          Freeverse brings public-domain poems into a clean reading surface with shareable line links,
-          author pages, editorial collections, and a growing multilingual corpus.
+          {copy.lede}
         </p>
         <div class="mt-8 flex flex-wrap gap-3">
           <a
             class="rounded-full bg-[var(--accent)] px-5 py-3 text-sm font-semibold text-[var(--accent-ink)] no-underline shadow-sm transition hover:brightness-105"
-            href={`${base}browse/`}
+            href={browsePath(base, locale)}
           >
-            Explore the library
+            {copy.explore}
           </a>
           <a
             class="rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_92%,transparent)] px-5 py-3 text-sm font-semibold text-[var(--ink)] no-underline transition hover:border-black/20"
-            href={`${base}search/`}
+            href={searchPath(base, locale)}
           >
-            Search poems
+            {copy.search}
           </a>
           <a
             class="rounded-full border border-transparent px-5 py-3 text-sm font-semibold text-[var(--muted)] no-underline transition hover:text-[var(--ink)]"
-            href={`${base}authors/`}
+            href={authorsPath(base, locale)}
           >
-            Browse authors
+            {copy.authors}
           </a>
         </div>
       </section>
 
       <section class="grid gap-4 sm:grid-cols-3">
+        {copy.cards.map(([title, body]) => (
         <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] p-5 shadow-[var(--shadow)]">
-          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Reader-first</div>
+          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">{title}</div>
           <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
-            Stable line breaks, linkable passages, and typography tuned for long reading instead of skimming.
+            {body}
           </p>
         </div>
-        <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] p-5 shadow-[var(--shadow)]">
-          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Editorial Paths</div>
-          <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
-            Collections and author pages make the library navigable without turning it into a sterile database.
-          </p>
-        </div>
-        <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_90%,transparent)] p-5 shadow-[var(--shadow)]">
-          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Machine-readable</div>
-          <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
-            JSON-LD, sitemap support, and public Alcove exports make the corpus usable beyond the browser.
-          </p>
-        </div>
+        ))}
       </section>
     </div>
 
@@ -79,17 +163,17 @@ const featuredStanza = featured ? await loadFirstStanza(featured) : undefined;
       <div class="rounded-[2rem] border border-black/10 bg-[linear-gradient(180deg,color-mix(in_oklab,var(--paper)_96%,transparent),color-mix(in_oklab,var(--paper)_88%,transparent))] p-6 shadow-[var(--shadow)] sm:p-7">
         <div class="mb-5 flex items-center justify-between gap-3">
           <div>
-            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Featured Poem</div>
-            <div class="mt-1 text-sm italic text-[var(--muted)]">A small daily delight</div>
+            <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">{copy.featured}</div>
+            <div class="mt-1 text-sm italic text-[var(--muted)]">{copy.featuredSub}</div>
           </div>
           <span class="rounded-full border border-amber-950/10 bg-amber-100/75 px-3 py-1 text-xs font-medium text-amber-900">
-            Open the page, read the whole thing
+            {copy.featuredBadge}
           </span>
         </div>
 
         {featured ? (
           <>
-            <a class="block no-underline" href={`${base}poem/${featured.id}/`}>
+            <a class="block no-underline" href={poemPath(base, featured.id, locale)}>
               <div class="font-serif text-3xl font-semibold tracking-[-0.03em] text-[var(--ink)]">
                 {featured.title}
               </div>
@@ -100,51 +184,51 @@ const featuredStanza = featured ? await loadFirstStanza(featured) : undefined;
             {featuredStanza ? (
               <a
                 class="mt-6 block rounded-[1.5rem] border border-black/10 bg-[var(--preview-bg)] p-5 no-underline transition hover:border-black/20"
-                href={`${base}poem/${featured.id}/`}
+                href={poemPath(base, featured.id, locale)}
                 aria-label={`Read featured poem: ${featured.title} by ${featured.author}`}
               >
                 <pre class="m-0 whitespace-pre-wrap font-serif text-base leading-8 text-[var(--ink)]">{featuredStanza}</pre>
               </a>
             ) : (
-              <p class="mt-6 text-sm text-[var(--muted)]">(Preview unavailable.)</p>
+              <p class="mt-6 text-sm text-[var(--muted)]">{copy.previewUnavailable}</p>
             )}
             <div class="mt-6 flex flex-wrap gap-3">
               <a
                 class="rounded-full bg-[var(--accent)] px-4 py-2.5 text-sm font-semibold text-[var(--accent-ink)] no-underline transition hover:brightness-105"
-                href={`${base}poem/${featured.id}/`}
+                href={poemPath(base, featured.id, locale)}
               >
-                Read poem
+                {copy.read}
               </a>
               <a
                 class="rounded-full border border-black/10 bg-[color-mix(in_oklab,var(--paper)_92%,transparent)] px-4 py-2.5 text-sm font-semibold text-[var(--ink)] no-underline transition hover:border-black/20"
-                href={`${base}browse/`}
+                href={browsePath(base, locale)}
               >
-                Explore poems
+                {copy.explorePoems}
               </a>
             </div>
           </>
         ) : (
-          <p class="text-sm text-[var(--muted)]">(No featured poem set.)</p>
+          <p class="text-sm text-[var(--muted)]">{copy.noFeatured}</p>
         )}
       </div>
 
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2">
         <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_92%,transparent)] p-5 shadow-[var(--shadow)]">
-          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Collections</div>
+          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">{copy.collections}</div>
           <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
-            Follow small editorial paths through grief, mortality, Romantic intensity, and future themes.
+            {copy.collectionsBody}
           </p>
-          <a class="mt-4 inline-flex rounded-full border border-black/10 px-4 py-2 text-sm font-semibold text-[var(--ink)] no-underline" href={`${base}collections/`}>
-            Browse collections
+          <a class="mt-4 inline-flex rounded-full border border-black/10 px-4 py-2 text-sm font-semibold text-[var(--ink)] no-underline" href={collectionsPath(base, locale)}>
+            {copy.collectionsAction}
           </a>
         </div>
         <div class="rounded-[1.75rem] border border-black/10 bg-[color-mix(in_oklab,var(--paper)_92%,transparent)] p-5 shadow-[var(--shadow)]">
-          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">Project</div>
+          <div class="text-xs font-semibold uppercase tracking-[0.22em] text-[var(--muted)]">{copy.project}</div>
           <p class="mt-3 text-sm leading-7 text-[var(--muted)]">
-            Public corpus, search index, and static machine-readable exports, all shipped from the same source.
+            {copy.projectBody}
           </p>
           <a class="mt-4 inline-flex rounded-full border border-black/10 px-4 py-2 text-sm font-semibold text-[var(--ink)] no-underline" href="https://github.com/Pro777/freeverse">
-            View repository
+            {copy.projectAction}
           </a>
         </div>
       </div>

--- a/site/src/pages/poem/[...id].astro
+++ b/site/src/pages/poem/[...id].astro
@@ -3,7 +3,8 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import { loadRelatedPoems } from "../../lib/collections";
 import { loadPoemMetas, loadPoemText, type PoemMeta } from "../../lib/poems";
 import { AUTHOR_INFO } from "../../lib/authors";
-import { authorPath } from "../../lib/url";
+import { authorPath, browsePath, poemPath } from "../../lib/url";
+import { normalizeUILocale } from "../../lib/i18n";
 // (tests) line-link hash logic is unit-tested separately in src/lib/lineLinks.ts
 
 export async function getStaticPaths() {
@@ -28,6 +29,7 @@ const description = `Read ${poem.title} by ${poem.author}.`;
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
 const canonicalPath = `${base}poem/${poem.id}/`;
 const canonicalUrl = Astro.site ? new URL(canonicalPath, Astro.site).toString() : undefined;
 const authorUrl = Astro.site ? new URL(authorPath(base, poem.author_slug), Astro.site).toString() : undefined;
@@ -78,7 +80,9 @@ const poemStructuredData = {
 <BaseLayout
   title={title}
   description={description}
-  currentPath={""}
+  currentPath={`/poem/${poem.id}/`}
+  locale={locale}
+  canonicalPath={canonicalPath}
   structuredData={poemStructuredData}
 >
   <article
@@ -115,11 +119,11 @@ const poemStructuredData = {
       </div>
       <p class="reader-byline">
         <span class="muted">by</span>{' '}
-        <a href={authorPath(base, poem.author_slug)}>
+        <a href={authorPath(base, poem.author_slug, locale)}>
           <strong>{poem.author}</strong>
         </a>
         <span class="muted" style="margin: 0 0.35rem;">·</span>
-        <a class="muted" href={`${base}browse/`}>Explore poems</a>
+        <a class="muted" href={browsePath(base, locale)}>Explore poems</a>
       </p>
     </header>
 
@@ -190,12 +194,12 @@ const poemStructuredData = {
           {relatedPoems.map(({ poem: relatedPoem, reason }) => (
             <li>
               <p style="margin: 0;">
-                <a class="list-title" href={`${base}poem/${relatedPoem.id}/`}>
+                <a class="list-title" href={poemPath(base, relatedPoem.id, locale)}>
                   <strong>{relatedPoem.title}</strong>
                 </a>
               </p>
               <p class="muted related-reading-meta">
-                <a href={authorPath(base, relatedPoem.author_slug)}>{relatedPoem.author}</a>
+                <a href={authorPath(base, relatedPoem.author_slug, locale)}>{relatedPoem.author}</a>
                 <span class="related-reading-dot">·</span>
                 <span>{reason}</span>
               </p>

--- a/site/src/pages/search.astro
+++ b/site/src/pages/search.astro
@@ -3,24 +3,26 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import { formatCenturyLabel } from "../lib/authors";
 import { loadPoemMetas } from "../lib/poems";
 import { authorPath } from "../lib/url";
+import { normalizeUILocale, poemPath } from "../lib/i18n";
 
 const base = import.meta.env.BASE_URL.endsWith("/")
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
+const locale = normalizeUILocale(Astro.props.locale);
 
 const poems = await loadPoemMetas();
 const docs = poems.map((p) => ({
   id: p.id,
   title: p.title,
   author: p.author,
-  authorUrl: authorPath(base, p.author_slug),
+  authorUrl: authorPath(base, p.author_slug, locale),
   century: p.century,
   centuryLabel: formatCenturyLabel(p.century),
-  url: `${base}poem/${p.id}/`,
+  url: poemPath(base, p.id, locale),
 }));
 ---
 
-<BaseLayout title="Search · Freeverse" description="Search poems by title, author, theme, or mood." currentPath="/search">
+<BaseLayout title="Search · Freeverse" description="Search poems by title, author, theme, or mood." currentPath="/search/" locale={locale}>
   <section class="hero">
     <h1>Search</h1>
     <p class="lede">Type a title, author, theme, or mood. Instant results from a build-time semantic index.</p>


### PR DESCRIPTION
## Summary
- enable Astro i18n routing for English, Spanish, and French
- publish locale-prefixed route layers with localized shared chrome and homepage copy
- keep poem identity stable with canonical unprefixed poem URLs and `hreflang` alternates

## Verification
- `cd site && npm run build`
- spot-checked localized homepage and localized poem output in `site/dist`

Closes #146