### PR TITLE
Deepen John Donne coverage (#187)

### DIFF
--- a/meta/john-donne/song-go-and-catch-a-falling-star.yml
+++ b/meta/john-donne/song-go-and-catch-a-falling-star.yml
@@ -1,0 +1,14 @@
+id: john-donne/song-go-and-catch-a-falling-star
+slug: song-go-and-catch-a-falling-star
+author: John Donne
+author_slug: john-donne
+title: 'Song: Go and Catch a Falling Star'
+century: 17
+text_path: poems/john-donne/song-go-and-catch-a-falling-star.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Oxford_Book_of_English_Verse_1250-1900/Song_(Donne)
+public_domain_rationale: 'Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source.'
+collection_title: Oxford Book of English Verse 1250-1900
+collection_source_url: https://en.wikisource.org/wiki/Oxford_Book_of_English_Verse_1250-1900
+notes: Orthography and capitalization preserved from Wikisource.

--- a/meta/john-donne/the-bait.yml
+++ b/meta/john-donne/the-bait.yml
@@ -1,0 +1,14 @@
+id: john-donne/the-bait
+slug: the-bait
+author: John Donne
+author_slug: john-donne
+title: The Bait
+century: 17
+text_path: poems/john-donne/the-bait.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Bait
+public_domain_rationale: 'Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source.'
+collection_title: Wikisource
+collection_source_url: https://en.wikisource.org/wiki/Author:John_Donne
+notes: Orthography and capitalization preserved from Wikisource.

--- a/meta/john-donne/the-expiration.yml
+++ b/meta/john-donne/the-expiration.yml
@@ -1,0 +1,14 @@
+id: john-donne/the-expiration
+slug: the-expiration
+author: John Donne
+author_slug: john-donne
+title: The Expiration
+century: 17
+text_path: poems/john-donne/the-expiration.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Expiration
+public_domain_rationale: 'Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source.'
+collection_title: Wikisource
+collection_source_url: https://en.wikisource.org/wiki/Author:John_Donne
+notes: Orthography and capitalization preserved from Wikisource.

--- a/meta/john-donne/the-flea.yml
+++ b/meta/john-donne/the-flea.yml
@@ -1,0 +1,14 @@
+id: john-donne/the-flea
+slug: the-flea
+author: John Donne
+author_slug: john-donne
+title: The Flea
+century: 17
+text_path: poems/john-donne/the-flea.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_of_John_Donne/Volume_1/The_Flea
+public_domain_rationale: 'Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source.'
+collection_title: Poems of John Donne, Volume 1
+collection_source_url: https://en.wikisource.org/wiki/Poems_of_John_Donne/Volume_1
+notes: Orthography and capitalization preserved from Wikisource.

--- a/meta/john-donne/the-undertaking.yml
+++ b/meta/john-donne/the-undertaking.yml
@@ -1,0 +1,14 @@
+id: john-donne/the-undertaking
+slug: the-undertaking
+author: John Donne
+author_slug: john-donne
+title: The Undertaking
+century: 17
+text_path: poems/john-donne/the-undertaking.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_Undertaking
+public_domain_rationale: 'Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source.'
+collection_title: Wikisource
+collection_source_url: https://en.wikisource.org/wiki/Author:John_Donne
+notes: Orthography and capitalization preserved from Wikisource.

--- a/poems/john-donne/song-go-and-catch-a-falling-star.txt
+++ b/poems/john-donne/song-go-and-catch-a-falling-star.txt
@@ -1,0 +1,29 @@
+GO and catch a falling star,
+Get with child a mandrake root,
+Tell me where all past years are,
+Or who cleft the Devil's foot:
+Teach me to hear mermaids singing,
+Or to keep off envy's stinging,
+And find
+What wind
+Serves to advance an honest mind.
+
+If thou be'st born to strange sights,
+Things invisible to see,
+Ride ten thousand days and nights
+Till Age snow white hairs on thee;
+Thou, when thou return'st, wilt tell me
+All strange wonders that befell thee,
+And swear
+No where
+Lives a woman true and fair.
+
+If thou find'st one, let me know;
+Such a pilgrimage were sweet.
+Yet do not; I would not go,
+Though at next door we might meet.
+Though she were true when you met her,
+And last till you write your letter,
+Yet she
+Will be
+False, ere I come, to two or three.

--- a/poems/john-donne/the-bait.txt
+++ b/poems/john-donne/the-bait.txt
@@ -1,0 +1,34 @@
+COME live with me, and be my love,
+And we will some new pleasures prove
+Of golden sands, and crystal brooks,
+With silken lines and silver hooks.
+
+There will the river whisp'ring run
+Warm'd by thy eyes, more than the sun;
+And there th' enamour'd fish will stay,
+Begging themselves they may betray.
+
+When thou wilt swim in that live bath,
+Each fish, which every channel hath,
+Will amorously to thee swim,
+Gladder to catch thee, than thou him.
+
+If thou, to be so seen, be'st loth,
+By sun or moon, thou dark'nest both,
+And if myself have leave to see,
+I need not their light, having thee.
+
+Let others freeze with angling reeds,
+And cut their legs with shells and weeds,
+Or treacherously poor fish beset,
+With strangling snare, or windowy net.
+
+Let coarse bold hands from slimy nest
+The bedded fish in banks out-wrest;
+Or curious traitors, sleeve-silk flies,
+Bewitch poor fishes' wand'ring eyes.
+
+For thee, thou need'st no such deceit,
+For thou thyself art thine own bait:
+That fish, that is not catch'd thereby,
+Alas! is wiser far than I.

--- a/poems/john-donne/the-expiration.txt
+++ b/poems/john-donne/the-expiration.txt
@@ -1,0 +1,13 @@
+SO, so, break off this last lamenting kiss,
+Which sucks two souls, and vapours both away;
+Turn, thou ghost, that way, and let me turn this,
+And let ourselves benight our happiest day.
+We ask none leave to love; nor will we owe
+Any so cheap a death as saying, "Go."
+
+Go; and if that word have not quite killed thee,
+Ease me with death, by bidding me go too.
+Or, if it have, let my word work on me,
+And a just office on a murderer do.
+Except it be too late, to kill me so,
+Being double dead, going, and bidding, "Go."

--- a/poems/john-donne/the-flea.txt
+++ b/poems/john-donne/the-flea.txt
@@ -1,0 +1,30 @@
+Mark but this flea, and mark in this,
+How little that which thou deniest me is;
+It suck’d me first, and now sucks thee,
+And in this flea our two bloods mingled be.
+Thou know’st that this cannot be said
+A sin, nor shame, nor loss of maidenhead;
+Yet this enjoys before it woo,
+And pamper’d swells with one blood made of two;
+And this, alas! is more than we would do.
+
+10O stay, three lives in one flea spare,
+Where we almost, yea, more than married are.
+This flea is you and I, and this
+Our marriage bed, and marriage temple is.
+
+Though parents grudge, and you, we’re met,
+And cloister’d in these living walls of jet.
+Though use make you apt to kill me,
+Let not to that self-murder added be,
+And sacrilege, three sins in killing three.
+
+Cruel and sudden, hast thou since
+20Purpled thy nail in blood of innocence?
+Wherein could this flea guilty be,
+Except in that drop which it suck’d from thee?
+Yet thou triumph’st, and say’st that thou
+Find’st not thyself nor me the weaker now.
+’Tis true; then learn how false fears be;
+Just so much honour, when thou yield’st to me,
+Will waste, as this flea’s death took life from thee.

--- a/poems/john-donne/the-undertaking.txt
+++ b/poems/john-donne/the-undertaking.txt
@@ -1,0 +1,4 @@
+I HAVE done one braver thing
+Than all the Worthies did;
+And yet a braver thence doth spring,
+Which is, to keep that hid.

--- a/scripts/ingest-wikisource-donne-depth.mjs
+++ b/scripts/ingest-wikisource-donne-depth.mjs
@@ -1,0 +1,220 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const execFileAsync = promisify(execFile);
+
+const POEMS = [
+  {
+    author: "John Donne",
+    author_slug: "john-donne",
+    century: 17,
+    slug: "the-flea",
+    title: "The Flea",
+    source_url: "https://en.wikisource.org/wiki/Poems_of_John_Donne/Volume_1/The_Flea",
+    collection_title: "Poems of John Donne, Volume 1",
+    collection_source_url: "https://en.wikisource.org/wiki/Poems_of_John_Donne/Volume_1",
+    page_title: "Poems of John Donne/Volume 1/The Flea",
+    start_line: "Mark but this flea, and mark in this,",
+    end_line: "Will waste, as this flea’s death took life from thee.",
+  },
+  {
+    author: "John Donne",
+    author_slug: "john-donne",
+    century: 17,
+    slug: "the-bait",
+    title: "The Bait",
+    source_url: "https://en.wikisource.org/wiki/The_Bait",
+    collection_title: "Wikisource",
+    collection_source_url: "https://en.wikisource.org/wiki/Author:John_Donne",
+    page_title: "The Bait",
+    start_line: "COME live with me, and be my love,",
+    end_line: "Alas! is wiser far than I.",
+  },
+  {
+    author: "John Donne",
+    author_slug: "john-donne",
+    century: 17,
+    slug: "the-expiration",
+    title: "The Expiration",
+    source_url: "https://en.wikisource.org/wiki/The_Expiration",
+    collection_title: "Wikisource",
+    collection_source_url: "https://en.wikisource.org/wiki/Author:John_Donne",
+    page_title: "The Expiration",
+    start_line: "SO, so, break off this last lamenting kiss,",
+    end_line: "Being double dead, going, and bidding, \"Go.\"",
+  },
+  {
+    author: "John Donne",
+    author_slug: "john-donne",
+    century: 17,
+    slug: "the-undertaking",
+    title: "The Undertaking",
+    source_url: "https://en.wikisource.org/wiki/The_Undertaking",
+    collection_title: "Wikisource",
+    collection_source_url: "https://en.wikisource.org/wiki/Author:John_Donne",
+    page_title: "The Undertaking",
+    start_line: "I HAVE done one braver thing",
+    end_line: "Which is, to keep that hid.",
+  },
+  {
+    author: "John Donne",
+    author_slug: "john-donne",
+    century: 17,
+    slug: "song-go-and-catch-a-falling-star",
+    title: "Song: Go and Catch a Falling Star",
+    source_url: "https://en.wikisource.org/wiki/Oxford_Book_of_English_Verse_1250-1900/Song_(Donne)",
+    collection_title: "Oxford Book of English Verse 1250-1900",
+    collection_source_url: "https://en.wikisource.org/wiki/Oxford_Book_of_English_Verse_1250-1900",
+    page_title: "Oxford Book of English Verse 1250-1900/Song (Donne)",
+    start_line: "GO and catch a falling star,",
+    end_line: "False, ere I come, to two or three.",
+  },
+];
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&#8195;/g, "    ")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#91;/g, "[")
+    .replace(/&#93;/g, "]")
+    .replace(/&#95;/g, "_")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…");
+}
+
+function cleanRenderedText(html) {
+  let body = html.includes('<div class="prp-pages-output"')
+    ? html.slice(html.indexOf('<div class="prp-pages-output"'))
+    : html;
+  const referencesIndex = body.indexOf('<div class="mw-references-wrap');
+  if (referencesIndex !== -1) body = body.slice(0, referencesIndex);
+
+  body = body.replace(/<style[\s\S]*?<\/style>/g, "");
+  body = body.replace(/<link[^>]*>/g, "");
+  body = body.replace(/<sup[^>]*>.*?<\/sup>/gs, "");
+  body = body.replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+  body = body.replace(/<span[^>]*class="wst-gap[^"]*"[^>]*><\/span>/g, "    ");
+  body = body.replace(/<br\s*\/?>\n?/g, "\n");
+  body = body.replace(/<\/p>\s*<p>/g, "\n\n");
+  body = body.replace(/<[^>]+>/g, "");
+
+  return decodeHtml(body)
+    .replace(/\u00a0/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function extractPoem(text, startLine, endLine) {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  const start = lines.findIndex((line) => line.trim() === startLine);
+  if (start === -1) throw new Error(`Start line not found: ${startLine}`);
+
+  const end = lines.findIndex((line, index) => index >= start && line.trim() === endLine);
+  if (end === -1) throw new Error(`End line not found: ${endLine}`);
+
+  return lines
+    .slice(start, end + 1)
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchPoemText(pageTitle, startLine, endLine) {
+  const url =
+    "https://en.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  let lastError;
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const { stdout } = await execFileAsync("curl", ["-L", "--fail", "--silent", url], {
+        maxBuffer: 10 * 1024 * 1024,
+      });
+      const json = JSON.parse(stdout);
+      if (!json.parse?.text) throw new Error(`Wikisource parse failed for ${pageTitle}`);
+      return extractPoem(cleanRenderedText(json.parse.text), startLine, endLine);
+    } catch (error) {
+      lastError = error;
+      if (attempt < 3) {
+        await new Promise((resolve) => setTimeout(resolve, 1000 * attempt));
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+function buildMeta(poem) {
+  return yaml.dump(
+    {
+      id: `${poem.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: poem.author,
+      author_slug: poem.author_slug,
+      title: poem.title,
+      century: poem.century,
+      text_path: `poems/${poem.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: poem.source_url,
+      public_domain_rationale:
+        "Public domain in the United States: Donne died 1631 and the Wikisource text is from a public-domain source.",
+      collection_title: poem.collection_title,
+      collection_source_url: poem.collection_source_url,
+      notes: "Orthography and capitalization preserved from Wikisource.",
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  let created = 0;
+
+  for (const poem of POEMS) {
+    const poemsDir = path.join("poems", poem.author_slug);
+    const metaDir = path.join("meta", poem.author_slug);
+    await fs.mkdir(poemsDir, { recursive: true });
+    await fs.mkdir(metaDir, { recursive: true });
+
+    const text = await fetchPoemText(poem.page_title, poem.start_line, poem.end_line);
+    const poemPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    let existed = true;
+    try {
+      await fs.access(poemPath);
+    } catch {
+      existed = false;
+    }
+
+    await fs.writeFile(poemPath, `${text}\n`, "utf8");
+    await fs.writeFile(metaPath, buildMeta(poem), "utf8");
+    created += 1;
+    console.log(`${poem.author}: ${existed ? "updated" : "created"} ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #187

## Summary
- add five canonical John Donne poems from approved Wikisource sources
- add matching metadata sidecars under `meta/john-donne`
- add a repeatable Donne ingest script

## Testing
- cd site && npm run build