### PR TITLE
Deepen Alfred Lord Tennyson coverage (#201)

### DIFF
--- a/meta/alfred-tennyson/lady-clara-vere-de-vere.yml
+++ b/meta/alfred-tennyson/lady-clara-vere-de-vere.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/lady-clara-vere-de-vere
+slug: lady-clara-vere-de-vere
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: Lady Clara Vere de Vere
+century: 19
+text_path: poems/alfred-tennyson/lady-clara-vere-de-vere.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/8601
+public_domain_rationale: 'Public domain in the United States: first published 1842 (pre-1929); text via Project Gutenberg eBook #8601.'
+collection_title: The Early Poems of Alfred Lord Tennyson
+collection_source_url: https://www.gutenberg.org/ebooks/8601

--- a/meta/alfred-tennyson/sir-galahad.yml
+++ b/meta/alfred-tennyson/sir-galahad.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/sir-galahad
+slug: sir-galahad
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: Sir Galahad
+century: 19
+text_path: poems/alfred-tennyson/sir-galahad.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/8601
+public_domain_rationale: 'Public domain in the United States: first published 1842 (pre-1929); text via Project Gutenberg eBook #8601.'
+collection_title: The Early Poems of Alfred Lord Tennyson
+collection_source_url: https://www.gutenberg.org/ebooks/8601

--- a/meta/alfred-tennyson/the-beggar-maid.yml
+++ b/meta/alfred-tennyson/the-beggar-maid.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/the-beggar-maid
+slug: the-beggar-maid
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: The Beggar Maid
+century: 19
+text_path: poems/alfred-tennyson/the-beggar-maid.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/8601
+public_domain_rationale: 'Public domain in the United States: first published 1842 (pre-1929); text via Project Gutenberg eBook #8601.'
+collection_title: The Early Poems of Alfred Lord Tennyson
+collection_source_url: https://www.gutenberg.org/ebooks/8601

--- a/meta/alfred-tennyson/the-death-of-the-old-year.yml
+++ b/meta/alfred-tennyson/the-death-of-the-old-year.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/the-death-of-the-old-year
+slug: the-death-of-the-old-year
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: The Death of the Old Year
+century: 19
+text_path: poems/alfred-tennyson/the-death-of-the-old-year.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/8601
+public_domain_rationale: 'Public domain in the United States: first published 1833 (pre-1929); text via Project Gutenberg eBook #8601.'
+collection_title: The Early Poems of Alfred Lord Tennyson
+collection_source_url: https://www.gutenberg.org/ebooks/8601

--- a/meta/alfred-tennyson/the-lady-of-shalott.yml
+++ b/meta/alfred-tennyson/the-lady-of-shalott.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/the-lady-of-shalott
+slug: the-lady-of-shalott
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: The Lady of Shalott
+century: 19
+text_path: poems/alfred-tennyson/the-lady-of-shalott.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/8601
+public_domain_rationale: 'Public domain in the United States: first published 1833 (pre-1929); text via Project Gutenberg eBook #8601.'
+collection_title: The Early Poems of Alfred Lord Tennyson
+collection_source_url: https://www.gutenberg.org/ebooks/8601

--- a/poems/alfred-tennyson/lady-clara-vere-de-vere.txt
+++ b/poems/alfred-tennyson/lady-clara-vere-de-vere.txt
@@ -1,0 +1,81 @@
+Lady Clara Vere de Vere,
+Of me you shall not win renown:
+You thought to break a country heart
+For pastime, ere you went to town.
+At me you smiled, but unbeguiled
+I saw the snare, and I retired:
+The daughter of a hundred Earls,
+You are not one to be desired.
+
+Lady Clara Vere de Vere,
+I know you proud to bear your name,
+Your pride is yet no mate for mine,
+Too proud to care from whence I came.
+Nor would I break for your sweet sake
+A heart that doats on truer charms.
+A simple maiden in her flower
+Is worth a hundred coats-of-arms.
+
+Lady Clara Vere de Vere,
+Some meeker pupil you must find,
+For were you queen of all that is,
+I could not stoop to such a mind.
+You sought to prove how I could love,
+And my disdain is my reply.
+The lion on your old stone gates
+Is not more cold to you than I.
+
+Lady Clara Vere de Vere,
+You put strange memories in my head.
+Not thrice your branching limes have blown
+Since I beheld young Laurence dead.
+Oh your sweet eyes, your low replies:
+A great enchantress you may be;
+But there was that across his throat
+Which you hardly cared to see.
+
+Lady Clara Vere de Vere,
+When thus he met his mother’s view,
+She had the passions of her kind,
+She spake some certain truths of you.
+
+Indeed I heard one bitter word
+That scarce is fit for you to hear;
+Her manners had not that repose
+Which stamps the caste of Vere de Vere.
+
+Lady Clara Vere de Vere,
+There stands a spectre in your hall:
+The guilt of blood is at your door:
+You changed a wholesome heart to gall.
+You held your course without remorse,
+To make him trust his modest worth,
+And, last, you fix’d a vacant stare,
+And slew him with your noble birth.
+
+Trust me, Clara Vere de Vere,
+From yon blue heavens above us bent
+The grand old gardener and his wife
+Smile at the claims of long descent.
+Howe’er it be, it seems to me,
+’Tis only noble to be good.
+Kind hearts are more than coronets,
+And simple faith than Norman blood.
+
+I know you, Clara Vere de Vere:
+You pine among your halls and towers:
+The languid light of your proud eyes
+Is wearied of the rolling hours.
+In glowing health, with boundless wealth,
+But sickening of a vague disease,
+You know so ill to deal with time,
+You needs must play such pranks as these.
+
+Clara, Clara Vere de Vere,
+If Time be heavy on your hands,
+Are there no beggars at your gate,
+Nor any poor about your lands?
+Oh! teach the orphan-boy to read,
+Or teach the orphan-girl to sew,
+Pray Heaven for a human heart,
+And let the foolish yoeman go.

--- a/poems/alfred-tennyson/sir-galahad.txt
+++ b/poems/alfred-tennyson/sir-galahad.txt
@@ -1,0 +1,92 @@
+My good blade carves the casques of men,
+My tough lance thrusteth sure,
+My strength is as the strength of ten,
+Because my heart is pure.
+
+The shattering trumpet shrilleth high,
+The hard brands shiver on the steel,
+The splinter’d spear-shafts crack and fly,
+The horse and rider reel:
+
+They reel, they roll in clanging lists,
+And when the tide of combat stands,
+Perfume and flowers fall in showers,
+That lightly rain from ladies’ hands.
+
+How sweet are looks that ladies bend
+On whom their favours fall!
+For them I battle till the end,
+To save from shame and thrall:
+But all my heart is drawn above,
+My knees are bow’d in crypt and shrine:
+I never felt the kiss of love,
+Nor maiden’s hand in mine.
+More bounteous aspects on me beam,
+Me mightier transports move and thrill;
+So keep I fair thro’ faith and prayer
+A virgin heart in work and will.
+
+When down the stormy crescent goes,
+A light before me swims,
+Between dark stems the forest glows,
+I hear a noise of hymns:
+Then by some secret shrine I ride;
+I hear a voice, but none are there;
+The stalls are void, the doors are wide,
+The tapers burning fair.
+Fair gleams the snowy altar-cloth,
+The silver vessels sparkle clean,
+The shrill bell rings, the censer swings,
+And solemn chaunts resound between.
+
+Sometimes on lonely mountain-meres
+I find a magic bark;
+I leap on board: no helmsman steers:
+I float till all is dark.
+A gentle sound, an awful light!
+Three angels bear the holy Grail:
+With folded feet, in stoles of white,
+On sleeping wings they sail.
+Ah, blessed vision! blood of God!
+My spirit beats her mortal bars,
+As down dark tides the glory slides,
+And star-like mingles with the stars.
+
+When on my goodly charger borne
+Thro’ dreaming towns I go,
+The cock crows ere the Christmas morn,
+The streets are dumb with snow.
+The tempest crackles on the leads,
+And, ringing, spins from brand and mail;
+But o’er the dark a glory spreads,
+And gilds the driving hail.
+I leave the plain, I climb the height;
+No branchy thicket shelter yields;
+But blessed forms in whistling storms
+Fly o’er waste fens and windy fields.
+
+A maiden knight—to me is given
+Such hope, I know not fear;
+I yearn to breathe the airs of heaven
+That often meet me here.
+I muse on joy that will not cease,
+Pure spaces clothed in living beams,
+Pure lilies of eternal peace,
+Whose odours haunt my dreams;
+And, stricken by an angel’s hand,
+This mortal armour that I wear,
+This weight and size, this heart and eyes,
+Are touch’d, are turn’d to finest air.
+
+The clouds are broken in the sky,
+And thro’ the mountain-walls
+A rolling organ-harmony
+Swells up, and shakes and falls.
+Then move the trees, the copses nod,
+Wings flutter, voices hover clear:
+“O just and faithful knight of God!
+Ride on! the prize is near”.
+So pass I hostel, hall, and grange;
+By bridge and ford, by park and pale,
+All-arm’d I ride, whate’er betide,
+Until I find the holy Grail.

--- a/poems/alfred-tennyson/the-beggar-maid.txt
+++ b/poems/alfred-tennyson/the-beggar-maid.txt
@@ -1,0 +1,17 @@
+Her arms across her breast she laid;
+She was more fair than words can say:
+Bare-footed came the beggar maid
+Before the king Cophetua.
+In robe and crown the king stept down,
+To meet and greet her on her way;
+“It is no wonder,” said the lords,
+“She is more beautiful than day”.
+
+As shines the moon in clouded skies,
+She in her poor attire was seen:
+One praised her ancles, one her eyes,
+One her dark hair and lovesome mien:
+So sweet a face, such angel grace,
+In all that land had never been:
+Cophetua sware a royal oath:
+“This beggar maid shall be my queen!”

--- a/poems/alfred-tennyson/the-death-of-the-old-year.txt
+++ b/poems/alfred-tennyson/the-death-of-the-old-year.txt
@@ -1,0 +1,59 @@
+Full knee-deep lies the winter snow,
+And the winter winds are wearily sighing:
+Toll ye the church-bell sad and slow,
+And tread softly and speak low,
+For the old year lies a-dying.
+Old year, you must not die;
+You came to us so readily,
+You lived with us so steadily,
+Old year, you shall not die.
+
+He lieth still: he doth not move:
+He will not see the dawn of day.
+He hath no other life above.
+He gave me a friend, and a true, true-love,
+And the New-year will take ’em away.
+Old year, you must not go;
+So long as you have been with us,
+Such joy as you have seen with us,
+Old year, you shall not go.
+
+He froth’d his bumpers to the brim;
+A jollier year we shall not see.
+But tho’ his eyes are waxing dim,
+And tho’ his foes speak ill of him,
+He was a friend to me.
+Old year, you shall not die;
+We did so laugh and cry with you,
+I’ve half a mind to die with you,
+Old year, if you must die.
+
+He was full of joke and jest,
+But all his merry quips are o’er.
+To see him die, across the waste
+His son and heir doth ride post-haste,
+But he’ll be dead before.
+Every one for his own.
+The night is starry and cold, my friend,
+And the New-year blithe and bold, my friend,
+Comes up to take his own.
+
+How hard he breathes! over the snow
+I heard just now the crowing cock.
+The shadows flicker to and fro:
+The cricket chirps: the light burns low:
+’Tis nearly twelve o’clock.
+Shake hands, before you die.
+Old year, we’ll dearly rue for you:
+What is it we can do for you?
+Speak out before you die.
+
+His face is growing sharp and thin.
+Alack! our friend is gone.
+Close up his eyes: tie up his chin:
+Step from the corpse, and let him in
+That standeth there alone,
+And waiteth at the door.
+There’s a new foot on the floor, my friend,
+And a new face at the door, my friend,
+A new face at the door.

--- a/poems/alfred-tennyson/the-lady-of-shalott.txt
+++ b/poems/alfred-tennyson/the-lady-of-shalott.txt
@@ -1,0 +1,200 @@
+On either side the river lie
+Long fields of barley and of rye,
+That clothe the wold and meet the sky;
+And thro’ the field the road runs by
+To many-tower’d Camelot;
+And up and down the people go,
+Gazing where the lilies blow
+Round an island there below,
+The island of Shalott.
+
+Willows whiten, aspens quiver,
+Little breezes dusk and shiver
+Thro’ the wave that runs for ever
+By the island in the river
+Flowing down to Camelot.
+Four gray walls, and four gray towers,
+Overlook a space of flowers,
+And the silent isle imbowers
+The Lady of Shalott.
+
+By the margin, willow-veil’d
+Slide the heavy barges trail’d
+By slow horses; and unhail’d
+The shallop flitteth silken-sail’d
+Skimming down to Camelot:
+But who hath seen her wave her hand?
+Or at the casement seen her stand?
+Or is she known in all the land,
+The Lady of Shalott?
+
+Only reapers, reaping early
+In among the bearded barley,
+Hear a song that echoes cheerly
+From the river winding clearly,
+Down to tower’d Camelot:
+And by the moon the reaper weary,
+Piling sheaves in uplands airy,
+Listening, whispers “’Tis the fairy
+Lady of Shalott”.
+
+
+Part II
+
+
+There she weaves by night and day
+A magic web with colours gay.
+She has heard a whisper say,
+A curse is on her if she stay
+To look down to Camelot.
+She knows not what the _curse_ may be,
+And so she weaveth steadily,
+And little other care hath she,
+The Lady of Shalott.
+
+And moving thro’ a mirror clear
+That hangs before her all the year,
+Shadows of the world appear.
+There she sees the highway near
+Winding down to Camelot:
+There the river eddy whirls,
+And there the surly village-churls,
+And the red cloaks of market girls,
+Pass onward from Shalott.
+
+Sometimes a troop of damsels glad,
+An abbot on an ambling pad,
+Sometimes a curly shepherd-lad,
+Or long-hair’d page in crimson clad,
+Goes by to tower’d Camelot;
+And sometimes thro’ the mirror blue
+The knights come riding two and two:
+She hath no loyal knight and true,
+The Lady of Shalott.
+
+But in her web she still delights
+To weave the mirror’s magic sights,
+For often thro’ the silent nights
+A funeral, with plumes and lights,
+And music, went to Camelot:
+Or when the moon was overhead,
+Came two young lovers lately wed;
+“I am half-sick of shadows,” said
+The Lady of Shalott.
+
+
+Part III
+
+
+A bow-shot from her bower-eaves,
+He rode between the barley sheaves,
+The sun came dazzling thro’ the leaves,
+And flamed upon the brazen greaves
+Of bold Sir Lancelot.
+A redcross knight for ever kneel’d
+To a lady in his shield,
+That sparkled on the yellow field,
+Beside remote Shalott.
+
+The gemmy bridle glitter’d free,
+Like to some branch of stars we see
+Hung in the golden Galaxy.
+The bridle bells rang merrily
+As he rode down to Camelot:
+And from his blazon’d baldric slung
+A mighty silver bugle hung,
+And as he rode his armour rung,
+Beside remote Shalott.
+
+All in the blue unclouded weather
+Thick-jewell’d shone the saddle-leather,
+The helmet and the helmet-feather
+Burn’d like one burning flame together,
+As he rode down to Camelot.
+As often thro’ the purple night,
+Below the starry clusters bright,
+Some bearded meteor, trailing light,
+Moves over still Shalott.
+
+His broad clear brow in sunlight glow’d;
+On burnish’d hooves his war-horse trode;
+From underneath his helmet flow’d
+His coal-black curls as on he rode,
+As he rode down to Camelot.
+From the bank and from the river
+He flashed into the crystal mirror,
+“Tirra lirra,” by the river
+Sang Sir Lancelot.
+
+She left the web, she left the loom;
+She made three paces thro’ the room,
+She saw the water-lily bloom,
+She saw the helmet and the plume,
+She look’d down to Camelot.
+Out flew the web and floated wide;
+The mirror crack’d from side to side;
+“The curse is come upon me,” cried
+The Lady of Shalott.
+
+Part IV
+
+
+In the stormy east-wind straining,
+The pale yellow woods were waning,
+The broad stream in his banks complaining,
+Heavily the low sky raining
+Over tower’d Camelot;
+Down she came and found a boat
+Beneath a willow left afloat,
+And round about the prow she wrote
+_The Lady of Shalott_.
+
+And down the river’s dim expanse—
+Like some bold seër in a trance,
+Seeing all his own mischance—
+With a glassy countenance
+Did she look to Camelot.
+And at the closing of the day
+She loosed the chain, and down she lay;
+The broad stream bore her far away,
+The Lady of Shalott.
+
+Lying, robed in snowy white
+That loosely flew to left and right—
+The leaves upon her falling light—
+Thro’ the noises of the night
+She floated down to Camelot;
+And as the boat-head wound along
+The willowy hills and fields among,
+They heard her singing her last song,
+The Lady of Shalott.
+
+Heard a carol, mournful, holy,
+Chanted loudly, chanted lowly,
+Till her blood was frozen slowly,
+And her eyes were darken’d wholly,
+Turn’d to tower’d Camelot;
+For ere she reach’d upon the tide
+The first house by the water-side,
+Singing in her song she died,
+The Lady of Shalott.
+
+Under tower and balcony,
+By garden-wall and gallery,
+A gleaming shape she floated by,
+Dead-pale between the houses high,
+Silent into Camelot.
+Out upon the wharfs they came,
+Knight and burgher, lord and dame,
+And round the prow they read her name,
+_The Lady of Shalott_
+
+Who is this? and what is here?
+And in the lighted palace near
+Died the sound of royal cheer;
+And they cross’d themselves for fear,
+All the knights at Camelot:
+But Lancelot mused a little space;
+He said, “She has a lovely face;
+God in his mercy lend her grace,
+The Lady of Shalott”.

--- a/scripts/ingest-gutenberg-tennyson-depth.mjs
+++ b/scripts/ingest-gutenberg-tennyson-depth.mjs
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const SOURCE = {
+  author: "Alfred Lord Tennyson",
+  author_slug: "alfred-tennyson",
+  century: 19,
+  source_ebook: "8601",
+  collection_title: "The Early Poems of Alfred Lord Tennyson",
+};
+
+const POEMS = [
+  {
+    slug: "the-death-of-the-old-year",
+    title: "The Death of the Old Year",
+    published_year: 1833,
+    start_line: "Full knee-deep lies the winter snow,",
+    end_line: "A new face at the door.",
+  },
+  {
+    slug: "lady-clara-vere-de-vere",
+    title: "Lady Clara Vere de Vere",
+    published_year: 1842,
+    start_line: "Lady Clara Vere de Vere,",
+    end_line: "And let the foolish yoeman go.",
+  },
+  {
+    slug: "sir-galahad",
+    title: "Sir Galahad",
+    published_year: 1842,
+    start_line: "My good blade carves the casques of men,",
+    end_line: "Until I find the holy Grail.",
+  },
+  {
+    slug: "the-beggar-maid",
+    title: "The Beggar Maid",
+    published_year: 1842,
+    start_line: "Her arms across her breast she laid;",
+    end_line: "“This beggar maid shall be my queen!”",
+  },
+  {
+    slug: "the-lady-of-shalott",
+    title: "The Lady of Shalott",
+    published_year: 1833,
+    start_line: "On either side the river lie",
+    end_line: "The Lady of Shalott”.",
+  },
+];
+
+function normalizeText(raw) {
+  return raw.replace(/\r\n?/g, "\n").replace(/[ \t]+$/gm, "");
+}
+
+function stripBoilerplate(raw) {
+  const start = raw.match(/\*\*\*\s*START OF[\s\S]*?\*\*\*/i);
+  const end = raw.match(/\*\*\*\s*END OF[\s\S]*?\*\*\*/i);
+  const startIdx = start ? start.index + start[0].length : 0;
+  const endIdx = end ? end.index : raw.length;
+  return raw.slice(startIdx, endIdx).trim();
+}
+
+function normalizeLineForMatch(line) {
+  return line.replace(/\[\d+\]/g, "").trim();
+}
+
+function cleanLine(line) {
+  return line.replace(/\[\d+\]/g, "");
+}
+
+function buildMeta(poem) {
+  const sourceUrl = `https://www.gutenberg.org/ebooks/${SOURCE.source_ebook}`;
+  return yaml.dump(
+    {
+      id: `${SOURCE.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: SOURCE.author,
+      author_slug: SOURCE.author_slug,
+      title: poem.title,
+      century: SOURCE.century,
+      text_path: `poems/${SOURCE.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Project Gutenberg",
+      source_url: sourceUrl,
+      public_domain_rationale:
+        `Public domain in the United States: first published ${poem.published_year} ` +
+        `(pre-1929); text via Project Gutenberg eBook #${SOURCE.source_ebook}.`,
+      collection_title: SOURCE.collection_title,
+      collection_source_url: sourceUrl,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  const poemsDir = path.join("poems", SOURCE.author_slug);
+  const metaDir = path.join("meta", SOURCE.author_slug);
+  await fs.mkdir(poemsDir, { recursive: true });
+  await fs.mkdir(metaDir, { recursive: true });
+
+  const response = await fetch(`https://www.gutenberg.org/ebooks/${SOURCE.source_ebook}.txt.utf-8`);
+  if (!response.ok) throw new Error(`Failed to fetch ${SOURCE.author} (${response.status})`);
+  const lines = stripBoilerplate(normalizeText(await response.text())).split("\n");
+
+  let created = 0;
+  for (const poem of POEMS) {
+    const start = lines.findIndex((line) => normalizeLineForMatch(line) === poem.start_line);
+    if (start === -1) throw new Error(`Start line not found: ${poem.start_line}`);
+
+    const end = lines.findIndex(
+      (line, index) => index >= start && normalizeLineForMatch(line) === poem.end_line,
+    );
+    if (end === -1) throw new Error(`End line not found: ${poem.end_line}`);
+
+    const text = lines
+      .slice(start, end + 1)
+      .map(cleanLine)
+      .join("\n")
+      .trim();
+
+    const poemPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    let existed = true;
+    try {
+      await fs.access(poemPath);
+    } catch {
+      existed = false;
+    }
+
+    await fs.writeFile(poemPath, `${text}\n`, "utf8");
+    await fs.writeFile(metaPath, buildMeta(poem), "utf8");
+    created += 1;
+    console.log(`${SOURCE.author}: ${existed ? "updated" : "created"} ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add 5 canonical Alfred Lord Tennyson poems from Project Gutenberg #8601
- add matching metadata sidecars
- add a repeatable Tennyson ingest script

## Testing
- cd site && npm run build