### PR TITLE
Deepen Walt Whitman coverage (#207)

### DIFF
--- a/meta/walt-whitman/a-clear-midnight.yml
+++ b/meta/walt-whitman/a-clear-midnight.yml
@@ -1,0 +1,13 @@
+id: walt-whitman/a-clear-midnight
+slug: a-clear-midnight
+author: Walt Whitman
+author_slug: walt-whitman
+title: A Clear Midnight
+century: 19
+text_path: poems/walt-whitman/a-clear-midnight.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/1322
+public_domain_rationale: 'Public domain in the United States: Project Gutenberg ebook sourced from pre-1929 editions and the author died in 1892.'
+collection_title: Leaves of Grass
+collection_source_url: https://www.gutenberg.org/ebooks/1322

--- a/meta/walt-whitman/i-sit-and-look-out.yml
+++ b/meta/walt-whitman/i-sit-and-look-out.yml
@@ -1,0 +1,13 @@
+id: walt-whitman/i-sit-and-look-out
+slug: i-sit-and-look-out
+author: Walt Whitman
+author_slug: walt-whitman
+title: I Sit and Look Out
+century: 19
+text_path: poems/walt-whitman/i-sit-and-look-out.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/1322
+public_domain_rationale: 'Public domain in the United States: Project Gutenberg ebook sourced from pre-1929 editions and the author died in 1892.'
+collection_title: Leaves of Grass
+collection_source_url: https://www.gutenberg.org/ebooks/1322

--- a/meta/walt-whitman/the-dalliance-of-the-eagles.yml
+++ b/meta/walt-whitman/the-dalliance-of-the-eagles.yml
@@ -1,0 +1,13 @@
+id: walt-whitman/the-dalliance-of-the-eagles
+slug: the-dalliance-of-the-eagles
+author: Walt Whitman
+author_slug: walt-whitman
+title: The Dalliance of the Eagles
+century: 19
+text_path: poems/walt-whitman/the-dalliance-of-the-eagles.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/1322
+public_domain_rationale: 'Public domain in the United States: Project Gutenberg ebook sourced from pre-1929 editions and the author died in 1892.'
+collection_title: Leaves of Grass
+collection_source_url: https://www.gutenberg.org/ebooks/1322

--- a/meta/walt-whitman/there-was-a-child-went-forth.yml
+++ b/meta/walt-whitman/there-was-a-child-went-forth.yml
@@ -1,0 +1,13 @@
+id: walt-whitman/there-was-a-child-went-forth
+slug: there-was-a-child-went-forth
+author: Walt Whitman
+author_slug: walt-whitman
+title: There Was a Child Went Forth
+century: 19
+text_path: poems/walt-whitman/there-was-a-child-went-forth.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/1322
+public_domain_rationale: 'Public domain in the United States: Project Gutenberg ebook sourced from pre-1929 editions and the author died in 1892.'
+collection_title: Leaves of Grass
+collection_source_url: https://www.gutenberg.org/ebooks/1322

--- a/meta/walt-whitman/this-compost.yml
+++ b/meta/walt-whitman/this-compost.yml
@@ -1,0 +1,13 @@
+id: walt-whitman/this-compost
+slug: this-compost
+author: Walt Whitman
+author_slug: walt-whitman
+title: This Compost
+century: 19
+text_path: poems/walt-whitman/this-compost.txt
+text_in_repo: true
+source_label: Project Gutenberg
+source_url: https://www.gutenberg.org/ebooks/1322
+public_domain_rationale: 'Public domain in the United States: Project Gutenberg ebook sourced from pre-1929 editions and the author died in 1892.'
+collection_title: Leaves of Grass
+collection_source_url: https://www.gutenberg.org/ebooks/1322

--- a/poems/walt-whitman/a-clear-midnight.txt
+++ b/poems/walt-whitman/a-clear-midnight.txt
@@ -1,0 +1,7 @@
+This is thy hour O Soul, thy free flight into the wordless,
+  Away from books, away from art, the day erased, the lesson done,
+  Thee fully forth emerging, silent, gazing, pondering the themes thou
+      lovest best,
+  Night, sleep, death and the stars.
+
+BOOK XXXIII.  SONGS OF PARTING

--- a/poems/walt-whitman/i-sit-and-look-out.txt
+++ b/poems/walt-whitman/i-sit-and-look-out.txt
@@ -1,0 +1,18 @@
+I sit and look out upon all the sorrows of the world, and upon all
+      oppression and shame,
+  I hear secret convulsive sobs from young men at anguish with
+      themselves, remorseful after deeds done,
+  I see in low life the mother misused by her children, dying,
+      neglected, gaunt, desperate,
+  I see the wife misused by her husband, I see the treacherous seducer
+      of young women,
+  I mark the ranklings of jealousy and unrequited love attempted to be
+      hid, I see these sights on the earth,
+  I see the workings of battle, pestilence, tyranny, I see martyrs and
+      prisoners,
+  I observe a famine at sea, I observe the sailors casting lots who
+      shall be kill’d to preserve the lives of the rest,
+  I observe the slights and degradations cast by arrogant persons upon
+      laborers, the poor, and upon negroes, and the like;
+  All these--all the meanness and agony without end I sitting look out upon,
+  See, hear, and am silent.

--- a/poems/walt-whitman/the-dalliance-of-the-eagles.txt
+++ b/poems/walt-whitman/the-dalliance-of-the-eagles.txt
@@ -1,0 +1,10 @@
+Skirting the river road, (my forenoon walk, my rest,)
+  Skyward in air a sudden muffled sound, the dalliance of the eagles,
+  The rushing amorous contact high in space together,
+  The clinching interlocking claws, a living, fierce, gyrating wheel,
+  Four beating wings, two beaks, a swirling mass tight grappling,
+  In tumbling turning clustering loops, straight downward falling,
+  Till o’er the river pois’d, the twain yet one, a moment’s lull,
+  A motionless still balance in the air, then parting, talons loosing,
+  Upward again on slow-firm pinions slanting, their separate diverse flight,
+  She hers, he his, pursuing.

--- a/poems/walt-whitman/there-was-a-child-went-forth.txt
+++ b/poems/walt-whitman/there-was-a-child-went-forth.txt
@@ -1,0 +1,61 @@
+There was a child went forth every day,
+  And the first object he look’d upon, that object he became,
+  And that object became part of him for the day or a certain part of the day,
+  Or for many years or stretching cycles of years.
+
+  The early lilacs became part of this child,
+  And grass and white and red morning-glories, and white and red
+      clover, and the song of the phoebe-bird,
+  And the Third-month lambs and the sow’s pink-faint litter, and the
+      mare’s foal and the cow’s calf,
+  And the noisy brood of the barnyard or by the mire of the pond-side,
+  And the fish suspending themselves so curiously below there, and the
+      beautiful curious liquid,
+  And the water-plants with their graceful flat heads, all became part of him.
+
+  The field-sprouts of Fourth-month and Fifth-month became part of him,
+  Winter-grain sprouts and those of the light-yellow corn, and the
+      esculent roots of the garden,
+  And the apple-trees cover’d with blossoms and the fruit afterward,
+      and wood-berries, and the commonest weeds by the road,
+  And the old drunkard staggering home from the outhouse of the
+      tavern whence he had lately risen,
+  And the schoolmistress that pass’d on her way to the school,
+  And the friendly boys that pass’d, and the quarrelsome boys,
+  And the tidy and fresh-cheek’d girls, and the barefoot negro boy and girl,
+  And all the changes of city and country wherever he went.
+
+  His own parents, he that had father’d him and she that had conceiv’d
+      him in her womb and birth’d him,
+  They gave this child more of themselves than that,
+  They gave him afterward every day, they became part of him.
+
+  The mother at home quietly placing the dishes on the supper-table,
+  The mother with mild words, clean her cap and gown, a wholesome
+      odor falling off her person and clothes as she walks by,
+  The father, strong, self-sufficient, manly, mean, anger’d, unjust,
+  The blow, the quick loud word, the tight bargain, the crafty lure,
+  The family usages, the language, the company, the furniture, the
+      yearning and swelling heart,
+  Affection that will not be gainsay’d, the sense of what is real, the
+      thought if after all it should prove unreal,
+  The doubts of day-time and the doubts of night-time, the curious
+      whether and how,
+  Whether that which appears so is so, or is it all flashes and specks?
+  Men and women crowding fast in the streets, if they are not flashes
+      and specks what are they?
+  The streets themselves and the facades of houses, and goods in the windows,
+  Vehicles, teams, the heavy-plank’d wharves, the huge crossing at
+      the ferries,
+  The village on the highland seen from afar at sunset, the river between,
+  Shadows, aureola and mist, the light falling on roofs and gables of
+      white or brown two miles off,
+  The schooner near by sleepily dropping down the tide, the little
+      boat slack-tow’d astern,
+  The hurrying tumbling waves, quick-broken crests, slapping,
+  The strata of color’d clouds, the long bar of maroon-tint away
+      solitary by itself, the spread of purity it lies motionless in,
+  The horizon’s edge, the flying sea-crow, the fragrance of salt marsh
+      and shore mud,
+  These became part of that child who went forth every day, and who
+      now goes, and will always go forth every day.

--- a/poems/walt-whitman/this-compost.txt
+++ b/poems/walt-whitman/this-compost.txt
@@ -1,0 +1,65 @@
+1
+  Something startles me where I thought I was safest,
+  I withdraw from the still woods I loved,
+  I will not go now on the pastures to walk,
+  I will not strip the clothes from my body to meet my lover the sea,
+  I will not touch my flesh to the earth as to other flesh to renew me.
+
+  O how can it be that the ground itself does not sicken?
+  How can you be alive you growths of spring?
+  How can you furnish health you blood of herbs, roots, orchards, grain?
+  Are they not continually putting distemper’d corpses within you?
+  Is not every continent work’d over and over with sour dead?
+
+  Where have you disposed of their carcasses?
+  Those drunkards and gluttons of so many generations?
+  Where have you drawn off all the foul liquid and meat?
+  I do not see any of it upon you to-day, or perhaps I am deceiv’d,
+  I will run a furrow with my plough, I will press my spade through
+      the sod and turn it up underneath,
+  I am sure I shall expose some of the foul meat.
+
+       2
+  Behold this compost! behold it well!
+  Perhaps every mite has once form’d part of a sick person--yet behold!
+  The grass of spring covers the prairies,
+  The bean bursts noiselessly through the mould in the garden,
+  The delicate spear of the onion pierces upward,
+  The apple-buds cluster together on the apple-branches,
+  The resurrection of the wheat appears with pale visage out of its graves,
+  The tinge awakes over the willow-tree and the mulberry-tree,
+  The he-birds carol mornings and evenings while the she-birds sit on
+      their nests,
+  The young of poultry break through the hatch’d eggs,
+  The new-born of animals appear, the calf is dropt from the cow, the
+      colt from the mare,
+  Out of its little hill faithfully rise the potato’s dark green leaves,
+  Out of its hill rises the yellow maize-stalk, the lilacs bloom in
+      the dooryards,
+  The summer growth is innocent and disdainful above all those strata
+      of sour dead.
+
+  What chemistry!
+  That the winds are really not infectious,
+  That this is no cheat, this transparent green-wash of the sea which
+      is so amorous after me,
+  That it is safe to allow it to lick my naked body all over with its tongues,
+  That it will not endanger me with the fevers that have deposited
+      themselves in it,
+  That all is clean forever and forever,
+  That the cool drink from the well tastes so good,
+  That blackberries are so flavorous and juicy,
+  That the fruits of the apple-orchard and the orange-orchard, that
+      melons, grapes, peaches, plums, will none of them poison me,
+  That when I recline on the grass I do not catch any disease,
+  Though probably every spear of grass rises out of what was once
+      catching disease.
+
+  Now I am terrified at the Earth, it is that calm and patient,
+  It grows such sweet things out of such corruptions,
+  It turns harmless and stainless on its axis, with such endless
+      successions of diseas’d corpses,
+  It distills such exquisite winds out of such infused fetor,
+  It renews with such unwitting looks its prodigal, annual, sumptuous crops,
+  It gives such divine materials to men, and accepts such leavings
+      from them at last.

--- a/scripts/ingest-gutenberg-whitman-depth.mjs
+++ b/scripts/ingest-gutenberg-whitman-depth.mjs
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const SOURCE = {
+  author: "Walt Whitman",
+  author_slug: "walt-whitman",
+  century: 19,
+  source_ebook: "1322",
+  collection_title: "Leaves of Grass",
+};
+
+const EXTRACT_SPECS = [
+  {
+    slug: "i-sit-and-look-out",
+    title: "I Sit and Look Out",
+    start: "I Sit and Look Out",
+    end: "To Rich Givers",
+  },
+  {
+    slug: "the-dalliance-of-the-eagles",
+    title: "The Dalliance of the Eagles",
+    start: "The Dalliance of the Eagles",
+    end: "Roaming in Thought [After reading Hegel]",
+  },
+  {
+    slug: "there-was-a-child-went-forth",
+    title: "There Was a Child Went Forth",
+    start: "There Was a Child Went Forth",
+    end: "Old Ireland",
+  },
+  {
+    slug: "this-compost",
+    title: "This Compost",
+    start: "This Compost",
+    end: "To a Foil’d European Revolutionaire",
+  },
+  {
+    slug: "a-clear-midnight",
+    title: "A Clear Midnight",
+    start: "A Clear Midnight",
+    end: "As the Time Draws Nigh",
+  },
+];
+
+function normalizeText(raw) {
+  return raw.replace(/\r\n?/g, "\n").replace(/[ \t]+$/gm, "");
+}
+
+function stripBoilerplate(raw) {
+  const start = raw.match(/\*\*\*\s*START OF[\s\S]*?\*\*\*/i);
+  const end = raw.match(/\*\*\*\s*END OF[\s\S]*?\*\*\*/i);
+  const startIdx = start ? start.index + start[0].length : 0;
+  const endIdx = end ? end.index : raw.length;
+  return raw.slice(startIdx, endIdx).trim();
+}
+
+function extractPoem(text, { start, end, title }) {
+  const startIndex = text.indexOf(start);
+  if (startIndex === -1) throw new Error(`Start marker not found for ${title}`);
+
+  const fromStart = text.slice(startIndex + start.length).trimStart();
+  const endIndex = fromStart.indexOf(end);
+  if (endIndex === -1) throw new Error(`End marker not found for ${title}`);
+
+  return fromStart
+    .slice(0, endIndex)
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function buildMeta(spec) {
+  return yaml.dump(
+    {
+      id: `${SOURCE.author_slug}/${spec.slug}`,
+      slug: spec.slug,
+      author: SOURCE.author,
+      author_slug: SOURCE.author_slug,
+      title: spec.title,
+      century: SOURCE.century,
+      text_path: `poems/${SOURCE.author_slug}/${spec.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Project Gutenberg",
+      source_url: `https://www.gutenberg.org/ebooks/${SOURCE.source_ebook}`,
+      public_domain_rationale:
+        "Public domain in the United States: Project Gutenberg ebook sourced from pre-1929 editions and the author died in 1892.",
+      collection_title: SOURCE.collection_title,
+      collection_source_url: `https://www.gutenberg.org/ebooks/${SOURCE.source_ebook}`,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  const poemsDir = path.join("poems", SOURCE.author_slug);
+  const metaDir = path.join("meta", SOURCE.author_slug);
+  await fs.mkdir(poemsDir, { recursive: true });
+  await fs.mkdir(metaDir, { recursive: true });
+
+  const response = await fetch(`https://www.gutenberg.org/ebooks/${SOURCE.source_ebook}.txt.utf-8`, {
+    redirect: "follow",
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Gutenberg ebook ${SOURCE.source_ebook}: ${response.status}`);
+  }
+  const ebookText = normalizeText(stripBoilerplate(await response.text()));
+
+  for (const spec of EXTRACT_SPECS) {
+    const poem = extractPoem(ebookText, spec);
+    await fs.writeFile(path.join(poemsDir, `${spec.slug}.txt`), `${poem}\n`, "utf8");
+    await fs.writeFile(path.join(metaDir, `${spec.slug}.yml`), buildMeta(spec), "utf8");
+    console.log(`${SOURCE.author}: created ${spec.slug}`);
+  }
+
+  console.log(`Total created: ${EXTRACT_SPECS.length}`);
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add 5 canonical Walt Whitman poems from Project Gutenberg #1322
- add matching metadata sidecars
- add a repeatable Whitman ingest script

## Testing
- cd site && npm run build