### PR TITLE
Deepen John Keats coverage (#203)

### DIFF
--- a/meta/john-keats/in-a-drear-nighted-december.yml
+++ b/meta/john-keats/in-a-drear-nighted-december.yml
@@ -1,0 +1,13 @@
+id: john-keats/in-a-drear-nighted-december
+slug: in-a-drear-nighted-december
+author: John Keats
+author_slug: john-keats
+title: In a Drear-Nighted December
+century: 19
+text_path: poems/john-keats/in-a-drear-nighted-december.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/Stanzas:_%27In_a_drear-nighted_December%27
+public_domain_rationale: 'Public domain in the United States: first published 1817 (pre-1929); text via English Wikisource.'
+collection_title: The Complete Poetical Works and Letters of John Keats
+collection_source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats

--- a/meta/john-keats/ode-on-melancholy.yml
+++ b/meta/john-keats/ode-on-melancholy.yml
@@ -1,0 +1,13 @@
+id: john-keats/ode-on-melancholy
+slug: ode-on-melancholy
+author: John Keats
+author_slug: john-keats
+title: Ode on Melancholy
+century: 19
+text_path: poems/john-keats/ode-on-melancholy.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/Ode_on_Melancholy
+public_domain_rationale: 'Public domain in the United States: first published 1820 (pre-1929); text via English Wikisource.'
+collection_title: The Complete Poetical Works and Letters of John Keats
+collection_source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats

--- a/meta/john-keats/ode-to-psyche.yml
+++ b/meta/john-keats/ode-to-psyche.yml
@@ -1,0 +1,13 @@
+id: john-keats/ode-to-psyche
+slug: ode-to-psyche
+author: John Keats
+author_slug: john-keats
+title: Ode to Psyche
+century: 19
+text_path: poems/john-keats/ode-to-psyche.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/Ode_to_Psyche
+public_domain_rationale: 'Public domain in the United States: first published 1820 (pre-1929); text via English Wikisource.'
+collection_title: The Complete Poetical Works and Letters of John Keats
+collection_source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats

--- a/meta/john-keats/on-sitting-down-to-read-king-lear-once-again.yml
+++ b/meta/john-keats/on-sitting-down-to-read-king-lear-once-again.yml
@@ -1,0 +1,13 @@
+id: john-keats/on-sitting-down-to-read-king-lear-once-again
+slug: on-sitting-down-to-read-king-lear-once-again
+author: John Keats
+author_slug: john-keats
+title: On Sitting Down to Read King Lear Once Again
+century: 19
+text_path: poems/john-keats/on-sitting-down-to-read-king-lear-once-again.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/On_sitting_down_to_read_%27King_Lear%27_once_again
+public_domain_rationale: 'Public domain in the United States: first published 1818 (pre-1929); text via English Wikisource.'
+collection_title: The Complete Poetical Works and Letters of John Keats
+collection_source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats

--- a/meta/john-keats/to-sleep.yml
+++ b/meta/john-keats/to-sleep.yml
@@ -1,0 +1,13 @@
+id: john-keats/to-sleep
+slug: to-sleep
+author: John Keats
+author_slug: john-keats
+title: To Sleep
+century: 19
+text_path: poems/john-keats/to-sleep.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/To_Sleep
+public_domain_rationale: 'Public domain in the United States: first published 1816 (pre-1929); text via English Wikisource.'
+collection_title: The Complete Poetical Works and Letters of John Keats
+collection_source_url: https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats

--- a/poems/john-keats/in-a-drear-nighted-december.txt
+++ b/poems/john-keats/in-a-drear-nighted-december.txt
@@ -1,0 +1,26 @@
+In a drear-nighted December,
+Too happy, happy tree,
+Thy branches ne'er remember
+Their green felicity:
+The north cannot undo them,
+With a sleety whistle through them;
+Nor frozen thawings glue them
+From budding at the prime.
+
+In a drear-nighted December,
+Too happy, happy brook,
+Thy bubblings ne'er remember
+Apollo's summer look;
+But with a sweet forgetting,
+They stay their crystal fretting,
+Never, never petting
+About the frozen time.
+
+Ah! would 't were so with many
+A gentle girl and boy!
+But were there ever any
+Writh'd not at passèd joy?
+To know the change and feel it,
+When there is none to heal it,
+Nor numbèd sense to steal it,
+Was never said in rhyme.

--- a/poems/john-keats/ode-on-melancholy.txt
+++ b/poems/john-keats/ode-on-melancholy.txt
@@ -1,0 +1,36 @@
+No, no! go not to Lethe, neither twist
+Wolf's-bane, tight-rooted, for its poisonous wine;
+Nor suffer thy pale forehead to be kiss'd
+By nightshade, ruby grape of Proserpine;
+Make not your rosary of yew-berries,
+Nor let the beetle, or the death-moth be
+Your mournful Psyche, nor the downy owl
+A partner in your sorrow's mysteries;
+For shade to shade will come too drowsily,
+And drown the wakeful anguish of the soul.
+
+II
+
+But when the melancholy fit shall fall
+Sudden from heaven like a weeping cloud,
+That fosters the droop-headed flowers all,
+And hides the green hills in an April shroud;
+Then glut thy sorrow on a morning rose,
+Or on the rainbow of the salt-sand wave,
+Or on the wealth of globed peonies;
+Or if thy mistress some rich anger shows,
+Emprison her soft hand, and let her rave,
+And feed deep, deep upon her peerless eyes.
+
+III
+
+She dwells with Beauty—Beauty that must die;
+And Joy, whose hand is ever at his lips
+Bidding adieu; and aching Pleasure nigh,
+Turning to poison while the bee-mouth sips:
+Aye, in the very temple of Delight
+Veil'd Melancholy has her sovran shrine,
+Though seen of none save him whose strenuous tongue
+Can burst Joy's grape against his palate fine;
+His soul shall taste the sadness of her might,
+And be among her cloudy trophies hung.

--- a/poems/john-keats/ode-to-psyche.txt
+++ b/poems/john-keats/ode-to-psyche.txt
@@ -1,0 +1,79 @@
+O goddess! hear these tuneless numbers, wrung
+By sweet enforcement and remembrance dear,
+And pardon that thy secrets should be sung
+Even into thine own soft-conched ear:
+Surely I dreamt to-day, or did I see
+The winged Psyche with awaken'd eyes?
+I wander'd in a forest thoughtlessly,
+And, on the sudden, fainting with surprise,
+Saw two fair creatures, couched side by side
+In deepest grass, beneath the whisp'ring roof
+Of leaves and trembled blossoms, where there ran
+A brooklet, scarce espied:
+
+II
+
+'Mid hush'd, cool-rooted flowers fragrant-eyed,
+Blue, silver-white, and budded Tyrian,
+They lay calm-breathing on the bedded grass;
+Their arms embraced, and their pinions too;
+Their lips touch'd not, but had not bade adieu,
+As if disjoined by soft-handed slumber,
+And ready still past kisses to outnumber
+At tender eye-dawn of aurorean love:
+The winged boy I knew;
+But who wast thou, O happy, happy dove?
+His Psyche true!
+
+III
+
+O latest-born and loveliest vision far
+Of all Olympus' faded hierarchy!
+Fairer than Phœbe's sapphire-region'd star,
+Or Vesper, amorous glow-worm of the sky;
+Fairer than these, though temple thou hast none,
+Nor altar heap'd with flowers;
+Nor virgin-choir to make delicious moan
+Upon the midnight hours;
+No voice, no lute, no pipe, no incense sweet
+From chain-swung censer teeming;
+No shrine, no grove, no oracle, no heat
+Of pale-mouth'd prophet dreaming.
+
+IV
+
+O brightest! though too late for antique vows,
+Too, too late for the fond believing lyre,
+When holy were the haunted forest boughs,
+Holy the air, the water, and the fire;
+Yet even in these days so far retired
+From happy pieties, thy lucent fans,
+Fluttering among the faint Olympians,
+I see, and sing, by my own eyes inspired.
+So let me be thy choir, and make a moan
+Upon the midnight hours;
+Thy voice, thy lute, thy pipe, thy incense sweet
+From swinged censer teeming;
+Thy shrine, thy grove, thy oracle, thy heat
+Of pale-mouth'd prophet dreaming.
+
+V
+
+Yes, I will be thy priest, and build a fane
+In some untrodden region of my mind,
+Where branched thoughts, new-grown with pleasant pain,
+Instead of pines shall murmur in the wind:
+Far, far around shall those dark-cluster'd trees
+Fledge the wild-ridged mountains steep by steep;
+And there by zephyrs, streams, and birds, and bees,
+The moss-lain Dryads shall be lulled to sleep;
+And in the midst of this wide quietness
+A rosy sanctuary will I dress
+With the wreath'd trellis of a working brain,
+With buds, and bells, and stars without a name,
+With all the gardener Fancy e'er could feign,
+Who breeding flowers, will never breed the same:
+And there shall be for thee all soft delight
+That shadowy thought can win,
+A bright torch, and a casement ope at night,
+To let the warm Love in!

--- a/poems/john-keats/on-sitting-down-to-read-king-lear-once-again.txt
+++ b/poems/john-keats/on-sitting-down-to-read-king-lear-once-again.txt
@@ -1,0 +1,14 @@
+O golden-tongued Romance, with serene lute!
+Fair plumèd Syren, Queen of far away!
+Leave melodizing on this wintry day,
+Shut up thine olden pages, and be mute:
+Adieu! for once again the fierce dispute,
+Betwixt damnation and impassion'd clay,
+Must I burn through; once more humbly assay
+The bitter sweet of this Shakespearean fruit:
+Chief Poet! and ye clouds of Albion,
+Begetters of our deep eternal theme!
+When through the old oak forest I am gone,
+Let me not wander in a barren dream,
+But when I am consumèd in the Fire,
+Give me new Phœnix-wings to fly at my desire.

--- a/poems/john-keats/to-sleep.txt
+++ b/poems/john-keats/to-sleep.txt
@@ -1,0 +1,14 @@
+O soft embalmer of the still midnight,
+Shutting, with careful fingers and benign,
+Our gloom-pleased eyes, embower'd from the light,
+Enshaded in forgetfulness divine:
+O soothest Sleep! if so it please thee, close,
+In midst of this thine hymn, my willing eyes,
+Or wait the amen, ere thy poppy throws
+Around my bed its dewy charities;
+Then save me, or the passed day will shine
+Upon my pillow, breeding many woes;
+Save me from curious conscience, that still lords
+Its strength for darkness, burrowing like a mole;
+Turn the key deftly in the oiled wards,
+And seal the hushed casket of my soul.

--- a/scripts/ingest-wikisource-keats-depth.mjs
+++ b/scripts/ingest-wikisource-keats-depth.mjs
@@ -1,0 +1,225 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const POEMS = [
+  {
+    author: "John Keats",
+    author_slug: "john-keats",
+    century: 19,
+    slug: "ode-on-melancholy",
+    title: "Ode on Melancholy",
+    published_year: 1820,
+    source_url: "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/Ode_on_Melancholy",
+    collection_title: "The Complete Poetical Works and Letters of John Keats",
+    collection_source_url: "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats",
+    page_title: "The complete poetical works and letters of John Keats/Ode on Melancholy",
+    start_line: "No, no! go not to Lethe, neither twist",
+    end_line: "And be among her cloudy trophies hung.",
+  },
+  {
+    author: "John Keats",
+    author_slug: "john-keats",
+    century: 19,
+    slug: "ode-to-psyche",
+    title: "Ode to Psyche",
+    published_year: 1820,
+    source_url: "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/Ode_to_Psyche",
+    collection_title: "The Complete Poetical Works and Letters of John Keats",
+    collection_source_url: "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats",
+    page_title: "The complete poetical works and letters of John Keats/Ode to Psyche",
+    start_line: "O goddess! hear these tuneless numbers, wrung",
+    end_line: "To let the warm Love in!",
+  },
+  {
+    author: "John Keats",
+    author_slug: "john-keats",
+    century: 19,
+    slug: "to-sleep",
+    title: "To Sleep",
+    published_year: 1816,
+    source_url: "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/To_Sleep",
+    collection_title: "The Complete Poetical Works and Letters of John Keats",
+    collection_source_url: "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats",
+    page_title: "The complete poetical works and letters of John Keats/To Sleep",
+    start_line: "O soft embalmer of the still midnight,",
+    end_line: "And seal the hushed casket of my soul.",
+  },
+  {
+    author: "John Keats",
+    author_slug: "john-keats",
+    century: 19,
+    slug: "on-sitting-down-to-read-king-lear-once-again",
+    title: "On Sitting Down to Read King Lear Once Again",
+    published_year: 1818,
+    source_url:
+      "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/On_sitting_down_to_read_%27King_Lear%27_once_again",
+    collection_title: "The Complete Poetical Works and Letters of John Keats",
+    collection_source_url: "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats",
+    page_title: "The complete poetical works and letters of John Keats/On sitting down to read 'King Lear' once again",
+    start_line: "O golden-tongued Romance, with serene lute!",
+    end_line: "Give me new Phœnix-wings to fly at my desire.",
+  },
+  {
+    author: "John Keats",
+    author_slug: "john-keats",
+    century: 19,
+    slug: "in-a-drear-nighted-december",
+    title: "In a Drear-Nighted December",
+    published_year: 1817,
+    source_url:
+      "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats/Stanzas:_%27In_a_drear-nighted_December%27",
+    collection_title: "The Complete Poetical Works and Letters of John Keats",
+    collection_source_url: "https://en.wikisource.org/wiki/The_complete_poetical_works_and_letters_of_John_Keats",
+    page_title: "The complete poetical works and letters of John Keats/Stanzas: 'In a drear-nighted December'",
+    start_line: "In a drear-nighted December,",
+    end_line: "Was never said in rhyme.",
+  },
+];
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#91;/g, "[")
+    .replace(/&#93;/g, "]")
+    .replace(/&#95;/g, "_")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…")
+    .replace(/&#230;/g, "æ")
+    .replace(/&#339;/g, "œ");
+}
+
+function cleanRenderedText(html) {
+  let body = html.slice(html.indexOf('<div class="prp-pages-output"'));
+  const referencesIndex = body.indexOf('<div class="mw-references-wrap');
+  if (referencesIndex !== -1) body = body.slice(0, referencesIndex);
+
+  body = body.replace(/<style[\s\S]*?<\/style>/g, "");
+  body = body.replace(/<link[^>]*>/g, "");
+  body = body.replace(/<sup[^>]*>.*?<\/sup>/gs, "");
+  body = body.replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+  body = body.replace(/<span[^>]*class="wst-gap[^"]*"[^>]*><\/span>/g, "    ");
+  body = body.replace(/<br\s*\/?>\n?/g, "\n");
+  body = body.replace(/<\/p>\s*<p>/g, "\n\n");
+  body = body.replace(/<[^>]+>/g, "");
+
+  return decodeHtml(body)
+    .replace(/\u00a0/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function normalizeMatch(value) {
+  return value.replace(/[’‘]/g, "'").replace(/[“”]/g, '"').replace(/\s+/g, " ").trim();
+}
+
+function extractPoem(text, startLine, endLine) {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  const start = lines.findIndex((line) => normalizeMatch(line) === normalizeMatch(startLine));
+  if (start === -1) {
+    throw new Error(`Start line not found: ${startLine}`);
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index >= start && normalizeMatch(line) === normalizeMatch(endLine),
+  );
+  if (end === -1) {
+    throw new Error(`End line not found: ${endLine}`);
+  }
+
+  return lines
+    .slice(start, end + 1)
+    .map((line) => line.replace(/(?<=[A-Za-zÀ-ÿ.,;:!?—’'"\]])\d+$/u, ""))
+    .filter((line) => !/^(?:[IVX]+\.|\d+\.)$/.test(line.trim()))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchPoemText(pageTitle, startLine, endLine) {
+  const url =
+    "https://en.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Wikisource page ${pageTitle} (${response.status})`);
+  }
+
+  const json = await response.json();
+  if (!json.parse?.text) {
+    throw new Error(`Wikisource parse failed for ${pageTitle}`);
+  }
+
+  return extractPoem(cleanRenderedText(json.parse.text), startLine, endLine);
+}
+
+function buildMeta(poem) {
+  return yaml.dump(
+    {
+      id: `${poem.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: poem.author,
+      author_slug: poem.author_slug,
+      title: poem.title,
+      century: poem.century,
+      text_path: `poems/${poem.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: poem.source_url,
+      public_domain_rationale:
+        `Public domain in the United States: first published ${poem.published_year} ` +
+        `(pre-1929); text via English Wikisource.`,
+      collection_title: poem.collection_title,
+      collection_source_url: poem.collection_source_url,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  let created = 0;
+
+  for (const poem of POEMS) {
+    const poemsDir = path.join("poems", poem.author_slug);
+    const metaDir = path.join("meta", poem.author_slug);
+    await fs.mkdir(poemsDir, { recursive: true });
+    await fs.mkdir(metaDir, { recursive: true });
+
+    const textPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    try {
+      await fs.access(textPath);
+      console.log(`Skipping existing poem text: ${textPath}`);
+      continue;
+    } catch {}
+
+    const text = await fetchPoemText(poem.page_title, poem.start_line, poem.end_line);
+    await fs.writeFile(textPath, `${text}\n`);
+    await fs.writeFile(metaPath, buildMeta(poem));
+    created += 1;
+    console.log(`${poem.author}: created ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add 5 canonical John Keats poems from English Wikisource
- add matching metadata sidecars
- add a repeatable Keats ingest script

## Testing
- cd site && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five poems by John Keats: "In a Drear-Nighted December," "Ode on Melancholy," "Ode to Psyche," "On Sitting Down to Read King Lear Once Again," and "To Sleep"
  * All poems include complete metadata and public domain attribution from Wikisource

<!-- end of auto-generated comment: release notes by coderabbit.ai -->