### PR TITLE
Deepen William Ernest Henley coverage (#181)

### DIFF
--- a/meta/william-ernest-henley/a-late-lark-twitters-from-the-quiet-skies.yml
+++ b/meta/william-ernest-henley/a-late-lark-twitters-from-the-quiet-skies.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/a-late-lark-twitters-from-the-quiet-skies
+slug: a-late-lark-twitters-from-the-quiet-skies
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: A Late Lark Twitters from the Quiet Skies
+century: 19
+text_path: poems/william-ernest-henley/a-late-lark-twitters-from-the-quiet-skies.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1886 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/meta/william-ernest-henley/or-ever-the-knightly-years-were-gone.yml
+++ b/meta/william-ernest-henley/or-ever-the-knightly-years-were-gone.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/or-ever-the-knightly-years-were-gone
+slug: or-ever-the-knightly-years-were-gone
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: Or Ever the Knightly Years Were Gone
+century: 19
+text_path: poems/william-ernest-henley/or-ever-the-knightly-years-were-gone.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1876 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/meta/william-ernest-henley/the-sea-is-full-of-wandering-foam.yml
+++ b/meta/william-ernest-henley/the-sea-is-full-of-wandering-foam.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/the-sea-is-full-of-wandering-foam
+slug: the-sea-is-full-of-wandering-foam
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: The Sea Is Full of Wandering Foam
+century: 19
+text_path: poems/william-ernest-henley/the-sea-is-full-of-wandering-foam.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1876 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/meta/william-ernest-henley/the-skies-are-strown-with-stars.yml
+++ b/meta/william-ernest-henley/the-skies-are-strown-with-stars.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/the-skies-are-strown-with-stars
+slug: the-skies-are-strown-with-stars
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: The Skies Are Strown with Stars
+century: 19
+text_path: poems/william-ernest-henley/the-skies-are-strown-with-stars.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1877 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/meta/william-ernest-henley/while-the-west-is-paling.yml
+++ b/meta/william-ernest-henley/while-the-west-is-paling.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/while-the-west-is-paling
+slug: while-the-west-is-paling
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: While the West Is Paling
+century: 19
+text_path: poems/william-ernest-henley/while-the-west-is-paling.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1876 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/poems/william-ernest-henley/a-late-lark-twitters-from-the-quiet-skies.txt
+++ b/poems/william-ernest-henley/a-late-lark-twitters-from-the-quiet-skies.txt
@@ -1,0 +1,25 @@
+A LATE lark twitters from the quiet skies;
+   And from the west,
+   Where the sun, his day’s work ended,
+   Lingers as in content,
+   There falls on the old, grey city
+   An influence luminous and serene,
+   A shining peace.
+
+   The smoke ascends
+   In a rosy-and-golden haze.  The spires
+   Shine, and are changed.  In the valley
+   Shadows rise.  The lark sings on.  The sun,
+   Closing his benediction,
+   Sinks, and the darkening air
+   Thrills with a sense of the triumphing night—
+   Night with her train of stars
+   And her great gift of sleep.
+
+   So be my passing!
+   My task accomplished and the long day done,
+   My wages taken, and in my heart
+   Some late lark singing,
+   Let me be gathered to the quiet west,
+   The sundown splendid and serene,
+   Death.

--- a/poems/william-ernest-henley/or-ever-the-knightly-years-were-gone.txt
+++ b/poems/william-ernest-henley/or-ever-the-knightly-years-were-gone.txt
@@ -1,0 +1,28 @@
+OR ever the knightly years were gone
+      With the old world to the grave,
+   I was a King in Babylon
+      And you were a Christian Slave.
+
+   I saw, I took, I cast you by,
+      I bent and broke your pride.
+   You loved me well, or I heard them lie,
+      But your longing was denied.
+   Surely I knew that by and by
+      You cursed your gods and died.
+
+   And a myriad suns have set and shone
+      Since then upon the grave
+   Decreed by the King in Babylon
+      To her that had been his Slave.
+
+   The pride I trampled is now my scathe,
+      For it tramples me again.
+   The old resentment lasts like death,
+      For you love, yet you refrain.
+   I break my heart on your hard unfaith,
+      And I break my heart in vain.
+
+   Yet not for an hour do I wish undone
+      The deed beyond the grave,
+   When I was a King in Babylon
+      And you were a Virgin Slave.

--- a/poems/william-ernest-henley/the-sea-is-full-of-wandering-foam.txt
+++ b/poems/william-ernest-henley/the-sea-is-full-of-wandering-foam.txt
@@ -1,0 +1,9 @@
+THE sea is full of wandering foam,
+      The sky of driving cloud;
+   My restless thoughts among them roam . . .
+      The night is dark and loud.
+
+   Where are the hours that came to me
+      So beautiful and bright?
+   A wild wind shakes the wilder sea . . .
+      O, dark and loud’s the night!

--- a/poems/william-ernest-henley/the-skies-are-strown-with-stars.txt
+++ b/poems/william-ernest-henley/the-skies-are-strown-with-stars.txt
@@ -1,0 +1,11 @@
+THE skies are strown with stars,
+      The streets are fresh with dew
+   A thin moon drifts to westward,
+   The night is hushed and cheerful.
+      My thought is quick with you.
+
+   Near windows gleam and laugh,
+      And far away a train
+   Clanks glowing through the stillness:
+   A great content’s in all things,
+      And life is not in vain.

--- a/poems/william-ernest-henley/while-the-west-is-paling.txt
+++ b/poems/william-ernest-henley/while-the-west-is-paling.txt
@@ -1,0 +1,14 @@
+WHILE the west is paling
+      Starshine is begun.
+   While the dusk is failing
+      Glimmers up the sun.
+
+   So, till darkness cover
+      Life’s retreating gleam,
+   Lover follows lover,
+      Dream succeeds to dream.
+
+   Stoop to my endeavour,
+      O my love, and be
+   Only and for ever
+      Sun and stars to me.

--- a/scripts/ingest-gutenberg-henley-depth.mjs
+++ b/scripts/ingest-gutenberg-henley-depth.mjs
@@ -1,0 +1,163 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const SOURCE = {
+  author: "William Ernest Henley",
+  author_slug: "william-ernest-henley",
+  century: 19,
+  source_ebook: "1568",
+  collection_title: "Poems",
+};
+
+const POEMS = [
+  {
+    slug: "the-sea-is-full-of-wandering-foam",
+    title: "The Sea Is Full of Wandering Foam",
+    published_year: 1876,
+    start_line: "THE sea is full of wandering foam,",
+    end_line: "O, dark and loud’s the night!",
+  },
+  {
+    slug: "while-the-west-is-paling",
+    title: "While the West Is Paling",
+    published_year: 1876,
+    start_line: "WHILE the west is paling",
+    end_line: "Sun and stars to me.",
+  },
+  {
+    slug: "the-skies-are-strown-with-stars",
+    title: "The Skies Are Strown with Stars",
+    published_year: 1877,
+    start_line: "THE skies are strown with stars,",
+    end_line: "And life is not in vain.",
+  },
+  {
+    slug: "a-late-lark-twitters-from-the-quiet-skies",
+    title: "A Late Lark Twitters from the Quiet Skies",
+    published_year: 1886,
+    start_line: "A LATE lark twitters from the quiet skies;",
+    end_line: "Death.",
+  },
+  {
+    slug: "or-ever-the-knightly-years-were-gone",
+    title: "Or Ever the Knightly Years Were Gone",
+    published_year: 1876,
+    start_line: "OR ever the knightly years were gone",
+    end_line: "And you were a Virgin Slave.",
+  },
+];
+
+function normalizeText(raw) {
+  return raw.replace(/\r\n?/g, "\n").replace(/[ \t]+$/gm, "");
+}
+
+function normalizeLineForMatch(line) {
+  return line.replace(/\s+\d+\s*$/, "").trim();
+}
+
+function stripBoilerplate(raw) {
+  const start = raw.match(/\*\*\*\s*START OF[\s\S]*?\*\*\*/i);
+  const end = raw.match(/\*\*\*\s*END OF[\s\S]*?\*\*\*/i);
+  const startIdx = start ? start.index + start[0].length : 0;
+  const endIdx = end ? end.index : raw.length;
+  return raw.slice(startIdx, endIdx).trim();
+}
+
+async function fetchLines(ebookId) {
+  const url = `https://www.gutenberg.org/cache/epub/${ebookId}/pg${ebookId}.txt`;
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync("curl", ["-L", "--fail", "--silent", url], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      return stripBoilerplate(normalizeText(stdout)).split("\n");
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, attempt * 1000));
+      }
+    }
+  }
+  throw lastError;
+}
+
+function extractPoem(lines, startLine, endLine) {
+  const start = lines.findIndex((line) => normalizeLineForMatch(line) === startLine);
+  if (start === -1) throw new Error(`Start line not found: ${startLine}`);
+
+  const end = lines.findIndex(
+    (line, index) => index >= start && normalizeLineForMatch(line) === endLine,
+  );
+  if (end === -1) throw new Error(`End line not found: ${endLine}`);
+
+  return lines
+    .slice(start, end + 1)
+    .map((line) => line.replace(/\s+\d+\s*$/, ""))
+    .join("\n")
+    .trim();
+}
+
+function buildMeta(poem) {
+  const sourceUrl = `https://www.gutenberg.org/cache/epub/${SOURCE.source_ebook}/pg${SOURCE.source_ebook}.txt`;
+  return yaml.dump(
+    {
+      id: `${SOURCE.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: SOURCE.author,
+      author_slug: SOURCE.author_slug,
+      title: poem.title,
+      century: SOURCE.century,
+      text_path: `poems/${SOURCE.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Project Gutenberg",
+      source_url: sourceUrl,
+      public_domain_rationale:
+        `Public domain in the United States: first published ${poem.published_year} ` +
+        `(pre-1929); text via Project Gutenberg eBook #${SOURCE.source_ebook}.`,
+      collection_title: SOURCE.collection_title,
+      collection_source_url: `https://www.gutenberg.org/ebooks/${SOURCE.source_ebook}`,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  const poemsDir = path.join("poems", SOURCE.author_slug);
+  const metaDir = path.join("meta", SOURCE.author_slug);
+  await fs.mkdir(poemsDir, { recursive: true });
+  await fs.mkdir(metaDir, { recursive: true });
+
+  const lines = await fetchLines(SOURCE.source_ebook);
+  let created = 0;
+
+  for (const poem of POEMS) {
+    const text = extractPoem(lines, poem.start_line, poem.end_line);
+    const poemPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    let existed = true;
+    try {
+      await fs.access(poemPath);
+    } catch {
+      existed = false;
+    }
+
+    await fs.writeFile(poemPath, `${text}\n`, "utf8");
+    await fs.writeFile(metaPath, buildMeta(poem), "utf8");
+    created += 1;
+    console.log(`${SOURCE.author}: ${existed ? "updated" : "created"} ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add five more William Ernest Henley poems from approved Project Gutenberg sources
- add matching metadata sidecars with explicit US public-domain rationale
- add a repeatable Henley-specific Gutenberg ingest script

## Testing
- cd site && npm run build

Closes #181