### PR TITLE
Deepen Samuel Taylor Coleridge coverage (#197)

### DIFF
--- a/meta/samuel-taylor-coleridge/the-nightingale.yml
+++ b/meta/samuel-taylor-coleridge/the-nightingale.yml
@@ -1,0 +1,13 @@
+id: samuel-taylor-coleridge/the-nightingale
+slug: the-nightingale
+author: Samuel Taylor Coleridge
+author_slug: samuel-taylor-coleridge
+title: The Nightingale
+century: 19
+text_path: poems/samuel-taylor-coleridge/the-nightingale.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/8208/pg8208.txt
+public_domain_rationale: 'Public domain in the United States: first published 1800 (pre-1929); text via Project Gutenberg eBook #8208.'
+collection_title: The Complete Poetical Works of Samuel Taylor Coleridge, Vol. I
+collection_source_url: https://www.gutenberg.org/ebooks/8208

--- a/meta/samuel-taylor-coleridge/the-pains-of-sleep.yml
+++ b/meta/samuel-taylor-coleridge/the-pains-of-sleep.yml
@@ -1,0 +1,13 @@
+id: samuel-taylor-coleridge/the-pains-of-sleep
+slug: the-pains-of-sleep
+author: Samuel Taylor Coleridge
+author_slug: samuel-taylor-coleridge
+title: The Pains of Sleep
+century: 19
+text_path: poems/samuel-taylor-coleridge/the-pains-of-sleep.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/8208/pg8208.txt
+public_domain_rationale: 'Public domain in the United States: first published 1803 (pre-1929); text via Project Gutenberg eBook #8208.'
+collection_title: The Complete Poetical Works of Samuel Taylor Coleridge, Vol. I
+collection_source_url: https://www.gutenberg.org/ebooks/8208

--- a/meta/samuel-taylor-coleridge/this-lime-tree-bower-my-prison.yml
+++ b/meta/samuel-taylor-coleridge/this-lime-tree-bower-my-prison.yml
@@ -1,0 +1,13 @@
+id: samuel-taylor-coleridge/this-lime-tree-bower-my-prison
+slug: this-lime-tree-bower-my-prison
+author: Samuel Taylor Coleridge
+author_slug: samuel-taylor-coleridge
+title: This Lime-Tree Bower My Prison
+century: 19
+text_path: poems/samuel-taylor-coleridge/this-lime-tree-bower-my-prison.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/8208/pg8208.txt
+public_domain_rationale: 'Public domain in the United States: first published 1800 (pre-1929); text via Project Gutenberg eBook #8208.'
+collection_title: The Complete Poetical Works of Samuel Taylor Coleridge, Vol. I
+collection_source_url: https://www.gutenberg.org/ebooks/8208

--- a/meta/samuel-taylor-coleridge/to-nature.yml
+++ b/meta/samuel-taylor-coleridge/to-nature.yml
@@ -1,0 +1,13 @@
+id: samuel-taylor-coleridge/to-nature
+slug: to-nature
+author: Samuel Taylor Coleridge
+author_slug: samuel-taylor-coleridge
+title: To Nature
+century: 19
+text_path: poems/samuel-taylor-coleridge/to-nature.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/8208/pg8208.txt
+public_domain_rationale: 'Public domain in the United States: first published 1820 (pre-1929); text via Project Gutenberg eBook #8208.'
+collection_title: The Complete Poetical Works of Samuel Taylor Coleridge, Vol. I
+collection_source_url: https://www.gutenberg.org/ebooks/8208

--- a/meta/samuel-taylor-coleridge/work-without-hope.yml
+++ b/meta/samuel-taylor-coleridge/work-without-hope.yml
@@ -1,0 +1,13 @@
+id: samuel-taylor-coleridge/work-without-hope
+slug: work-without-hope
+author: Samuel Taylor Coleridge
+author_slug: samuel-taylor-coleridge
+title: Work Without Hope
+century: 19
+text_path: poems/samuel-taylor-coleridge/work-without-hope.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/8208/pg8208.txt
+public_domain_rationale: 'Public domain in the United States: first published 1827 (pre-1929); text via Project Gutenberg eBook #8208.'
+collection_title: The Complete Poetical Works of Samuel Taylor Coleridge, Vol. I
+collection_source_url: https://www.gutenberg.org/ebooks/8208

--- a/poems/samuel-taylor-coleridge/the-nightingale.txt
+++ b/poems/samuel-taylor-coleridge/the-nightingale.txt
@@ -1,0 +1,118 @@
+  No cloud, no relique of the sunken day
+  Distinguishes the West, no long thin slip
+  Of sullen light, no obscure trembling hues.
+  Come, we will rest on this old mossy bridge!
+  You see the glimmer of the stream beneath,
+  But hear no murmuring: it flows silently,
+  O'er its soft bed of verdure. All is still,
+  A balmy night! and though the stars be dim,
+  Yet let us think upon the vernal showers
+  That gladden the green earth, and we shall find
+  A pleasure in the dimness of the stars.
+  And hark! the Nightingale begins its song,
+  "Most musical, most melancholy" bird!
+  A melancholy bird? Oh! idle thought!
+  In Nature there is nothing melancholy.
+  But some night-wandering man whose heart was pierced
+  With the remembrance of a grievous wrong,
+  Or slow distemper, or neglected love,
+  (And so, poor wretch! fill'd all things with himself,
+  And made all gentle sounds tell back the tale
+  Of his own sorrow) he, and such as he,
+  First named these notes a melancholy strain.
+  And many a poet echoes the conceit;
+  Poet who hath been building up the rhyme
+  When he had better far have stretched his limbs
+  Beside a brook in mossy forest-dell,
+  By sun or moon-light, to the influxes
+  Of shapes and sounds and shifting elements
+  Surrendering his whole spirit, of his song
+  And of his fame forgetful! so his fame
+  Should share in Nature's immortality,
+  A venerable thing! and so his song
+  Should make all Nature lovelier, and itself
+  Be loved like Nature! But 'twill not be so;
+  And youths and maidens most poetical,
+  Who lose the deepening twilights of the spring
+  In ball-rooms and hot theatres, they still
+  Full of meek sympathy must heave their sighs
+  O'er Philomela's pity-pleading strains.
+
+  My Friend, and thou, our Sister! we have learnt
+  A different lore: we may not thus profane
+  Nature's sweet voices, always full of love
+  And joyance! 'Tis the merry Nightingale
+  That crowds, and hurries, and precipitates
+  With fast thick warble his delicious notes,
+  As he were fearful that an April night
+  Would be too short for him to utter forth
+  His love-chant, and disburthen his full soul
+  Of all its music!
+
+  And I know a grove
+  Of large extent, hard by a castle huge,
+  Which the great lord inhabits not; and so
+  This grove is wild with tangling underwood,
+  And the trim walks are broken up, and grass,
+  Thin grass and king-cups grow within the paths.
+  But never elsewhere in one place I knew
+  So many nightingales; and far and near,
+  In wood and thicket, over the wide grove,
+  They answer and provoke each other's songs,
+  With skirmish and capricious passagings,
+  And murmurs musical and swift jug jug,
+  And one low piping sound more sweet than all--
+  Stirring the air with such an harmony,
+  That should you close your eyes, you might almost
+  Forget it was not day! On moonlight bushes,
+  Whose dewy leaflets are but half-disclosed,
+  You may perchance behold them on the twigs,
+  Their bright, bright eyes, their eyes both bright and full,
+  Glistening, while many a glow-worm in the shade
+  Lights up her love-torch.
+
+                            A most gentle Maid,
+  Who dwelleth in her hospitable home
+  Hard by the castle, and at latest eve
+  (Even like a Lady vowed and dedicate
+  To something more than Nature in the grove)
+  Glides through the pathways; she knows all their notes,
+  That gentle Maid! and oft, a moment's space,
+  What time the moon was lost behind a cloud,
+  Hath heard a pause of silence; till the moon
+  Emerging, hath awakened earth and sky
+  With one sensation, and those wakeful birds
+  Have all burst forth in choral minstrelsy,
+  As if some sudden gale had swept at once
+  A hundred airy harps! And she hath watched
+  Many a nightingale perch giddily
+  On blossomy twig still swinging from the breeze,
+  And to that motion tune his wanton song
+  Like tipsy joy that reels with tossing head.
+
+    Farewell, O Warbler! till to-morrow eve,
+  And you, my friends! farewell, a short farewell!
+  We have been loitering long and pleasantly,
+  And now for our dear homes.--That strain again!
+  Full fain it would delay me! My dear babe,
+  Who, capable of no articulate sound,
+  Mars all things with his imitative lisp,
+  How he would place his hand beside his ear,
+  His little hand, the small forefinger up,
+  And bid us listen! And I deem it wise
+  To make him Nature's play-mate. He knows well
+  The evening-star; and once, when he awoke
+  In most distressful mood (some inward pain
+  Had made up that strange thing, an infant's dream),
+  I hurried with him to our orchard-plot,
+  And he beheld the moon, and, hushed at once,
+  Suspends his sobs, and laughs most silently,
+  While his fair eyes, that swam with undropped
+  tears,
+  Did glitter in the yellow moon-beam! Well!--
+  It is a father's tale: But if that Heaven
+  Should give me life, his childhood shall grow up
+  Familiar with these songs, that with the night
+  He may associate joy.--Once more, farewell,
+  Sweet Nightingale! once more, my friends!
+  farewell.

--- a/poems/samuel-taylor-coleridge/the-pains-of-sleep.txt
+++ b/poems/samuel-taylor-coleridge/the-pains-of-sleep.txt
@@ -1,0 +1,54 @@
+  Ere on my bed my limbs I lay,
+  It hath not been my use to pray
+  With moving lips or bended knees;
+  But silently, by slow degrees,
+  My spirit I to Love compose,
+  In humble trust mine eye-lids close,
+  With reverential resignation,
+  No wish conceived, no thought exprest,
+  Only a _sense_ of supplication;
+  A sense o'er all my soul imprest
+  That I am weak, yet not unblest,
+  Since in me, round me, everywhere
+  Eternal Strength and Wisdom are.
+
+  But yester-night I pray'd aloud
+  In anguish and in agony,
+  Up-starting from the fiendish crowd
+  Of shapes and thoughts that tortured me:
+  A lurid light, a trampling throng,
+  Sense of intolerable wrong,
+  And whom I scorned, those only strong!
+  Thirst of revenge, the powerless will
+  Still baffled, and yet burning still!
+  Desire with loathing strangely mixed
+  On wild or hateful objects fixed.
+  Fantastic passions! maddening brawl!
+  And shame and terror over all!
+  Deeds to be hid which were not hid,
+  Which all confused I could not know
+  Whether I suffered, or I did:
+  For all seem'd guilt, remorse or woe,
+  My own or others still the same
+  Life-stifling fear, soul-stifling shame!
+
+  So two nights passed: the night's dismay
+  Saddened and stunned the coming day.
+  Sleep, the wide blessing, seemed to me
+  Distemper's worst calamity.
+  The third night, when my own loud scream
+  Had waked me from the fiendish dream,
+  O'ercome with sufferings strange and wild,
+  I wept as I had been a child;
+  And having thus by tears subdued
+  My anguish to a milder mood,
+  Such punishments, I said, were due
+  To natures deepliest stained with sin:
+  For aye entempesting anew
+  The unfathomable hell within
+  The horror of their deeds to view,
+  To know and loathe, yet wish and do!
+  Such griefs with such men well agree,
+  But wherefore, wherefore fall on me?
+  To be beloved is all I need,
+  And whom I love, I love indeed.

--- a/poems/samuel-taylor-coleridge/this-lime-tree-bower-my-prison.txt
+++ b/poems/samuel-taylor-coleridge/this-lime-tree-bower-my-prison.txt
@@ -1,0 +1,80 @@
+  Well, they are gone, and here must I remain,
+  This lime-tree bower my prison! I have lost
+  Beauties and feelings, such as would have been
+  Most sweet to my remembrance even when age
+  Had dimmed mine eyes to blindness! They, meanwhile,
+  Friends, whom I never more may meet again,
+  On springy heath, along the hill-top edge,
+  Wander in gladness, and wind down, perchance,
+  To that still roaring dell, of which I told;
+  The roaring dell, o'erwooded, narrow, deep,
+  And only speckled by the mid-day sun;
+  Where its slim trunk the ash from rock to rock
+  Flings arching like a bridge--that branchless ash,
+  Unsunned and damp, whose few poor yellow-leaves
+  Ne'er tremble in the gale, yet tremble still,
+  Fanned by the water-fall! and there my friends
+  Behold the dark green file of long lank weeds,
+  That all at once (a most fantastic sight!)
+  Still nod and drip beneath the dripping edge
+  Of the blue clay-stone.
+
+  Now, my friends emerge
+  Beneath the wide wide Heaven--and view again
+  The many-steepled tract magnificent
+  Of hilly fields and meadows, and the sea,
+  With some fair bark, perhaps, whose sails light up
+  The slip of smooth clear blue betwixt two Isles
+  Of purple shadow! Yes! they wander on
+  In gladness all; but thou, me thinks, most glad,
+  My gentle-hearted Charles! for thou hast pined
+  And hungered after Nature, many a year,
+  In the great City pent, winning thy way
+  With sad yet patient soul, through evil and pain
+  And strange calamity! Ah! slowly sink
+  Behind the western ridge, thou glorious Sun!
+  Shine in the slant beams of the sinking orb,
+  Ye purple heath-flowers! richlier burn, ye clouds
+  Live in the yellow light, ye distant groves!
+  And kindle, thou blue Ocean! So my friend
+  Struck with deep joy may stand, as I have stood,
+  Silent with swimming sense; yea, gazing round
+  On the wide landscape, gaze till all doth seem
+  Less gross than bodily; and of such hues
+  As veil the Almighty Spirit, when yet he makes
+  Spirits perceive his presence.
+
+  A delight
+  Comes sudden on my heart, and I am glad
+  As I myself were there! Nor in this bower,
+  This little lime-tree bower, have I not marked
+  Much that has soothed me. Pale beneath the blaze
+  Hung the transparent foliage; and I watched
+  Some broad and sunny leaf, and loved to see
+  The shadow of the leaf and stem above,
+  Dappling its sunshine! And that walnut-tree
+  Was richly tinged, and a deep radiance lay
+  Full on the ancient ivy, which usurps
+  Those fronting elms, and now, with blackest mass--
+  Makes their dark branches gleam a lighter hue
+  Through the late twilight: and though now the bat
+  Wheels silent by, and not a swallow twitters,
+  Yet still the solitary humble-bee
+  Sings in the bean-flower! Henceforth I shall know
+  That Nature ne'er deserts the wise and pure;
+  No plot so narrow, be but Nature there,
+  No waste so vacant, but may well employ
+  Each faculty of sense, and keep the heart.
+  Awake to Love and Beauty! and sometimes
+  'Tis well to be bereft of promised good,
+  That we may lift the soul, and contemplate
+  With lively joy the joys we cannot share.
+  My gentle-hearted Charles! when the last rook
+  Beat its straight path along the dusky air
+  Homewards, I blest it! deeming, its black wing
+  (Now a dim speck, now vanishing in light)
+  Had cross'd the mighty orb's dilated glory,
+  While thou stood'st gazing; or when all was still,
+  Flew creeking o'er thy head, and had a charm
+  For thee, my gentle-hearted Charles, to whom
+  No sound is dissonant which tells of Life.

--- a/poems/samuel-taylor-coleridge/to-nature.txt
+++ b/poems/samuel-taylor-coleridge/to-nature.txt
@@ -1,0 +1,14 @@
+  It may indeed be phantasy: when I
+  Essay to draw from all created things
+  Deep, heartfelt, inward joy that closely clings;
+  And trace in leaves and flowers that round me lie
+  Lessons of love and earnest piety.
+  So let it be; and if the wide world rings
+  In mock of this belief, it brings
+  Nor fear, nor grief, nor vain, perplexity.
+  So will I build my altar in the fields,
+  And the blue sky my fretted dome shall be,
+  And the sweet fragrance that the wild flower yields
+  Shall be the incense I will yield to Thee,
+  Thee only God! and thou shalt not despise
+  Even me, the priest of this poor sacrifice.

--- a/poems/samuel-taylor-coleridge/work-without-hope.txt
+++ b/poems/samuel-taylor-coleridge/work-without-hope.txt
@@ -1,0 +1,14 @@
+  All Nature seems at work. Slugs leave their lair--
+  The bees are stirring--birds are on the wing--
+  And Winter, slumbering in the open air,
+  Wears on his smiling face a dream of Spring!
+  And I the while, the sole unbusy thing,
+  Nor honey make, nor pair, nor build, nor sing.
+  Yet well I ken the banks where amaranths blow,
+  Have traced the fount whence streams of nectar flow.
+  Bloom, O ye amaranths! bloom for whom ye may,
+  For me ye bloom not! Glide, rich streams, away!
+  With lips unbrightened, wreathless brow, I stroll:
+  And would you learn the spells that drowse my soul?
+  Work without Hope draws nectar in a sieve,
+  And Hope without an object cannot live.

--- a/scripts/ingest-gutenberg-coleridge-depth.mjs
+++ b/scripts/ingest-gutenberg-coleridge-depth.mjs
@@ -1,0 +1,151 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const POET = {
+  author: "Samuel Taylor Coleridge",
+  author_slug: "samuel-taylor-coleridge",
+  century: 19,
+  source_ebook: "8208",
+  collection_title: "The Complete Poetical Works of Samuel Taylor Coleridge, Vol. I",
+  targets: [
+    {
+      heading: "THIS LIME-TREE BOWER MY PRISON",
+      slug: "this-lime-tree-bower-my-prison",
+      title: "This Lime-Tree Bower My Prison",
+      published_year: 1800,
+      start_line: "Well, they are gone, and here must I remain,",
+      end_line: "No sound is dissonant which tells of Life.",
+    },
+    {
+      heading: "THE NIGHTINGALE",
+      slug: "the-nightingale",
+      title: "The Nightingale",
+      published_year: 1800,
+      start_line: "No cloud, no relique of the sunken day",
+      end_line: "farewell.",
+    },
+    {
+      heading: "WORK WITHOUT HOPE",
+      slug: "work-without-hope",
+      title: "Work Without Hope",
+      published_year: 1827,
+      start_line: "All Nature seems at work. Slugs leave their lair--",
+      end_line: "And Hope without an object cannot live.",
+    },
+    {
+      heading: "TO NATURE",
+      slug: "to-nature",
+      title: "To Nature",
+      published_year: 1820,
+      start_line: "It may indeed be phantasy: when I",
+      end_line: "Even me, the priest of this poor sacrifice.",
+    },
+    {
+      heading: "THE PAINS OF SLEEP",
+      slug: "the-pains-of-sleep",
+      title: "The Pains of Sleep",
+      published_year: 1803,
+      start_line: "Ere on my bed my limbs I lay,",
+      end_line: "And whom I love, I love indeed.",
+    },
+  ],
+};
+
+function normalizeText(raw) {
+  return raw.replace(/\r\n?/g, "\n").replace(/[ \t]+$/gm, "");
+}
+
+function stripBoilerplate(raw) {
+  const start = raw.match(/\*\*\*\s*START OF[\s\S]*?\*\*\*/i);
+  const end = raw.match(/\*\*\*\s*END OF[\s\S]*?\*\*\*/i);
+  const startIdx = start ? start.index + start[0].length : 0;
+  const endIdx = end ? end.index : raw.length;
+  return raw.slice(startIdx, endIdx).trim();
+}
+
+function key(value) {
+  return value.toLowerCase().replace(/['’]/g, "").replace(/[^a-z0-9]+/g, "");
+}
+
+function buildMeta(target) {
+  const sourceUrl = `https://www.gutenberg.org/cache/epub/${POET.source_ebook}/pg${POET.source_ebook}.txt`;
+  return yaml.dump(
+    {
+      id: `${POET.author_slug}/${target.slug}`,
+      slug: target.slug,
+      author: POET.author,
+      author_slug: POET.author_slug,
+      title: target.title,
+      century: POET.century,
+      text_path: `poems/${POET.author_slug}/${target.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Project Gutenberg",
+      source_url: sourceUrl,
+      public_domain_rationale: `Public domain in the United States: first published ${target.published_year} (pre-1929); text via Project Gutenberg eBook #${POET.source_ebook}.`,
+      collection_title: POET.collection_title,
+      collection_source_url: `https://www.gutenberg.org/ebooks/${POET.source_ebook}`,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+function cleanBlock(block) {
+  return block.map((line) =>
+    line
+      .replace("Bur* hear no murmuring: it flows silently,", "But hear no murmuring: it flows silently,")
+      .replace("No waste so vacant, but. may well employ", "No waste so vacant, but may well employ"),
+  );
+}
+
+async function main() {
+  const poemsDir = path.join("poems", POET.author_slug);
+  const metaDir = path.join("meta", POET.author_slug);
+  await fs.mkdir(poemsDir, { recursive: true });
+  await fs.mkdir(metaDir, { recursive: true });
+
+  const response = await fetch(`https://www.gutenberg.org/ebooks/${POET.source_ebook}.txt.utf-8`);
+  if (!response.ok) throw new Error(`Failed to fetch ${POET.author} (${response.status})`);
+
+  const lines = stripBoilerplate(normalizeText(await response.text())).split("\n");
+  const targetMap = new Map(POET.targets.map((target) => [key(target.heading), target]));
+  const hits = new Map();
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const heading = lines[index].trim();
+    const target = targetMap.get(key(heading));
+    if (target) hits.set(target.slug, { index, target });
+  }
+
+  const ordered = [...hits.values()].sort((a, b) => a.index - b.index);
+
+  let created = 0;
+  for (let index = 0; index < ordered.length; index += 1) {
+    const current = ordered[index];
+    const startIndex = lines.findIndex((line, lineIndex) => lineIndex >= current.index && line.trim() === current.target.start_line);
+    if (startIndex === -1) continue;
+    const endIndex = lines.findIndex(
+      (line, lineIndex) => lineIndex >= startIndex && line.trim() === current.target.end_line,
+    );
+    if (endIndex === -1) continue;
+    const block = lines.slice(startIndex, endIndex + 1);
+
+    while (block.length > 0 && block[0].trim() === "") block.shift();
+    while (block.length > 0 && block[block.length - 1].trim() === "") block.pop();
+    if (block.filter((line) => line.trim() !== "").length < 3) continue;
+
+    const cleaned = cleanBlock(block);
+
+    await fs.writeFile(path.join(poemsDir, `${current.target.slug}.txt`), `${cleaned.join("\n")}\n`, "utf8");
+    await fs.writeFile(path.join(metaDir, `${current.target.slug}.yml`), buildMeta(current.target), "utf8");
+    created += 1;
+    console.log(`${POET.author}: created ${current.target.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #197

## Summary
- add five more Coleridge poems from Project Gutenberg eBook #8208
- add matching metadata sidecars under `meta/samuel-taylor-coleridge`
- add a dedicated Coleridge depth ingest script using `js-yaml`

## Testing
- cd site && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five poems by Samuel Taylor Coleridge to the collection: "The Nightingale," "The Pains of Sleep," "This Lime-Tree Bower My Prison," "To Nature," and "Work Without Hope," each with complete metadata and source attribution from Project Gutenberg.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->