### PR TITLE
Deepen George Herbert coverage (#185)

### DIFF
--- a/meta/george-herbert/affliction-i.yml
+++ b/meta/george-herbert/affliction-i.yml
@@ -1,0 +1,14 @@
+id: george-herbert/affliction-i
+slug: affliction-i
+author: George Herbert
+author_slug: george-herbert
+title: Affliction (I)
+century: 17
+text_path: poems/george-herbert/affliction-i.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Affliction_(I)
+public_domain_rationale: 'Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source.'
+collection_title: 'The Temple: Sacred Poems and Private Ejaculations'
+collection_source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations
+notes: Orthography preserved from the 1633 text on Wikisource.

--- a/meta/george-herbert/deniall.yml
+++ b/meta/george-herbert/deniall.yml
@@ -1,0 +1,14 @@
+id: george-herbert/deniall
+slug: deniall
+author: George Herbert
+author_slug: george-herbert
+title: Deniall
+century: 17
+text_path: poems/george-herbert/deniall.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Deniall
+public_domain_rationale: 'Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source.'
+collection_title: 'The Temple: Sacred Poems and Private Ejaculations'
+collection_source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations
+notes: Orthography preserved from the 1633 text on Wikisource.

--- a/meta/george-herbert/jordan-i.yml
+++ b/meta/george-herbert/jordan-i.yml
@@ -1,0 +1,14 @@
+id: george-herbert/jordan-i
+slug: jordan-i
+author: George Herbert
+author_slug: george-herbert
+title: Jordan (I)
+century: 17
+text_path: poems/george-herbert/jordan-i.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Jordan_(I)
+public_domain_rationale: 'Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source.'
+collection_title: 'The Temple: Sacred Poems and Private Ejaculations'
+collection_source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations
+notes: Orthography preserved from the 1633 text on Wikisource.

--- a/meta/george-herbert/prayer-i.yml
+++ b/meta/george-herbert/prayer-i.yml
@@ -1,0 +1,14 @@
+id: george-herbert/prayer-i
+slug: prayer-i
+author: George Herbert
+author_slug: george-herbert
+title: Prayer (I)
+century: 17
+text_path: poems/george-herbert/prayer-i.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Prayer_(I)
+public_domain_rationale: 'Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source.'
+collection_title: 'The Temple: Sacred Poems and Private Ejaculations'
+collection_source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations
+notes: Orthography preserved from the 1633 text on Wikisource.

--- a/meta/george-herbert/vertue.yml
+++ b/meta/george-herbert/vertue.yml
@@ -1,0 +1,14 @@
+id: george-herbert/vertue
+slug: vertue
+author: George Herbert
+author_slug: george-herbert
+title: Vertue
+century: 17
+text_path: poems/george-herbert/vertue.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Vertue
+public_domain_rationale: 'Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source.'
+collection_title: 'The Temple: Sacred Poems and Private Ejaculations'
+collection_source_url: https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations
+notes: Orthography preserved from the 1633 text on Wikisource.

--- a/poems/george-herbert/affliction-i.txt
+++ b/poems/george-herbert/affliction-i.txt
@@ -1,0 +1,76 @@
+WHen first thou didst entice to thee my heart,
+I thought the service brave:
+So many joyes I writ down for my part,
+Besides what I might have
+Out of my stock of naturall delights,
+Augmented with thy gracious benefits.
+
+I looked on thy furniture so fine,
+And made it fine to me:
+Thy glorious houshold-stuffe did me entwine,
+And 'tice me unto thee.
+Such starres I counted mine: both heav'n and earth
+Payd me my wages in a world of mirth.
+
+What pleasures could I want, whose King I served,
+Where joyes my fellows were?
+Thus argu'd into hopes, my thoughts reserved
+No place for grief or fear.
+Therefore my sudden soul caught at the place,
+And made her youth and fiercenesse seek thy face:
+
+At first thou gav'st me milk and sweetnesses;
+I had my wish and way:
+My dayes were straw'd with flow'rs and happinesse;
+There was no moneth but May.
+But with my yeares sorrow did twist and grow,
+And made a partie unawares for wo.
+
+My flesh began unto my soul in pain,
+Sicknesses cleave my bones;
+Consuming agues dwell in ev'ry vein,
+And tune my breath to grones.
+Sorrow was all my soul; I scarce beleeved,
+Till grief did tell me roundly, that I lived.
+
+When I got health, thou took'st away my life,
+And more; for my friends die:
+My mirth and edge was lost; a blunted knife
+Was of more use then I.
+Thus thinne and lean without a fence or friend,
+I was blown through with ev'ry storm and winde.
+
+Whereas my birth and spirit rather took
+The way that takes the town;
+Thou didst betray me to a lingring book,
+And wrap me in a gown.
+I was entangled in the world of strife,
+Before I had the power to change my life.
+
+Yet, for I threatned oft the siege to raise,
+Not simpring all mine age,
+Thou often didst with Academick praise
+Melt and dissolve my rage.
+I took thy sweetned pill, till I came neare;
+I could not go away, nor persevere.
+
+Yet left perchance I should too happie be
+In my unhappinesse,
+Turning my purge to food, thou throwest me
+Into more sicknesses.
+Thus doth thy power crosse-bias me, not making
+Thine own gift good, yet me from my wayes taking.
+
+Now I am here, what thou wilt do with me
+None of my books will show
+I reade, and sigh, and wish I were a tree;
+For sure then I should grow
+To fruit or shade: at least some bird would trust
+Her houshold to me, and I should be just.
+
+Yet, though thou troublest me, I must be meek;
+In weaknesse must be stout.
+Well, I will change the service, and go seek
+Some other master out.
+Ah my deare God! though I am clean forgot,
+Let me not love thee, if I love thee not.

--- a/poems/george-herbert/deniall.txt
+++ b/poems/george-herbert/deniall.txt
@@ -1,0 +1,35 @@
+WHen my devotions could not pierce
+Thy silent eares;
+Then was my heart broken, as was my verse:
+My breast was full of fears
+And disorder:
+
+My bent thoughts, like a brittle bow,
+Did flie asunder:
+Each took his way; some would to pleasures go,
+Some to the warres and thunder
+Of alarms.
+
+As good go any where, they say,
+As to benumme
+Both knees and heart, in crying night and day,
+Come, come, my God, O come!
+But no hearing.
+
+O that thou shouldst give dust a tongue
+To crie to thee,
+And then not heare it crying! all day long
+My heart was in my knee,
+But no hearing.
+
+Therefore my soul lay out of sight,
+Untun'd, unstrung:
+My feeble spirit, unable to look right,
+Like a nipt blossome, hung
+Discontented.
+
+O cheer and tune my heartlesse breast,
+Deferre no time;
+That so thy favours granting my request,
+They and my minde may chime,
+And mend my ryme.

--- a/poems/george-herbert/jordan-i.txt
+++ b/poems/george-herbert/jordan-i.txt
@@ -1,0 +1,17 @@
+WHo sayes that fictions onely and false hair
+Become a verse? Is there in truth no beautie?
+Is all good structure in a winding stair?
+May no lines passe, except they do their dutie
+Not to a true, but painted chair?
+
+Is it no verse, except enchanted groves
+And sudden arbours shadow course-spunne lines?
+Must purling streams refresh a lovers loves?
+Must all be vail'd, while he that reades, divines,
+Catching the sense at two removes?
+
+Shepherds are honest people; let them sing:
+Riddle who list, for me, and pull for Prime:
+I envie no mans nightingale or spring:
+Nor let them punish me with losse of ryme,
+Who plainly say, My God, My King.

--- a/poems/george-herbert/prayer-i.txt
+++ b/poems/george-herbert/prayer-i.txt
@@ -1,0 +1,17 @@
+PRayer the Churches banquet, Angels age,
+Gods breath in man returning to his birth,
+The soul in paraphrase, heart in pilgrimage,
+The Christian plummet sounding heav'n and earth,
+
+Engine against th' Almightie, sinners towre,
+Reversed thunder, Christ-side-piercing spear,
+The six-daies world-transposing in an houre,
+A kinde of tune, which all things heare and fear,
+
+Softnesse, and peace, and joy, and love, and blisse,
+Exalted Manna, gladnesse of the best,
+Heaven in ordinarie, man well drest,
+The milkie way, the bird of Paradise,
+
+Church-bels beyond the starres heard, the souls bloud,
+The land of spices; something understood.

--- a/poems/george-herbert/vertue.txt
+++ b/poems/george-herbert/vertue.txt
@@ -1,0 +1,19 @@
+SWeet day, so cool, so calm, so bright,
+The bridall of the earth and skie:
+The dew shall weep thy fall to night;
+For thou must die.
+
+Sweet rose, whose hue angrie and brave
+Bids the rash gazer wipe his eye:
+Thy root is ever in its grave,
+And thou must die.
+
+Sweet spring, full of sweet dayes and roses,
+A box where sweets compacted lie;
+My musick shows ye have your closes,
+And all must die.
+
+Onely a sweet and vertuous soul,
+Like season'd timber, never gives;
+But though the whole world turn to coal,
+Then chiefly lives.

--- a/scripts/ingest-wikisource-herbert-depth.mjs
+++ b/scripts/ingest-wikisource-herbert-depth.mjs
@@ -1,0 +1,221 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const POEMS = [
+  {
+    author: "George Herbert",
+    author_slug: "george-herbert",
+    century: 17,
+    slug: "prayer-i",
+    title: "Prayer (I)",
+    source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Prayer_(I)",
+    collection_title: "The Temple: Sacred Poems and Private Ejaculations",
+    collection_source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations",
+    page_title: "The Temple: Sacred Poems and Private Ejaculations/Prayer (I)",
+    start_line: "PRayer the Churches banquet, Angels age,",
+    end_line: "The land of spices; something understood.",
+  },
+  {
+    author: "George Herbert",
+    author_slug: "george-herbert",
+    century: 17,
+    slug: "jordan-i",
+    title: "Jordan (I)",
+    source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Jordan_(I)",
+    collection_title: "The Temple: Sacred Poems and Private Ejaculations",
+    collection_source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations",
+    page_title: "The Temple: Sacred Poems and Private Ejaculations/Jordan (I)",
+    start_line: "WHo sayes that fictions onely and false hair",
+    end_line: "Who plainly say, My God, My King.",
+  },
+  {
+    author: "George Herbert",
+    author_slug: "george-herbert",
+    century: 17,
+    slug: "deniall",
+    title: "Deniall",
+    source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Deniall",
+    collection_title: "The Temple: Sacred Poems and Private Ejaculations",
+    collection_source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations",
+    page_title: "The Temple: Sacred Poems and Private Ejaculations/Deniall",
+    start_line: "WHen my devotions could not pierce",
+    end_line: "And mend my ryme.",
+  },
+  {
+    author: "George Herbert",
+    author_slug: "george-herbert",
+    century: 17,
+    slug: "affliction-i",
+    title: "Affliction (I)",
+    source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Affliction_(I)",
+    collection_title: "The Temple: Sacred Poems and Private Ejaculations",
+    collection_source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations",
+    page_title: "The Temple: Sacred Poems and Private Ejaculations/Affliction (I)",
+    start_line: "WHen first thou didst entice to thee my heart,",
+    end_line: "Let me not love thee, if I love thee not.",
+  },
+  {
+    author: "George Herbert",
+    author_slug: "george-herbert",
+    century: 17,
+    slug: "vertue",
+    title: "Vertue",
+    source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations/Vertue",
+    collection_title: "The Temple: Sacred Poems and Private Ejaculations",
+    collection_source_url: "https://en.wikisource.org/wiki/The_Temple:_Sacred_Poems_and_Private_Ejaculations",
+    page_title: "The Temple: Sacred Poems and Private Ejaculations/Vertue",
+    start_line: "SWeet day, so cool, so calm, so bright,",
+    end_line: "Then chiefly lives.",
+  },
+];
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&#8195;/g, "    ")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#91;/g, "[")
+    .replace(/&#93;/g, "]")
+    .replace(/&#95;/g, "_")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…");
+}
+
+function cleanRenderedText(html) {
+  let body = html.includes('<div class="prp-pages-output"')
+    ? html.slice(html.indexOf('<div class="prp-pages-output"'))
+    : html;
+  const referencesIndex = body.indexOf('<div class="mw-references-wrap');
+  if (referencesIndex !== -1) body = body.slice(0, referencesIndex);
+
+  body = body.replace(/<style[\s\S]*?<\/style>/g, "");
+  body = body.replace(/<link[^>]*>/g, "");
+  body = body.replace(/<sup[^>]*>.*?<\/sup>/gs, "");
+  body = body.replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+  body = body.replace(/<span[^>]*class="wst-gap[^"]*"[^>]*><\/span>/g, "    ");
+  body = body.replace(/<br\s*\/?>\n?/g, "\n");
+  body = body.replace(/<\/p>\s*<p>/g, "\n\n");
+  body = body.replace(/<[^>]+>/g, "");
+
+  return decodeHtml(body)
+    .replace(/\u00a0/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function extractPoem(text, startLine, endLine) {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  const start = lines.findIndex((line) => line.trim() === startLine);
+  if (start === -1) throw new Error(`Start line not found: ${startLine}`);
+
+  const end = lines.findIndex((line, index) => index >= start && line.trim() === endLine);
+  if (end === -1) throw new Error(`End line not found: ${endLine}`);
+
+  return lines
+    .slice(start, end + 1)
+    .filter((line) => line.trim() !== "¶ Prayer." && line.trim() !== "¶ Jordan." && line.trim() !== "¶ Deniall." && line.trim() !== "¶ Affliction." && line.trim() !== "¶ Vertue.")
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchPoemText(pageTitle, startLine, endLine) {
+  const url =
+    "https://en.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  let lastError;
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync("curl", ["-L", "--fail", "--silent", url], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      const json = JSON.parse(stdout);
+      if (!json.parse?.text) throw new Error(`Wikisource parse failed for ${pageTitle}`);
+      return extractPoem(cleanRenderedText(json.parse.text), startLine, endLine);
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+function buildMeta(poem) {
+  return yaml.dump(
+    {
+      id: `${poem.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: poem.author,
+      author_slug: poem.author_slug,
+      title: poem.title,
+      century: poem.century,
+      text_path: `poems/${poem.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: poem.source_url,
+      public_domain_rationale:
+        "Public domain in the United States: Herbert died 1633 and the Wikisource text is from a public-domain source.",
+      collection_title: poem.collection_title,
+      collection_source_url: poem.collection_source_url,
+      notes: "Orthography preserved from the 1633 text on Wikisource.",
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  let created = 0;
+
+  for (const poem of POEMS) {
+    const poemsDir = path.join("poems", poem.author_slug);
+    const metaDir = path.join("meta", poem.author_slug);
+    await fs.mkdir(poemsDir, { recursive: true });
+    await fs.mkdir(metaDir, { recursive: true });
+
+    const text = await fetchPoemText(poem.page_title, poem.start_line, poem.end_line);
+    const poemPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    let existed = true;
+    try {
+      await fs.access(poemPath);
+    } catch {
+      existed = false;
+    }
+
+    await fs.writeFile(poemPath, `${text}\n`, "utf8");
+    await fs.writeFile(metaPath, buildMeta(poem), "utf8");
+    created += 1;
+    console.log(`${poem.author}: ${existed ? "updated" : "created"} ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add five more George Herbert poems from approved Wikisource pages in The Temple
- add matching metadata sidecars with explicit public-domain rationale
- add a repeatable Herbert-specific Wikisource ingest script

## Testing
- cd site && npm run build

Closes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five new George Herbert poems to the collection: "Affliction (I)", "Deniall", "Jordan (I)", "Prayer (I)", and "Vertue".

* **Chores**
  * Added content ingestion tooling for sourcing poems from Wikisource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->