### PR TITLE
Deepen Oliver Wendell Holmes Sr. coverage (#179)

### DIFF
--- a/meta/oliver-wendell-holmes-sr/sun-and-shadow.yml
+++ b/meta/oliver-wendell-holmes-sr/sun-and-shadow.yml
@@ -1,0 +1,13 @@
+id: oliver-wendell-holmes-sr/sun-and-shadow
+slug: sun-and-shadow
+author: Oliver Wendell Holmes, Sr.
+author_slug: oliver-wendell-holmes-sr
+title: Sun and Shadow
+century: 19
+text_path: poems/oliver-wendell-holmes-sr/sun-and-shadow.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/7393/pg7393.txt
+public_domain_rationale: 'Public domain in the United States: included in The Poetical Works of Oliver Wendell Holmes — Volume 06; text via Project Gutenberg eBook #7393.'
+collection_title: The Poetical Works of Oliver Wendell Holmes — Volume 06
+collection_source_url: https://www.gutenberg.org/ebooks/7393

--- a/meta/oliver-wendell-holmes-sr/the-cambridge-churchyard.yml
+++ b/meta/oliver-wendell-holmes-sr/the-cambridge-churchyard.yml
@@ -1,0 +1,13 @@
+id: oliver-wendell-holmes-sr/the-cambridge-churchyard
+slug: the-cambridge-churchyard
+author: Oliver Wendell Holmes, Sr.
+author_slug: oliver-wendell-holmes-sr
+title: The Cambridge Churchyard
+century: 19
+text_path: poems/oliver-wendell-holmes-sr/the-cambridge-churchyard.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/7388/pg7388.txt
+public_domain_rationale: 'Public domain in the United States: included in The Poetical Works of Oliver Wendell Holmes — Volume 01: Earlier Poems (1830-1836); text via Project Gutenberg eBook #7388.'
+collection_title: 'The Poetical Works of Oliver Wendell Holmes — Volume 01: Earlier Poems'
+collection_source_url: https://www.gutenberg.org/ebooks/7388

--- a/meta/oliver-wendell-holmes-sr/the-height-of-the-ridiculous.yml
+++ b/meta/oliver-wendell-holmes-sr/the-height-of-the-ridiculous.yml
@@ -1,0 +1,13 @@
+id: oliver-wendell-holmes-sr/the-height-of-the-ridiculous
+slug: the-height-of-the-ridiculous
+author: Oliver Wendell Holmes, Sr.
+author_slug: oliver-wendell-holmes-sr
+title: The Height of the Ridiculous
+century: 19
+text_path: poems/oliver-wendell-holmes-sr/the-height-of-the-ridiculous.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/7388/pg7388.txt
+public_domain_rationale: 'Public domain in the United States: included in The Poetical Works of Oliver Wendell Holmes — Volume 01: Earlier Poems (1830-1836); text via Project Gutenberg eBook #7388.'
+collection_title: 'The Poetical Works of Oliver Wendell Holmes — Volume 01: Earlier Poems'
+collection_source_url: https://www.gutenberg.org/ebooks/7388

--- a/meta/oliver-wendell-holmes-sr/to-an-insect.yml
+++ b/meta/oliver-wendell-holmes-sr/to-an-insect.yml
@@ -1,0 +1,13 @@
+id: oliver-wendell-holmes-sr/to-an-insect
+slug: to-an-insect
+author: Oliver Wendell Holmes, Sr.
+author_slug: oliver-wendell-holmes-sr
+title: To an Insect
+century: 19
+text_path: poems/oliver-wendell-holmes-sr/to-an-insect.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/7388/pg7388.txt
+public_domain_rationale: 'Public domain in the United States: included in The Poetical Works of Oliver Wendell Holmes — Volume 01: Earlier Poems (1830-1836); text via Project Gutenberg eBook #7388.'
+collection_title: 'The Poetical Works of Oliver Wendell Holmes — Volume 01: Earlier Poems'
+collection_source_url: https://www.gutenberg.org/ebooks/7388

--- a/meta/oliver-wendell-holmes-sr/under-the-violets.yml
+++ b/meta/oliver-wendell-holmes-sr/under-the-violets.yml
@@ -1,0 +1,13 @@
+id: oliver-wendell-holmes-sr/under-the-violets
+slug: under-the-violets
+author: Oliver Wendell Holmes, Sr.
+author_slug: oliver-wendell-holmes-sr
+title: Under the Violets
+century: 19
+text_path: poems/oliver-wendell-holmes-sr/under-the-violets.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/7393/pg7393.txt
+public_domain_rationale: 'Public domain in the United States: included in The Poetical Works of Oliver Wendell Holmes — Volume 06; text via Project Gutenberg eBook #7393.'
+collection_title: The Poetical Works of Oliver Wendell Holmes — Volume 06
+collection_source_url: https://www.gutenberg.org/ebooks/7393

--- a/poems/oliver-wendell-holmes-sr/sun-and-shadow.txt
+++ b/poems/oliver-wendell-holmes-sr/sun-and-shadow.txt
@@ -1,0 +1,26 @@
+As I look from the isle, o'er its billows of green,
+To the billows of foam-crested blue,
+Yon bark, that afar in the distance is seen,
+Half dreaming, my eyes will pursue
+Now dark in the shadow, she scatters the spray
+As the chaff in the stroke of the flail;
+Now white as the sea-gull, she flies on her way,
+The sun gleaming bright on her sail.
+
+Yet her pilot is thinking of dangers to shun,--
+Of breakers that whiten and roar;
+How little he cares, if in shadow or sun
+They see him who gaze from the shore!
+He looks to the beacon that looms from the reef,
+To the rock that is under his lee,
+As he drifts on the blast, like a wind-wafted leaf,
+O'er the gulfs of the desolate sea.
+
+Thus drifting afar to the dim-vaulted caves
+Where life and its ventures are laid,
+The dreamers who gaze while we battle the waves
+May see us in sunshine or shade;
+Yet true to our course, though the shadows grow dark,
+We'll trim our broad sail as before,
+And stand by the rudder that governs the bark,
+Nor ask how we look from the shore!

--- a/poems/oliver-wendell-holmes-sr/the-cambridge-churchyard.txt
+++ b/poems/oliver-wendell-holmes-sr/the-cambridge-churchyard.txt
@@ -1,0 +1,125 @@
+OUR ancient church! its lowly tower,
+Beneath the loftier spire,
+Is shadowed when the sunset hour
+Clothes the tall shaft in fire;
+It sinks beyond the distant eye
+Long ere the glittering vane,
+High wheeling in the western sky,
+Has faded o'er the plain.
+
+Like Sentinel and Nun, they keep
+Their vigil on the green;
+One seems to guard, and one to weep,
+The dead that lie between;
+And both roll out, so full and near,
+Their music's mingling waves,
+They shake the grass, whose pennoned spear
+Leans on the narrow graves.
+
+The stranger parts the flaunting weeds,
+Whose seeds the winds have strown
+So thick, beneath the line he reads,
+They shade the sculptured stone;
+The child unveils his clustered brow,
+And ponders for a while
+The graven willow's pendent bough,
+Or rudest cherub's smile.
+
+But what to them the dirge, the knell?
+These were the mourner's share,--
+The sullen clang, whose heavy swell
+Throbbed through the beating air;
+The rattling cord, the rolling stone,
+The shelving sand that slid,
+And, far beneath, with hollow tone
+Rung on the coffin's lid.
+
+The slumberer's mound grows fresh and green,
+Then slowly disappears;
+The mosses creep, the gray stones lean,
+Earth hides his date and years;
+But, long before the once-loved name
+Is sunk or worn away,
+No lip the silent dust may claim,
+That pressed the breathing clay.
+
+Go where the ancient pathway guides,
+See where our sires laid down
+Their smiling babes, their cherished brides,
+The patriarchs of the town;
+Hast thou a tear for buried love?
+A sigh for transient power?
+All that a century left above,
+Go, read it in an hour!
+
+The Indian's shaft, the Briton's ball,
+The sabre's thirsting edge,
+The hot shell, shattering in its fall,
+The bayonet's rending wedge,--
+Here scattered death; yet, seek the spot,
+No trace thine eye can see,
+No altar,--and they need it not
+Who leave their children free!
+
+Look where the turbid rain-drops stand
+In many a chiselled square;
+The knightly crest, the shield, the brand
+Of honored names were there;--
+Alas! for every tear is dried
+Those blazoned tablets knew,
+Save when the icy marble's side
+Drips with the evening dew.
+
+Or gaze upon yon pillared stone,
+The empty urn of pride;
+There stand the Goblet and the Sun,--
+What need of more beside?
+Where lives the memory of the dead,
+Who made their tomb a toy?
+Whose ashes press that nameless bed?
+Go, ask the village boy!
+
+Lean o'er the slender western wall,
+Ye ever-roaming girls;
+The breath that bids the blossom fall
+May lift your floating curls,
+To sweep the simple lines that tell
+An exile's date and doom;
+And sigh, for where his daughters dwell,
+They wreathe the stranger's tomb.
+
+And one amid these shades was born,
+Beneath this turf who lies,
+Once beaming as the summer's morn,
+That closed her gentle eyes;
+If sinless angels love as we,
+Who stood thy grave beside,
+Three seraph welcomes waited thee,
+The daughter, sister, bride.
+
+I wandered to thy buried mound
+When earth was hid below
+The level of the glaring ground,
+Choked to its gates with snow,
+And when with summer's flowery waves
+The lake of verdure rolled,
+As if a Sultan's white-robed slaves
+Had scattered pearls and gold.
+
+Nay, the soft pinions of the air,
+That lift this trembling tone,
+Its breath of love may almost bear
+To kiss thy funeral stone;
+And, now thy smiles have passed away,
+For all the joy they gave,
+May sweetest dews and warmest ray
+Lie on thine early grave!
+
+When damps beneath and storms above
+Have bowed these fragile towers,
+Still o'er the graves yon locust grove
+Shall swing its Orient flowers;
+And I would ask no mouldering bust,
+If e'er this humble line,
+Which breathed a sigh o'er other's dust,
+Might call a tear on mine.

--- a/poems/oliver-wendell-holmes-sr/the-height-of-the-ridiculous.txt
+++ b/poems/oliver-wendell-holmes-sr/the-height-of-the-ridiculous.txt
@@ -1,0 +1,39 @@
+I WROTE some lines once on a time
+In wondrous merry mood,
+And thought, as usual, men would say
+They were exceeding good.
+
+They were so queer, so very queer,
+I laughed as I would die;
+Albeit, in the general way,
+A sober man am I.
+
+I called my servant, and he came;
+How kind it was of him
+To mind a slender man like me,
+He of the mighty limb.
+
+"These to the printer," I exclaimed,
+And, in my humorous way,
+I added, (as a trifling jest,)
+"There'll be the devil to pay."
+
+He took the paper, and I watched,
+And saw him peep within;
+At the first line he read, his face
+Was all upon the grin.
+
+He read the next; the grin grew broad,
+And shot from ear to ear;
+He read the third; a chuckling noise
+I now began to hear.
+
+The fourth; he broke into a roar;
+The fifth; his waistband split;
+The sixth; he burst five buttons off,
+And tumbled in a fit.
+
+Ten days and nights, with sleepless eye,
+I watched that wretched man,
+And since, I never dare to write
+As funny as I can.

--- a/poems/oliver-wendell-holmes-sr/to-an-insect.txt
+++ b/poems/oliver-wendell-holmes-sr/to-an-insect.txt
@@ -1,0 +1,53 @@
+I LOVE to hear thine earnest voice,
+Wherever thou art hid,
+Thou testy little dogmatist,
+Thou pretty Katydid
+Thou mindest me of gentlefolks,--
+Old gentlefolks are they,--
+Thou say'st an undisputed thing
+In such a solemn way.
+
+Thou art a female, Katydid
+I know it by the trill
+That quivers through thy piercing notes,
+So petulant and shrill;
+I think there is a knot of you
+Beneath the hollow tree,--
+A knot of spinster Katydids,---
+Do Katydids drink tea?
+
+Oh tell me where did Katy live,
+And what did Katy do?
+And was she very fair and young,
+And yet so wicked, too?
+Did Katy love a naughty man,
+Or kiss more cheeks than one?
+I warrant Katy did no more
+Than many a Kate has done.
+
+Dear me! I'll tell you all about
+My fuss with little Jane,
+And Ann, with whom I used to walk
+So often down the lane,
+And all that tore their locks of black,
+Or wet their eyes of blue,--
+Pray tell me, sweetest Katydid,
+What did poor Katy do?
+
+Ah no! the living oak shall crash,
+That stood for ages still,
+The rock shall rend its mossy base
+And thunder down the hill,
+Before the little Katydid
+Shall add one word, to tell
+The mystic story of the maid
+Whose name she knows so well.
+
+Peace to the ever-murmuring race!
+And when the latest one
+Shall fold in death her feeble wings
+Beneath the autumn sun,
+Then shall she raise her fainting voice,
+And lift her drooping lid,
+And then the child of future years
+Shall hear what Katy did.

--- a/poems/oliver-wendell-holmes-sr/under-the-violets.txt
+++ b/poems/oliver-wendell-holmes-sr/under-the-violets.txt
@@ -1,0 +1,47 @@
+HER hands are cold; her face is white;
+No more her pulses come and go;
+Her eyes are shut to life and light;--
+Fold the white vesture, snow on snow,
+And lay her where the violets blow.
+
+But not beneath a graven stone,
+To plead for tears with alien eyes;
+A slender cross of wood alone
+Shall say, that here a maiden lies
+In peace beneath the peaceful skies.
+
+And gray old trees of hugest limb
+Shall wheel their circling shadows round
+To make the scorching sunlight dim
+That drinks the greenness from the ground,
+And drop their dead leaves on her mound.
+
+When o'er their boughs the squirrels run,
+And through their leaves the robins call,
+And, ripening in the autumn sun,
+The acorns and the chestnuts fall,
+Doubt not that she will heed them all.
+
+For her the morning choir shall sing
+Its matins from the branches high,
+And every minstrel-voice of Spring,
+That trills beneath the April sky,
+Shall greet her with its earliest cry.
+
+When, turning round their dial-track,
+Eastward the lengthening shadows pass,
+Her little mourners, clad in black,
+The crickets, sliding through the grass,
+Shall pipe for her an evening mass.
+
+At last the rootlets of the trees
+Shall find the prison where she lies,
+And bear the buried dust they seize
+In leaves and blossoms to the skies.
+So may the soul that warmed it rise!
+
+If any, born of kindlier blood,
+Should ask, What maiden lies below?
+Say only this: A tender bud,
+That tried to blossom in the snow,
+Lies withered where the violets blow.

--- a/scripts/ingest-gutenberg-holmes-depth.mjs
+++ b/scripts/ingest-gutenberg-holmes-depth.mjs
@@ -1,0 +1,181 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const SOURCES = {
+  volume1: {
+    author: "Oliver Wendell Holmes, Sr.",
+    author_slug: "oliver-wendell-holmes-sr",
+    century: 19,
+    source_ebook: "7388",
+    collection_title: "The Poetical Works of Oliver Wendell Holmes — Volume 01: Earlier Poems",
+    public_domain_note:
+      "included in The Poetical Works of Oliver Wendell Holmes — Volume 01: Earlier Poems (1830-1836)",
+  },
+  volume6: {
+    author: "Oliver Wendell Holmes, Sr.",
+    author_slug: "oliver-wendell-holmes-sr",
+    century: 19,
+    source_ebook: "7393",
+    collection_title: "The Poetical Works of Oliver Wendell Holmes — Volume 06",
+    public_domain_note: "included in The Poetical Works of Oliver Wendell Holmes — Volume 06",
+  },
+};
+
+const POEMS = [
+  {
+    source: SOURCES.volume1,
+    slug: "the-cambridge-churchyard",
+    title: "The Cambridge Churchyard",
+    start_line: "OUR ancient church! its lowly tower,",
+    end_line: "Might call a tear on mine.",
+  },
+  {
+    source: SOURCES.volume1,
+    slug: "to-an-insect",
+    title: "To an Insect",
+    start_line: "I LOVE to hear thine earnest voice,",
+    end_line: "Shall hear what Katy did.",
+  },
+  {
+    source: SOURCES.volume1,
+    slug: "the-height-of-the-ridiculous",
+    title: "The Height of the Ridiculous",
+    start_line: "I WROTE some lines once on a time",
+    end_line: "As funny as I can.",
+  },
+  {
+    source: SOURCES.volume6,
+    slug: "sun-and-shadow",
+    title: "Sun and Shadow",
+    start_line: "As I look from the isle, o'er its billows of green,",
+    end_line: "Nor ask how we look from the shore!",
+  },
+  {
+    source: SOURCES.volume6,
+    slug: "under-the-violets",
+    title: "Under the Violets",
+    start_line: "HER hands are cold; her face is white;",
+    end_line: "Lies withered where the violets blow.",
+  },
+];
+
+function normalizeText(raw) {
+  return raw.replace(/\r\n?/g, "\n").replace(/[ \t]+$/gm, "");
+}
+
+function normalizeLineForMatch(line) {
+  return line.replace(/\s+\d+\s*$/, "").trim();
+}
+
+function stripBoilerplate(raw) {
+  const start = raw.match(/\*\*\*\s*START OF[\s\S]*?\*\*\*/i);
+  const end = raw.match(/\*\*\*\s*END OF[\s\S]*?\*\*\*/i);
+  const startIdx = start ? start.index + start[0].length : 0;
+  const endIdx = end ? end.index : raw.length;
+  return raw.slice(startIdx, endIdx).trim();
+}
+
+async function fetchLines(ebookId) {
+  const url = `https://www.gutenberg.org/cache/epub/${ebookId}/pg${ebookId}.txt`;
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync("curl", ["-L", "--fail", "--silent", url], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return stripBoilerplate(normalizeText(stdout)).split("\n");
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      }
+    }
+  }
+  throw lastError;
+}
+
+function extractPoem(lines, startLine, endLine) {
+  const start = lines.findIndex((line) => normalizeLineForMatch(line) === startLine);
+  if (start === -1) throw new Error(`Start line not found: ${startLine}`);
+
+  const end = lines.findIndex(
+    (line, index) => index >= start && normalizeLineForMatch(line) === endLine,
+  );
+  if (end === -1) throw new Error(`End line not found: ${endLine}`);
+
+  return lines
+    .slice(start, end + 1)
+    .map((line) => line.replace(/\s+\d+\s*$/, ""))
+    .join("\n")
+    .trim();
+}
+
+function buildMeta(poem) {
+  const source = poem.source;
+  const sourceUrl = `https://www.gutenberg.org/cache/epub/${source.source_ebook}/pg${source.source_ebook}.txt`;
+  return yaml.dump(
+    {
+      id: `${source.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: source.author,
+      author_slug: source.author_slug,
+      title: poem.title,
+      century: source.century,
+      text_path: `poems/${source.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Project Gutenberg",
+      source_url: sourceUrl,
+      public_domain_rationale:
+        `Public domain in the United States: ${source.public_domain_note}; ` +
+        `text via Project Gutenberg eBook #${source.source_ebook}.`,
+      collection_title: source.collection_title,
+      collection_source_url: `https://www.gutenberg.org/ebooks/${source.source_ebook}`,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  const cache = new Map();
+  let created = 0;
+
+  for (const poem of POEMS) {
+    const source = poem.source;
+    const poemsDir = path.join("poems", source.author_slug);
+    const metaDir = path.join("meta", source.author_slug);
+    await fs.mkdir(poemsDir, { recursive: true });
+    await fs.mkdir(metaDir, { recursive: true });
+
+    if (!cache.has(source.source_ebook)) {
+      cache.set(source.source_ebook, await fetchLines(source.source_ebook));
+    }
+
+    const text = extractPoem(cache.get(source.source_ebook), poem.start_line, poem.end_line);
+    const poemPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    let existed = true;
+    try {
+      await fs.access(poemPath);
+    } catch {
+      existed = false;
+    }
+
+    await fs.writeFile(poemPath, `${text}\n`, "utf8");
+    await fs.writeFile(metaPath, buildMeta(poem), "utf8");
+    created += 1;
+    console.log(`${source.author}: ${existed ? "updated" : "created"} ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add five more Oliver Wendell Holmes Sr. poems from approved Project Gutenberg sources
- add matching metadata sidecars with explicit US public-domain rationale
- add a repeatable Holmes-specific Gutenberg ingest script

## Testing
- cd site && npm run build

Closes #179