### PR TITLE
Deepen Andrew Marvell coverage (#189)

### DIFF
--- a/meta/andrew-marvell/bermudas.yml
+++ b/meta/andrew-marvell/bermudas.yml
@@ -1,0 +1,13 @@
+id: andrew-marvell/bermudas
+slug: bermudas
+author: Andrew Marvell
+author_slug: andrew-marvell
+title: Bermudas
+century: 17
+text_path: poems/andrew-marvell/bermudas.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/Bermudas
+public_domain_rationale: 'Public domain in the United States: first published 1681 (pre-1929); text via English Wikisource.'
+collection_title: Miscellaneous Poems
+collection_source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)

--- a/meta/andrew-marvell/eyes-and-tears.yml
+++ b/meta/andrew-marvell/eyes-and-tears.yml
@@ -1,0 +1,13 @@
+id: andrew-marvell/eyes-and-tears
+slug: eyes-and-tears
+author: Andrew Marvell
+author_slug: andrew-marvell
+title: Eyes and Tears
+century: 17
+text_path: poems/andrew-marvell/eyes-and-tears.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/Eyes_and_Tears
+public_domain_rationale: 'Public domain in the United States: first published 1681 (pre-1929); text via English Wikisource.'
+collection_title: Miscellaneous Poems
+collection_source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)

--- a/meta/andrew-marvell/on-a-drop-of-dew.yml
+++ b/meta/andrew-marvell/on-a-drop-of-dew.yml
@@ -1,0 +1,13 @@
+id: andrew-marvell/on-a-drop-of-dew
+slug: on-a-drop-of-dew
+author: Andrew Marvell
+author_slug: andrew-marvell
+title: On a Drop of Dew
+century: 17
+text_path: poems/andrew-marvell/on-a-drop-of-dew.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/On_a_Drop_of_Dew
+public_domain_rationale: 'Public domain in the United States: first published 1681 (pre-1929); text via English Wikisource.'
+collection_title: Miscellaneous Poems
+collection_source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)

--- a/meta/andrew-marvell/the-coronet.yml
+++ b/meta/andrew-marvell/the-coronet.yml
@@ -1,0 +1,13 @@
+id: andrew-marvell/the-coronet
+slug: the-coronet
+author: Andrew Marvell
+author_slug: andrew-marvell
+title: The Coronet
+century: 17
+text_path: poems/andrew-marvell/the-coronet.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/The_Coronet
+public_domain_rationale: 'Public domain in the United States: first published 1681 (pre-1929); text via English Wikisource.'
+collection_title: Miscellaneous Poems
+collection_source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)

--- a/meta/andrew-marvell/the-fair-singer.yml
+++ b/meta/andrew-marvell/the-fair-singer.yml
@@ -1,0 +1,13 @@
+id: andrew-marvell/the-fair-singer
+slug: the-fair-singer
+author: Andrew Marvell
+author_slug: andrew-marvell
+title: The Fair Singer
+century: 17
+text_path: poems/andrew-marvell/the-fair-singer.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/The_Fair_Singer
+public_domain_rationale: 'Public domain in the United States: first published 1681 (pre-1929); text via English Wikisource.'
+collection_title: Miscellaneous Poems
+collection_source_url: https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)

