### PR TITLE
Deepen William Ernest Henley coverage (#199)

### DIFF
--- a/meta/william-ernest-henley/beside-the-idle-summer-sea.yml
+++ b/meta/william-ernest-henley/beside-the-idle-summer-sea.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/beside-the-idle-summer-sea
+slug: beside-the-idle-summer-sea
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: Beside the Idle Summer Sea
+century: 19
+text_path: poems/william-ernest-henley/beside-the-idle-summer-sea.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1878 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/meta/william-ernest-henley/the-gods-are-dead.yml
+++ b/meta/william-ernest-henley/the-gods-are-dead.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/the-gods-are-dead
+slug: the-gods-are-dead
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: The Gods Are Dead
+century: 19
+text_path: poems/william-ernest-henley/the-gods-are-dead.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1890 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/meta/william-ernest-henley/we-shall-surely-die.yml
+++ b/meta/william-ernest-henley/we-shall-surely-die.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/we-shall-surely-die
+slug: we-shall-surely-die
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: We Shall Surely Die
+century: 19
+text_path: poems/william-ernest-henley/we-shall-surely-die.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1890 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/meta/william-ernest-henley/what-is-to-come.yml
+++ b/meta/william-ernest-henley/what-is-to-come.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/what-is-to-come
+slug: what-is-to-come
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: What Is to Come
+century: 19
+text_path: poems/william-ernest-henley/what-is-to-come.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1890 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/meta/william-ernest-henley/when-you-are-old.yml
+++ b/meta/william-ernest-henley/when-you-are-old.yml
@@ -1,0 +1,13 @@
+id: william-ernest-henley/when-you-are-old
+slug: when-you-are-old
+author: William Ernest Henley
+author_slug: william-ernest-henley
+title: When You Are Old
+century: 19
+text_path: poems/william-ernest-henley/when-you-are-old.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/cache/epub/1568/pg1568.txt
+public_domain_rationale: 'Public domain in the United States: first published 1890 (pre-1929); text via Project Gutenberg eBook #1568.'
+collection_title: Poems
+collection_source_url: https://www.gutenberg.org/ebooks/1568

--- a/poems/william-ernest-henley/beside-the-idle-summer-sea.txt
+++ b/poems/william-ernest-henley/beside-the-idle-summer-sea.txt
@@ -1,0 +1,15 @@
+BESIDE the idle summer sea
+   And in the vacant summer days,
+   Light Love came fluting down the ways,
+   Where you were loitering with me.
+
+   Who has not welcomed, even as we,
+   That jocund minstrel and his lays
+   Beside the idle summer sea
+   And in the vacant summer days?
+
+   We listened, we were fancy-free;
+   And lo! in terror and amaze
+   We stood alone—alone at gaze
+   With an implacable memory
+   Beside the idle summer sea.

--- a/poems/william-ernest-henley/the-gods-are-dead.txt
+++ b/poems/william-ernest-henley/the-gods-are-dead.txt
@@ -1,0 +1,17 @@
+THE gods are dead?  Perhaps they are!  Who knows?
+   Living at least in Lemprière undeleted,
+   The wise, the fair, the awful, the jocose,
+   Are one and all, I like to think, retreated
+   In some still land of lilacs and the rose.
+
+   Once higeh they sat, and high o’er earthly shows
+   With sacrificial dance and song were greeted.
+   Once . . . long ago.  But now, the story goes,
+                        The gods are dead.
+
+   It must be true.  The world, a world of prose,
+   Full-crammed with facts, in science swathed and sheeted,
+   Nods in a stertorous after-dinner doze!
+   Plangent and sad, in every wind that blows
+   Who will may hear the sorry words repeated:—
+                       ‘The Gods are Dead!’

--- a/poems/william-ernest-henley/we-shall-surely-die.txt
+++ b/poems/william-ernest-henley/we-shall-surely-die.txt
@@ -1,0 +1,15 @@
+WE shall surely die:
+   Must we needs grow old?
+   Grow old and cold,
+   And we know not why?
+
+   O, the By-and-By,
+   And the tale that’s told!
+   We shall surely die:
+   Must we needs grow old?
+
+   Grow old and sigh,
+   Grudge and withhold,
+   Resent and scold? . . .
+   Not you and I?
+   We shall surely die!

--- a/poems/william-ernest-henley/what-is-to-come.txt
+++ b/poems/william-ernest-henley/what-is-to-come.txt
@@ -1,0 +1,10 @@
+WHAT is to come we know not.  But we know
+   That what has been was good—was good to show,
+   Better to hide, and best of all to bear.
+   We are the masters of the days that were:
+   We have lived, we have loved, we have suffered . . . even so.
+
+   Shall we not take the ebb who had the flow?
+   Life was our friend.  Now, if it be our foe—
+   Dear, though it spoil and break us!—need we care
+               What is to come?

--- a/poems/william-ernest-henley/when-you-are-old.txt
+++ b/poems/william-ernest-henley/when-you-are-old.txt
@@ -1,0 +1,10 @@
+WHEN you are old, and I am passed away—
+   Passed, and your face, your golden face, is gray—
+   I think, whate’er the end, this dream of mine,
+   Comforting you, a friendly star will shine
+   Down the dim slope where still you stumble and stray.
+
+   So may it be: that so dead Yesterday,
+   No sad-eyed ghost but generous and gay,
+   May serve you memories like almighty wine,
+               When you are old!

--- a/scripts/ingest-gutenberg-henley-depth.mjs
+++ b/scripts/ingest-gutenberg-henley-depth.mjs
@@ -16,6 +16,41 @@ const SOURCE = {
 
 const POEMS = [
   {
+    slug: "the-gods-are-dead",
+    title: "The Gods Are Dead",
+    published_year: 1890,
+    start_line: "THE gods are dead?  Perhaps they are!  Who knows?",
+    end_line: "‘The Gods are Dead!’",
+  },
+  {
+    slug: "when-you-are-old",
+    title: "When You Are Old",
+    published_year: 1890,
+    start_line: "WHEN you are old, and I am passed away—",
+    end_line: "When you are old!",
+  },
+  {
+    slug: "beside-the-idle-summer-sea",
+    title: "Beside the Idle Summer Sea",
+    published_year: 1878,
+    start_line: "BESIDE the idle summer sea",
+    end_line: "Beside the idle summer sea.",
+  },
+  {
+    slug: "we-shall-surely-die",
+    title: "We Shall Surely Die",
+    published_year: 1890,
+    start_line: "WE shall surely die:",
+    end_line: "We shall surely die!",
+  },
+  {
+    slug: "what-is-to-come",
+    title: "What Is to Come",
+    published_year: 1890,
+    start_line: "WHAT is to come we know not.  But we know",
+    end_line: "What is to come?",
+  },
+  {
     slug: "the-sea-is-full-of-wandering-foam",
     title: "The Sea Is Full of Wandering Foam",
     published_year: 1876,


### PR DESCRIPTION
Closes #199

## Summary
- add five more William Ernest Henley poems from Project Gutenberg eBook #1568
- add matching metadata sidecars under `meta/william-ernest-henley`
- extend the dedicated Henley depth ingest script

## Testing
- cd site && npm run build