--- a/poems/andrew-marvell/bermudas.txt
+++ b/poems/andrew-marvell/bermudas.txt
@@ -1,0 +1,41 @@
+Where the remote Bermudas ride
+In th' Oceans bosome unespy'd,
+From a small Boat, that row'd along,
+The listning Winds receiv'd this Song.
+What should we do but sing his Praise
+That led us through the watry Maze,
+Unto an Isle so long unknown,
+And yet far kinder than our own?
+Where he the huge Sea-Monsters wracks,
+That lift the Deep upon their Backs.
+He lands us on a grassy Stage;
+Safe from the Storms, and Prelat's rage.
+
+He gave us this eternal Spring,
+Which here enamells every thing;
+And sends the Fowl's to us in care,
+On daily Visits through the Air.
+He hangs in shades the Orange bright,
+Like golden Lamps in a green Night.
+And does in the Pomgranates close,
+Jewels more rich than Ormus show's.
+He makes the Figs our mouths to meet;
+And throws the Melons at our feet.
+But Apples plants of such a price,
+No Tree could ever bear them twice.
+With Cedars, chosen by his hand,
+From Lebanon, he stores the Land.
+And makes the hollow Seas, that roar,
+Proclaime the Ambergris on shoar.
+He cast (of which we rather boast)
+The Gospels Pearl upon our Coast.
+And in these Rocks for us did frame
+A Temple, where to sound his Name.
+Oh let our Voice his Praise exalt,
+Till it arrive at Heavens Vault:
+Which thence (perhaps) rebounding, may
+Eccho beyond the Mexique Bay.
+Thus sung they, in the English boat,
+An holy and a chearful Note,
+And all the way, to guide their Chime,
+With falling Oars they kept the time.

--- a/poems/andrew-marvell/eyes-and-tears.txt
+++ b/poems/andrew-marvell/eyes-and-tears.txt
@@ -1,0 +1,70 @@
+How wisely Nature did decree,
+With the same Eyes to weep and see!
+That, having view'd the object vain,
+They might be ready to complain.
+
+And, since the Self-deluding Sight,
+In a false Angle takes each hight;
+These Tears which better measure all,
+Like wat'ry Lines and Plummets fall.
+
+Two Tears, which Sorrow long did weigh
+Within the Scales of either Eye,
+And then paid out in equal Poise,
+Are the true price of all my Joyes.
+
+What in the World most fair appears,
+Yea even Laughter, turns to Tears:
+And all the Jewels which we prize,
+Melt in these Pendants of the Eyes.
+
+I have through every Garden been,
+Amongst the Red, the White, the Green;
+
+And yet, from all the flow'rs I saw,
+No Hony, but these Tears could draw.
+
+So the all-seeing Sun each day
+Distills the World with Chymick Ray;
+But finds the Essence only Showers,
+Which straight in pity back he powers.
+
+Yet happy they whom Grief doth bless,
+That weep the more, and see the less:
+And, to preserve their Sight more true,
+Bath still their Eyes in their own Dew.
+
+So Magdalen, in Tears more wise
+Dissolv'd those captivating Eyes,
+Whose liquid Chaines could flowing meet
+To fetter her Redeemers feet.
+
+Not full sailes hasting loaden home,
+Nor the chast Ladies pregnant Womb,
+Nor Cynthia Teeming show's so fair,
+As two Eyes swoln with weeping are.
+
+The sparkling Glance that shoots Desire,
+Drench'd in these Waves, does lose it fire.
+Yea oft the Thund'rer pitty takes
+And here the hissing Lightning slakes.
+
+The Incense was to Heaven dear,
+Not as a Perfume, but a Tear.
+And Stars shew lovely in the Night,
+But as they seem the Tears of Light.
+
+Ope then mine Eyes your double Sluice,
+And practise so your noblest Use.
+For others too can see, or sleep;
+But only humane Eyes can weep.
+
+Now like two Clouds dissolving, drop,
+And at each Tear in distance stop:
+Now like two Fountains trickle down:
+Now like two sloods o'return and drown.
+
+Thus let your Streams o'reflow your Springs,
+Till Eyes and Tears be the same things:
+And each the other's difference bears;
+These weeping Eyes, those seeing Tears.

--- a/poems/andrew-marvell/on-a-drop-of-dew.txt
+++ b/poems/andrew-marvell/on-a-drop-of-dew.txt
@@ -1,0 +1,41 @@
+See how the Orient Dew,
+Shed from the Bosom of the Morn
+Into the blowing Roses,
+Yet careless of its Mansion new;
+For the clear Region where 'twas born
+Round in its self incloses:
+
+And in its little Globes Extent,
+Frames as it can its native Element.
+How it the purple flow'r does slight,
+Scarce touching where it lyes,
+But gazing back upon the Skies,
+Shines with a mournful Light;
+Like its own Tear,
+Because so long divided from the Sphear.
+Restless it roules and unsecure,
+Trembling lest it grow impure:
+Till the warm Sun pitty it's Pain,
+And to the Skies exhale it back again.
+So the Soul, that Drop, that Ray
+Of the clear Fountain of Eternal Day,
+Could it within the humane flow'r be seen,
+Remembring still its former height,
+Shuns the sweat leaves and blossoms green;
+And, recollecting its own Light,
+Does, in its pure and circling thoughts, express
+The greater Heaven in an Heaven less,
+In how coy a Figure wound,
+Every way it turns away:
+So the World excluding round,
+Yet receiving in the Day.
+Dark beneath, but bright above:
+Here disdaining, there in Love.
+How loose and easie hence to go:
+How girt and ready to ascend.
+Moving but on a point below,
+It all about does upwards bend.
+Such did the Manna's sacred Dew destil;
+White, and intire, though congeal'd and chill.
+Congeal'd on Earth: but does, dissolving, run
+Into the Glories of th' Almighty Sun.

--- a/poems/andrew-marvell/the-coronet.txt
+++ b/poems/andrew-marvell/the-coronet.txt
@@ -1,0 +1,27 @@
+When for the Thorns with which I long, too long,
+With many a piercing wound,
+My Saviours head have crown'd,
+I seek with garlands to redress that Wrong:
+Through every Garden, every Mead,
+I gather flow'rs (my fruits are only flow'rs),
+Dismantling all the fragrant Towers
+That once adorned my Shepherdesses head.
+And now when I have summ'd up all my store,
+Thinking (so I my self deceive)
+So rich a Chaplet thence to weave
+As never yet the king of Glory wore:
+Alas I find the Serpent old
+That, twining in his speckled breast,
+About the flow'rs disguis'd does fold
+With wreaths of Fame and Interest.
+Ah, foolish Man, that would'st debase with them
+And mortal Glory, Heaven's Diadem!
+But thou who only could'st the Serpent tame,
+Either his slipp'ry knots at once untie,
+
+And disintangle all his winding Snare:
+Or shatter too with him my curious frame:
+And let these wither, so that he may die,
+Though set with Skill and chosen out with Care.
+That they, while Thou on both their Spoils dost tread,
+May crown thy Feet, that could not crown thy Head.

--- a/poems/andrew-marvell/the-fair-singer.txt
+++ b/poems/andrew-marvell/the-fair-singer.txt
@@ -1,0 +1,20 @@
+To make a final conquest of all me,
+Love did compose so sweet an Enemy,
+In whom both Beauties to my death agree,
+Joyning themselves in fatal Harmony;
+That while she with her Eyes my Heart does bind,
+She with her Voice might captivate my Mind.
+
+I could have fled from One but singly fair:
+My dis-intangled Soul it self might save,
+Breaking the curled trammels of her hair.
+But how should I avoid to be her Slave,
+Whose subtile Art invisibly can wreath
+My Fetters of the very Air I breath?
+
+It had been easie fighting in some plain,
+Where Victory might hang in equal choice.
+But all resistance against her is vain,
+Who has th' advantage both of Eyes and Voice.
+And all my Forces needs must be undone,
+She having gained both the Wind and Sun.

--- a/scripts/ingest-wikisource-early-modern-depth.mjs
+++ b/scripts/ingest-wikisource-early-modern-depth.mjs
@@ -7,6 +7,76 @@ const POEMS = [
     author: "Andrew Marvell",
     author_slug: "andrew-marvell",
     century: 17,
+    slug: "on-a-drop-of-dew",
+    title: "On a Drop of Dew",
+    published_year: 1681,
+    source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/On_a_Drop_of_Dew",
+    collection_title: "Miscellaneous Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)",
+    page_title: "Miscellaneous Poems (Marvell)/On a Drop of Dew",
+    start_line: "See how the Orient Dew,",
+    end_line: "Into the Glories of th' Almighty Sun.",
+  },
+  {
+    author: "Andrew Marvell",
+    author_slug: "andrew-marvell",
+    century: 17,
+    slug: "bermudas",
+    title: "Bermudas",
+    published_year: 1681,
+    source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/Bermudas",
+    collection_title: "Miscellaneous Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)",
+    page_title: "Miscellaneous Poems (Marvell)/Bermudas",
+    start_line: "Where the remote Bermudas ride",
+    end_line: "With falling Oars they kept the time.",
+  },
+  {
+    author: "Andrew Marvell",
+    author_slug: "andrew-marvell",
+    century: 17,
+    slug: "the-coronet",
+    title: "The Coronet",
+    published_year: 1681,
+    source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/The_Coronet",
+    collection_title: "Miscellaneous Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)",
+    page_title: "Miscellaneous Poems (Marvell)/The Coronet",
+    start_line: "When for the Thorns with which I long, too long,",
+    end_line: "May crown thy Feet, that could not crown thy Head.",
+  },
+  {
+    author: "Andrew Marvell",
+    author_slug: "andrew-marvell",
+    century: 17,
+    slug: "eyes-and-tears",
+    title: "Eyes and Tears",
+    published_year: 1681,
+    source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/Eyes_and_Tears",
+    collection_title: "Miscellaneous Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)",
+    page_title: "Miscellaneous Poems (Marvell)/Eyes and Tears",
+    start_line: "How wisely Nature did decree,",
+    end_line: "These weeping Eyes, those seeing Tears.",
+  },
+  {
+    author: "Andrew Marvell",
+    author_slug: "andrew-marvell",
+    century: 17,
+    slug: "the-fair-singer",
+    title: "The Fair Singer",
+    published_year: 1681,
+    source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)/The_Fair_Singer",
+    collection_title: "Miscellaneous Poems",
+    collection_source_url: "https://en.wikisource.org/wiki/Miscellaneous_Poems_(Marvell)",
+    page_title: "Miscellaneous Poems (Marvell)/The Fair Singer",
+    start_line: "To make a final conquest of all me,",
+    end_line: "She having gained both the Wind and Sun.",
+  },
+  {
+    author: "Andrew Marvell",
+    author_slug: "andrew-marvell",
+    century: 17,
     slug: "the-garden",
     title: "The Garden",
     published_year: 1681,
@@ -112,7 +182,7 @@ function cleanRenderedText(html) {
 }
 
 function extractPoem(text, startLine, endLine) {
-  const lines = text.split("\n").map((line) => line.trimEnd());
+  const lines = text.split("\n").map((line) => line.trimEnd().replace(/^\*\s+/, ""));
   const start = lines.findIndex((line) => line.trim() === startLine);
   if (start === -1) throw new Error(`Start line not found: ${startLine}`);
 
@@ -124,9 +194,17 @@ function extractPoem(text, startLine, endLine) {
     .filter((line) => !/^[IVXLC]+[.]?$/.test(line.trim()))
     .filter(
       (line) =>
-        !["L'Allegro.", "Lycidas.", "The Garden.", "The Definition of Love."].includes(
-          line.trim(),
-        ),
+        ![
+          "L'Allegro.",
+          "Lycidas.",
+          "Bermudas.",
+          "Eyes and Tears.",
+          "On a Drop of Dew.",
+          "The Coronet.",
+          "The Definition of Love.",
+          "The Fair Singer.",
+          "The Garden.",
+        ].includes(line.trim()),
     )
     .join("\n")
     .replace(/\n{3,}/g, "\n\n")


### PR DESCRIPTION
Closes #189

## Summary
- add five canonical Andrew Marvell poems from `Miscellaneous Poems`
- add matching metadata sidecars under `meta/andrew-marvell`
- extend the shared early-modern Wikisource ingest script for the new Marvell tranche

## Testing
- cd site && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five 17th-century poems by Andrew Marvell to the collection: "Bermudas," "Eyes and Tears," "On a Drop of Dew," "The Coronet," and "The Fair Singer." All poems are sourced from Wikisource and available in the public domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->