### PR TITLE
Deepen Alfred Lord Tennyson coverage again (#209)

### DIFF
--- a/meta/alfred-tennyson/lady-clare.yml
+++ b/meta/alfred-tennyson/lady-clare.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/lady-clare
+slug: lady-clare
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: Lady Clare
+century: 19
+text_path: poems/alfred-tennyson/lady-clare.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_2/Lady_Clare
+public_domain_rationale: 'Public domain in the United States: first published 1842 (pre-1929); text via English Wikisource.'
+collection_title: Poems (Tennyson, 1843)
+collection_source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)

--- a/meta/alfred-tennyson/locksley-hall.yml
+++ b/meta/alfred-tennyson/locksley-hall.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/locksley-hall
+slug: locksley-hall
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: Locksley Hall
+century: 19
+text_path: poems/alfred-tennyson/locksley-hall.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_2/Locksley_Hall
+public_domain_rationale: 'Public domain in the United States: first published 1842 (pre-1929); text via English Wikisource.'
+collection_title: Poems (Tennyson, 1843)
+collection_source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)

--- a/meta/alfred-tennyson/mariana-in-the-south.yml
+++ b/meta/alfred-tennyson/mariana-in-the-south.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/mariana-in-the-south
+slug: mariana-in-the-south
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: Mariana in the South
+century: 19
+text_path: poems/alfred-tennyson/mariana-in-the-south.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_1/Mariana_in_the_South
+public_domain_rationale: 'Public domain in the United States: first published 1843 (pre-1929); text via English Wikisource.'
+collection_title: Poems (Tennyson, 1843)
+collection_source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)

--- a/meta/alfred-tennyson/morte-darthur.yml
+++ b/meta/alfred-tennyson/morte-darthur.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/morte-darthur
+slug: morte-darthur
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: Morte d’Arthur
+century: 19
+text_path: poems/alfred-tennyson/morte-darthur.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_2/Morte_d%27Arthur
+public_domain_rationale: 'Public domain in the United States: first published 1842 (pre-1929); text via English Wikisource.'
+collection_title: Poems (Tennyson, 1843)
+collection_source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)

--- a/meta/alfred-tennyson/the-palace-of-art.yml
+++ b/meta/alfred-tennyson/the-palace-of-art.yml
@@ -1,0 +1,13 @@
+id: alfred-tennyson/the-palace-of-art
+slug: the-palace-of-art
+author: Alfred Lord Tennyson
+author_slug: alfred-tennyson
+title: The Palace of Art
+century: 19
+text_path: poems/alfred-tennyson/the-palace-of-art.txt
+text_in_repo: true
+source_label: Wikisource
+source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_1/The_Palace_of_Art
+public_domain_rationale: 'Public domain in the United States: first published 1843 (pre-1929); text via English Wikisource.'
+collection_title: Poems (Tennyson, 1843)
+collection_source_url: https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)

--- a/poems/alfred-tennyson/lady-clare.txt
+++ b/poems/alfred-tennyson/lady-clare.txt
@@ -1,0 +1,80 @@
+Lord Ronald courted Lady Clare,
+I trow they did not part in scorn;
+Lord Ronald, her cousin, courted her
+And they will wed the morrow morn.
+"He does not love me for my birth,
+Nor for my lands so broad and fair;
+He loves me for my own true worth,
+And that is well," said Lady Clare.
+In there came old Alice the nurse,
+Said, "Who was this that went from thee?"
+"It was my cousin," said Lady Clare,
+"To-morrow he weds with me."
+"O God be thank'd!" said Alice the nurse,
+"That all comes round so just and fair:
+Lord Ronald is heir of all your lands,
+And you are not the Lady Clare."
+"Are ye out of your mind, my nurse, my nurse?"
+Said Lady Clare, "that ye speak so wild?"
+"As God's above," said Alice the nurse,
+"I speak the truth: you are my child.
+"The old Earl's daughter died at my breast;
+I speak the truth, as I live by bread!
+I buried her like my own sweet child,
+And put my child in her stead."
+"Falsely, falsely have ye done,
+O mother," she said, "if this be true,
+To keep the best man under the sun
+So many years from his due.
+"Nay now, my child," said Alice the nurse,
+"But keep the secret for your life,
+And all you have will be Lord Ronald's,
+When you are man and wife."
+"If I'm a beggar born," she said,
+"I will speak out, for I dare not lie.
+Pull off, pull off, the broach of gold,
+And fling the diamond necklace by."
+"Nay now, my child," said Alice the nurse,
+"But keep the secret all ye can."
+She said, "Not so: but I will know
+If there be any faith in man."
+"Nay now, what faith?" said Alice the nurse,
+"The man will cleave unto his right."
+"And he shall have it," the lady replied,
+"Though I should die to-night."
+"Yet give one kiss to your mother dear!
+Alas, my child, I sinn'd for thee."
+"O mother, mother, mother," she said,
+"So strange it seems to me.
+"Yet here's a kiss for my mother dear,
+My mother dear, if this be so,
+And lay your hand upon my head,
+And bless me, mother, ere I go."
+She clad herself in a russet gown,
+She was no longer Lady Clare:
+She went by dale, and she went by down,
+With a single rose in her hair.
+Down stept Lord Ronald from his tower:
+"O Lady Clare, you shame your worth!
+Why come you drest like a village maid,
+That are the flower of the earth?"
+"If I come drest like a village maid,
+I am but as my fortunes are:
+I am a beggar born," she said,
+"And not the Lady Clare."
+"Play me no tricks," said Lord Ronald,
+"For I am yours in word and in deed.
+Play me no tricks," said Lord Ronald,
+"Your riddle is hard to read."
+O and proudly stood she up!
+Her heart within her did not fail:
+She look'd into Lord Ronald's eyes,
+And told him all her nurse's tale.
+He laugh'd a laugh of merry scorn:
+He turn'd, and kiss'd her where she stood:
+"If you are not the heiress born,
+And I," said he, "the next in blood—
+"If you are not the heiress born,
+And I," said he, "the lawful heir,
+We two will wed to-morrow morn,
+And you shall still be Lady Clare."

--- a/poems/alfred-tennyson/locksley-hall.txt
+++ b/poems/alfred-tennyson/locksley-hall.txt
@@ -1,0 +1,194 @@
+Comrades, leave me here a little, while as yet 'tis early morn:
+Leave me here, and when you want me, sound upon the bugle horn.
+'Tis the place, and all around it, as of old, the curlews call,
+Dreary gleams about the moorland flying over Locksley Hall;
+Locksley Hall, that in the distance overlooks the sandy tracts,
+And the hollow ocean-ridges roaring into cataracts.
+Many a night from yonder ivied casement, ere I went to rest,
+Did I look on great Orion sloping slowly to the West.
+Many a night I saw the Pleiads, rising thro' the mellow shade,
+Glitter like a swarm of fire-flies tangled in a silver braid.
+Here about the beach I wander'd, nourishing a youth sublime
+With the fairy tales of science, and the long result of Time;
+When the centuries behind me like a fruitful land reposed;
+When I clung to all the present for the promise that it closed:
+When I dipt into the future far as human eye could see;
+Saw the Vision of the world, and all the wonder that would be.——
+In the Spring a fuller crimson comes upon the robin's breast;
+In the Spring the wanton lapwing gets himself another crest;
+In the Spring a livelier iris changes on the burnish'd dove;
+In the Spring a young man's fancy lightly turns to thoughts of love.
+Then her cheek was pale and thinner than should be for one so young,
+And her eyes on all my motions with a mute observance hung.
+And I said, "My cousin Amy, speak, and speak the truth to me,
+Trust me, cousin, all the current of my being sets to thee."
+On her pallid cheek and forehead came a colour and a light,
+As I have seen the rosy red flushing in the northern night.
+And she turn'd—her bosom shaken with a sudden storm of sighs—
+All the spirit deeply dawning in the dark of hazel eyes—
+Saying, "I have hid my feelings, fearing they should do me wrong;"
+Saying, "Dost thou love me, cousin?" weeping, "I have loved thee long."
+Love took up the glass of Time, and turn'd it in his glowing hands;
+Every moment, lightly shaken, ran itself in golden sands.
+Love took up the harp of Life, and smote on all the chords with might;
+Smote the chord of Self, that, trembling, pass'd in music out of sight.
+Many a morning on the moorland did we hear the copses ring,
+And her whisper throng'd my pulses with the fulness of the Spring.
+Many an evening by the waters did we watch the stately ships,
+And our spirits rush'd together at the touching of the lips.
+O my cousin, shallow-hearted! O my Amy, mine no more!
+O the dreary, dreary moorland! O the barren, barren shore!
+Falser than all fancy fathoms, falser than all songs have sung,
+Puppet to a father's threat, and servile to a shrewish tongue!
+Is it well to wish thee happy?—having known me—to decline
+On a range of lower feelings and a narrower heart than mine!
+Yet it shall be: thou shalt lower to his level day by day,
+What is fine within thee growing coarse to sympathise with clay.
+As the husband is, the wife is: thou art mated with a clown,
+And the grossness of his nature will have weight to drag thee down.
+He will hold thee, when his passion shall have spent its novel force,
+Something better than his dog, a little dearer than his horse.
+What is this? his eyes are heavy: think not they are glazed with wine.
+Go to him: it is thy duty: kiss him: take his hand in thine.
+It may be my lord is weary, that his brain is overwrought:
+Soothe him with thy finer fancies, touch him with thy lighter thought.
+He will answer to the purpose, easy things to understand———
+Better thou wert dead before me, tho' I slew thee with my hand!
+Better thou and I were lying, hidden from the heart's disgrace,
+Roll'd in one another's arms, and silent in a last embrace.
+Cursed be the social wants that sin against the strength of youth!
+Cursed be the social lies that warp us from the living truth!
+Cursed be the sickly forms that err from honest Nature's rule!
+Cursed be the gold that gilds the straiten'd forehead of the fool!
+Well—'tis well that I should bluster!—Hadst thou less unworthy proved—
+Would to God—for I had loved thee more than ever wife was loved.
+Am I mad, that I should cherish that which bears but bitter fruit?
+I will pluck it from my bosom, tho' my heart be at the root.
+Never, tho' my mortal summers to such length of years should come
+As the many-winter'd crow that leads the clanging rookery home.
+Where is comfort? in division of the records of the mind?
+Can I part her from herself, and love her, as I knew her, kind?
+I remember one that perish'd: sweetly did she speak and move:
+Such a one do I remember, whom to look at was to love.
+Can I think of her as dead, and love her for the love she bore?
+No—she never loved me truly: love is love for evermore.
+Comfort? comfort scorn'd of devils! this is truth the poet sings,
+That a sorrow's crown of sorrow is remembering happier things.
+Drug thy memories, lest thou learn it, lest thy heart be put to proof,
+In the dead unhappy night, and when the rain is on the roof.
+Like a dog, he hunts in dreams, and thou art staring at the wall,
+Where the dying night-lamp flickers, and the shadows rise and fall.
+Then a hand shall pass before thee, pointing to his drunken sleep,
+To thy widow'd marriage-pillows, to the tears that thou wilt weep.
+Thou shalt hear the "Never, never," whisper'd by the phantom years,
+And a song from out the distance in the ringing of thine ears;
+And an eye shall vex thee, looking ancient kindness on thy pain.
+Turn thee, turn thee on thy pillow: get thee to thy rest again.
+Nay, but Nature brings thee solace; for a tender voice will cry,
+'Tis a purer life than thine; a lip to drain thy trouble dry.
+Baby lips will laugh me down: my latest rival brings thee rest.
+Baby fingers, waxen touches, press me from the mother's breast.
+O, the child too clothes the father with a dearness not his due.
+Half is thine and half is his: it will be worthy of the two.
+O, I see thee old and formal, fitted to thy petty part,
+With a little hoard of maxims preaching down a daughter's heart.
+"They were dangerous guides the feelings—she herself was not exempt—
+Truly, she herself had suffer'd"—Perish in thy self-contempt!
+Overlive it—lower yet—be happy! wherefore should I care,
+I myself must mix with action, lest I wither by despair.
+What is that which I should turn to, lighting upon days like these?
+Every door is barr'd with gold, and opens but to golden keys.
+Every gate is throng'd with suitors, all the markets overflow.
+I have but an angry fancy: what is that which I should do?
+I had been content to perish, falling on the foeman's ground,
+When the ranks are roll'd in vapour, and the winds are laid with sound.
+But the jingling of the guinea helps the hurt that Honour feels,
+And the nations do but murmur, snarling at each other's heels.
+Can I but relive in sadness? I will turn that earlier page.
+Hide me from my deep emotion, O thou wondrous Mother-Age!
+Make me feel the wild pulsation that I felt before the strife,
+When I heard my days before me, and the tumult of my life;
+Yearning for the large excitement that the coming years would yield,
+Eager-hearted as a boy when first he leaves his father's field,
+And at night along the dusky highway near and nearer drawn,
+Sees in heaven the light of London flaring like a dreary dawn;
+And his spirit leaps within him to be gone before him then,
+Underneath the light he looks at, in among the throngs of men;
+Men, my brothers, men the workers, ever reaping something new:
+That which they have done but earnest of the things that they shall do:
+For I dipt into the future, far as human eye could see,
+Saw the vision of the world, and all the wonder that would be;
+Saw the heavens fill with commerce, argosies of magic sails,
+Pilots of the purple twilight, dropping down with costly bales;
+Heard the heavens fill with shouting, and there rain'd a ghastly dew
+From the nations' airy navies grappling in the central blue;
+Far along the world-wide whisper of the south-wind rushing warm,
+With the standards of the peoples plunging thro' the thunder-storm;
+Till the war-drum throbbed no longer, and the battle-flags were furl'd
+In the Parliament of man, the Federation of the world.
+There the common sense of most shall hold a fretful realm in awe,
+And the kindly earth shall slumber, lapt in universal law.
+So I triumph'd, ere my passion sweeping thro' me left me dry,
+Left me with the palsied heart, and left me with the jaundiced eye;
+Eye, to which all order festers, all things here are out of joint,
+Science moves, but slowly slowly, creeping on from point to point:
+Slowly comes a hungry people, as a lion, creeping nigher,
+Glares at one that nods and winks behind a slowly-dying fire.
+Yet I doubt not thro' the ages one increasing purpose runs,
+And the thoughts of men are widen'd with the process of the suns.
+What is that to him that reaps not harvest of his youthful joys,
+Tho' the deep heart of existence beat for ever like a boy's?
+Knowledge comes, but wisdom lingers, and I linger on the shore,
+And the individual withers, and the world is more and more.
+Knowledge comes, but wisdom lingers, and he bears a laden breast,
+Full of sad experience, moving toward the stillness of his rest.
+Hark, my merry comrades call me, sounding on the bugle-horn,
+They to whom my foolish passion were a target for their scorn:
+Shall it not be scorn to me to harp on such a moulder'd string?
+I am shamed thro' all my nature to have loved so slight a thing.
+Weakness to be wroth with weakness! woman's pleasure, woman's pain—
+Nature made them blinder motions bounded in a shallower brain:
+Woman is the lesser man, and all thy passions, match'd with mine,
+Are as moonlight unto sunlight, and as water unto wine—
+Here at least, where nature sickens, nothing. Ah, for some retreat
+Deep in yonder shining Orient, where my life began to beat;
+Where in wild Mahratta-battle fell my father evil-starr'd;—
+I was left a trampled orphan, and a selfish uncle's ward.
+Or to burst all links of habit—there to wander far away,
+On from island unto island at the gateways of the day.
+Larger constellations burning, mellow moons and happy skies,
+Breadths of tropic shade and palms in cluster, knots of Paradise.
+Never comes the trader, never floats an European flag,
+Slides the bird o'er lustrous woodland, swings the trailer from the crag;
+Droops the heavy-blossom'd bower, hangs the heavy-fruited tree—
+Summer isles of Eden lying in dark-purple spheres of sea.
+There methinks would be enjoyment more than in this march of mind,
+In the steamship, in the railway, in the thoughts that shake mankind.
+There the passions cramp'd no longer shall have scope and breathing-space;
+I will take some savage woman, she shall rear my dusky race.
+Iron-jointed, supple-sinew'd, they shall dive, and they shall run,
+Catch the wild goat by the hair, and hurl their lances in the sun;
+Whistle back the parrot's call, and leap the rainbows of the brooks.
+Not with blinded eyesight poring over miserable books———
+Fool, again the dream, the fancy! but I know my words are wild,
+But I count the gray barbarian lower than the Christian child.
+I, to herd with narrow foreheads, vacant of our glorious gains,
+Like a beast with lower pleasures, like a beast with lower pains!
+Mated with a squalid savage—what to me were sun or clime?
+I the heir of all the ages, in the foremost files of time—
+I that rather held it better men should perish one by one,
+Than that earth should stand at gaze like Joshua's moon in Ajalon!
+Not in vain the distance beacons. Forward, forward let us range.
+Let the great world spin for ever down the ringing grooves of change.
+Thro' the shadow of the globe we sweep into the younger day:
+Better fifty years of Europe than a cycle of Cathay.
+Mother-Age (for mine I knew not) help me as when life begun:
+Rift the hills, and roll the waters, flash the lightnings, weigh the Sun—
+O, I see the crescent promise of my spirit hath not set.
+Ancient founts of inspiration well thro' all my fancy yet.
+Howsoever these things be, a long farewell to Locksley Hall!
+Now for me the woods may wither, now for me the roof-tree fall.
+Comes a vapour from the margin, blackening over heath and holt,
+Cramming all the blast before it, in its breast a thunderbolt.
+Let it fall on Locksley Hall, with rain or hail, or fire or snow;
+For the mighty wind arises, roaring seaward, and I go.

--- a/poems/alfred-tennyson/mariana-in-the-south.txt
+++ b/poems/alfred-tennyson/mariana-in-the-south.txt
@@ -1,0 +1,12 @@
+With one black shadow at its feet,
+The house thro' all the level shines,
+Close-latticed to the brooding heat,
+And silent in its dusty vines:
+A faint-blue ridge upon the right,
+An empty river-bed before,
+And shallows on a distant shore,
+In glaring sand and inlets bright.
+But "Ave Mary," made she moan,
+And "Ave Mary," night and morn,
+And "Ah," she sang, "to be all alone,
+To live forgotten, and love forlorn."

--- a/poems/alfred-tennyson/morte-darthur.txt
+++ b/poems/alfred-tennyson/morte-darthur.txt
@@ -1,0 +1,302 @@
+So all day long the noise of battle roll'd
+Among the mountains by the winter sea;
+Until King Arthur's table, man by man,
+Had fall'n in Lyonness about their Lord,
+King Arthur: then, because his wound was deep,
+The bold Sir Bedivere uplifted him,
+Sir Bedivere, the last of all his knights,
+And bore him to a chapel nigh the field,
+A broken chancel with a broken cross,
+That stood on a dark strait of barren land.
+On one side lay the Ocean, and on one
+Lay a great water, and the moon was full.
+Then spake King Arthur to Sir Bedivere:
+"The sequel of to-day unsolders all
+The goodliest fellowship of famous knights
+Whereof this world holds record. Such a sleep
+They sleep—the men I loved. I think that we
+Shall never more, at any future time,
+Delight our souls with talk of knightly deeds,
+Walking about the gardens and the halls
+Of Camelot, as in the days that were.
+I perish by this people which I made,—
+Tho' Merlin sware that I should come again
+To rule once more—but let what will be, be,
+I am so deeply smitten thro' the helm
+That without help I cannot last till morn.
+Thou therefore take my brand Excalibur,
+Which was my pride: for thou rememberest how
+In those old days, one summer noon, an arm
+Rose up from out the bosom of the lake,
+Clothed in white samite, mystic, wonderful,
+Holding the sword—and how I row'd across
+And took it, and have worn it, like a king:
+And, wheresoever I am sung or told
+In aftertime, this also shall be known:
+But now delay not: take Excalibur,
+And fling him far into the middle mere:
+Watch what thou seëst, and lightly bring me word."
+To him replied the bold Sir Bedivere:
+"It is not meet, Sir King, to leave thee thus,
+Aidless, alone, and smitten thro' the helm.
+A little thing may harm a wounded man.
+Yet I thy hest will all perform at full,
+Watch what I see, and lightly bring thee word."
+So saying, from the ruin'd shrine he stept
+And in the moon athwart the place of tombs,
+Where lay the mighty bones of ancient men,
+Old knights, and over them the sea-wind sang
+Shrill, chill, with flakes of foam. He, stepping down
+By zig-zag paths, and juts of pointed rock,
+Came on the shining levels of the lake.
+There drew he forth the brand Excalibur,
+And o'er him, drawing it, the winter moon,
+Brightening the skirts of a long cloud, ran forth
+And sparkled keen with frost against the hilt:
+For all the haft twinkled with diamond sparks,
+Myriads of topaz-lights, and jacinth-work
+Of subtlest jewellery. He gazed so long
+That both his eyes were dazzled, as he stood,
+This way and that dividing the swift mind,
+In act to throw: but at the last it seem'd
+Better to leave Excalibur conceal'd
+There in the many-knotted waterflags,
+That whistled stiff and dry about the marge.
+So strode he back slow to the wounded king.
+Then spake King Arthur to Sir Bedivere:
+"Hast thou perform'd my mission which I gave?
+What is it thou hast seen? or what hast heard?"
+And answer made the bold Sir Bedivere:
+"I heard the ripple washing in the reeds,
+And the wild water lapping on the crag."
+To whom replied King Arthur, faint and pale:
+"Thou hast betray'd thy nature and thy name,
+Not rendering true answer, as beseem'd
+Thy fëalty, nor like a noble knight:
+For surer sign had follow'd, either hand,
+Or voice, or else a motion of the mere.
+This is a shameful thing for men to lie.
+Yet now, I charge thee, quickly go again
+As thou art lief and dear, and do the thing
+I bad thee, watch, and lightly bring me word."
+Then went Sir Bedivere the second time
+Counting the dewy pebbles, fix'd in thought;
+But when he saw the wonder of the hilt,
+How curiously and strangely chased, he smote
+His palms together, and he cried aloud,
+"And if indeed I cast the brand away,
+Surely a precious thing, one worthy note,
+Should thus be lost for ever from the earth,
+Which might have pleased the eyes of many men.
+What good should follow this, if this were done?
+What harm, undone? deep harm to disobey,
+Seeing obedience is the bond of rule,
+Were it well to obey then, if a king demand
+An act unprofitable against himself?
+The king is sick, and knows not what he does.
+What record, or what relic of my lord
+Should be to aftertime, but empty breath
+And rumours of a doubt? but were this kept,
+Stored in some treasure-house of mighty kings,
+Some one might show it at a joust of arms,
+Saying, 'King Arthur's sword, Excalibur,
+Wrought by the lonely maiden of the Lake.
+Nine years she wrought it, sitting in the deeps
+Upon the hidden bases of the hills.'
+So might some old man speak in the aftertime
+To all the people, winning reverence.
+But now much honour and much fame were lost."
+So spake he, clouded with his own conceit,
+And hid Excalibur the second time,
+And so strode back slow to the wounded King.
+Then spoke King Arthur, breathing heavily:
+"What is it thou hast seen? or what hast heard?"
+And answer made the bold Sir Bedivere:
+"I heard the water lapping on the crag,
+And the long ripple washing in the reeds."
+To whom replied King Arthur, much in wrath:
+"Ah, miserable and unkind, untrue,
+Unknightly, traitor-hearted! Woe is me!
+Authority forgets a dying king,
+Laid widow'd of the power in his eye
+That bow'd the will. I see thee what thou art.
+For thou, the latest-left of all my knights,
+In whom should meet the offices of all,
+Thou wouldst betray me for the precious hilt;
+Either from lust of gold, or like a girl
+Valuing the giddy pleasure of the eyes.
+Yet, for a man may fail in duty twice,
+And the third time may prosper, get thee hence:
+But, if thou spare to fling Excalibur,
+I will arise and slay thee with my hands."
+Then quickly rose Sir Bedivere, and ran,
+And, leaping down the ridges lightly, plunged
+Among the bulrush-beds, and clutch'd the sword,
+And strongly wheel'd and threw it. The great brand
+Made lightnings in the splendour of the moon,
+And flashing round and round, and whirl'd in an arch,
+Shot like a streamer of the northern morn,
+Seen where the moving isles of winter shock
+By night, with noises of the northern sea.
+So flash'd and fell the brand Excalibur:
+But ere he dipt the surface, rose an arm
+Clothed in white samite, mystic, wonderful,
+And caught him by the hilt, and brandish'd him
+Three times, and drew him under in the meer.
+And lightly went the other to the King.
+Then spoke King Arthur, drawing thicker breath:
+"Now see I by thine eyes that this is done.
+Speak out: what is it thou hast heard, or seen!"
+And answer made the bold Sir Bedivere:
+"Sir King, I closed mine eyelids, lest the gems
+Should blind my purpose, for I never saw,
+Nor shall see, here or elsewhere, till I die,
+Not though I live three lives of mortal men,
+So great a miracle as yonder hilt.
+Then with both hands I flung him, wheeling him;
+But when I look'd again, behold an arm,
+Clothed in white samite, mystic, wonderful,
+That caught him by the hilt, and brandish'd him
+Three times, and drew him under in the meer."
+And answer made King Arthur, breathing hard:
+"My end draws nigh; 'tis time that I were gone.
+Make broad thy shoulders to receive my weight,
+And bear me to the margin; yet I fear
+My wound hath taken cold, and I shall die."
+So saying, from the pavement he half rose,
+Slowly, with pain, reclining on his arm,
+And looking wistfully with wide blue eyes
+As in a picture. Him Sir Bedivere
+Remorsefully regarded thro' his tears,
+And would have spoken, but he found not words,
+Then took with care, and kneeling on one knee,
+O'er both his shoulders drew the languid hands,
+And rising bore him thro' the place of tombs.
+But, as he walk'd, King Arthur panted hard,
+Like one that feels a nightmare on his bed
+When all the house is mute. So sigh'd the King,
+Muttering and murmuring at his ear "Quick, quick!
+I fear it is too late, and I shall die."
+But the other swiftly strode from ridge to ridge,
+Clothed with his breath, and looking, as he walk'd,
+Larger than human on the frozen hills.
+He heard the deep behind him, and a cry
+Before. His own thought drove him like a goad.
+Dry clash'd his harness in the icy caves
+And barren chasms, and all to left and right
+The bare black cliff clang'd round him, as he based
+His feet on juts of slippery crag that rang
+Sharp-smitten with the dint of armed heels—
+And on a sudden, lo! the level lake,
+And the long glories of the winter moon.
+Then saw they how there hove a dusky barge,
+Dark as a funeral scarf from stem to stern,
+Beneath them; and descending they were ware
+That all the decks were dense with stately forms
+Black-stoled, black-hooded, like a dream—by these
+Three Queens with crowns of gold—and from them rose
+A cry that shiver'd to the tingling stars,
+And, as it were one voice, an agony
+Of lamentation, like a wind, that shrills
+All night in a waste land, where no one comes,
+Or hath come, since the making of the world.
+Then murmur'd Arthur, "Place me in the barge,"
+And to the barge they came. There those three Queens
+Put forth their hands, and took the King, and wept.
+But she, that rose the tallest of them all
+And fairest, laid his head upon her lap,
+And loosed the shatter'd casque, and chafed his hands,
+And call'd him by his name, complaining loud,
+And dropping bitter tears against his brow
+Striped with dark blood: for all his face was white
+And colourless, and like the wither'd moon
+Smote by the fresh beam of the springing east;
+And all his greaves and cuisses dash'd with drops
+Of onset; and the light and lustrous curls—
+That made his forehead like a rising sun
+High from the däis-throne—were parch'd with dust,
+Or, clotted into points and hanging loose,
+Mix'd with the knightly growth that fringed his lips.
+So like a shatter'd column lay the King;
+Not like that Arthur who, with lance in rest,
+From spur to plume a star of tournament,
+Shot thro' the lists at Camelot, and charged
+Before the eyes of ladies and of kings.
+Then loudly cried the bold Sir Bedivere,
+"Ah! my Lord Arthur, whither shall I go?
+Where shall I hide my forehead and my eyes?
+For now I see the true old times are dead,
+When every morning brought a noble chance,
+And every chance brought out a noble knight.
+Such times have been not since the light that led
+The holy Elders with the gift of myrrh.
+But now the whole round table is dissolved
+Which was an image of the mighty world;
+And I, the last, go forth companionless,
+And the days darken round me, and the years,
+Among new men, strange faces, other minds."
+And slowly answer'd Arthur from the barge:
+"The old order changeth, yielding place to new,
+And God fulfils himself in many ways,
+Lest one good custom should corrupt the world.
+Comfort thyself: what comfort is in me?
+I have lived my life, and that which I have done
+May He within himself make pure! but thou—
+If thou shouldst never see my face again,
+Pray for my soul. More things are wrought by prayer
+Than this world dreams of. Wherefore, let thy voice
+Rise like a fountain for me night and day.
+For what are men better than sheep or goats
+That nourish a blind life within the brain,
+If, knowing God, they lift not hands of prayer
+Both for themselves and those who call them friend?
+For so the whole round earth is every way
+Bound by gold chains about the feet of God.
+But now farewell. I am going a long way
+With these thou seëst—if indeed I go—
+(For all my mind is clouded with a doubt)
+To the island-valley of Avilion;
+Where falls not hail, or rain, or any snow,
+Nor ever wind blows loudly; but it lies
+Deep-meadow'd, happy, fair with orchard-lawns
+And bowery hollows crown'd with summer sea,
+Where I will heal me of my grievous wound."
+So said he, and the barge with oar and sail
+Moved from the brink, like some full-breasted swan
+That, fluting a wild carol ere her death,
+Ruffles her pure cold plume, and takes the flood
+With swarthy webs. Long stood Sir Bedivere
+Revolving many memories, till the hull
+Look'd one black dot against the verge of dawn,
+And on the meer the wailing died away.
+Here ended Hall, and our last light, that long
+Had wink'd and threaten'd darkness, flared and fell:
+At which the Parson, sent to sleep with sound,
+And waked with silence, grunted "Good!" but we
+Sat rapt: it was the tone with which he read—
+Perhaps some modern touches here and there
+Redeem'd it from the charge of nothingness—
+Or else we loved the man, and prized his work;
+I know not: but we sitting, as I said,
+The cock crew loud; as at that time of year
+The lusty bird takes every hour for dawn:
+Then Francis, muttering, like a man ill-used,
+"There now—that's nothing!" drew a little back,
+And drove his heel into the smoulder'd log,
+That sent a blast of sparkles up the flue:
+And so to bed; where yet in sleep I seem'd
+To sail with Arthur under looming shores,
+Point after point, till on to dawn, when dreams
+Begin to feel the truth and stir of day,
+To me, methought, who waited with a crowd,
+There came a bark that, blowing forward, bore
+King Arthur, like a modern gentleman
+Of stateliest port; and all the people cried,
+"Arthur is come again: he cannot die."
+Then those that stood upon the hills behind
+Repeated—"Come again, and thrice as fair;"
+And, further inland, voices echoed—"Come
+With all good things, and war shall be no more."
+At this a hundred bells began to peal,
+That with the sound I woke, and heard indeed
+The clear church-bells ring in the Christmas morn.

--- a/poems/alfred-tennyson/the-palace-of-art.txt
+++ b/poems/alfred-tennyson/the-palace-of-art.txt
@@ -1,0 +1,292 @@
+I built my soul a lordly pleasure-house,
+Wherein at ease for aye to dwell.
+I said, "O Soul, make merry and carouse,
+Dear soul, for all is well."
+A huge crag-platform, smooth as burnish'd brass,
+I chose. The ranged ramparts bright
+From level meadow-bases of deep grass
+Suddenly scaled the light.
+Thereon I built it firm. Of ledge or shelf
+The rock rose clear, or winding stair.
+My soul would live alone unto herself
+In her high palace there.
+And "while the world runs round and round," I said,
+"Reign thou apart, a quiet king,
+Still as, while Saturn whirls his stedfast shade
+Sleeps on his luminous ring."
+To which my soul made answer readily:
+"Trust me, in bliss I shall abide
+In this great mansion, that is built for me,
+So royal-rich and wide."
+Four courts I made, East, West and South and North,
+In each a squared lawn, wherefrom
+The golden gorge of dragons spouted forth
+A flood of fountain-foam.
+And round the cool green courts there ran a row
+Of cloisters, branch'd like mighty woods,
+Echoing all night to that sonorous flow
+Of spouted fountain-floods.
+And round the roofs a gilded gallery
+That lent broad verge to distant lands,
+Far as the wild swan wings, to where the sky
+Dipt down to sea and sands.
+From those four jets four currents in one swell
+Across the mountain stream'd below
+In misty folds, that floating as they fell
+Lit up a torrent-bow.
+And high on every peak a statue seem'd
+To hang on tiptoe, tossing up
+A cloud of incense of all odour steam'd
+From out a golden cup.
+So that she thought, "And who shall gaze upon
+My palace with unblinded eyes,
+While this great bow will waver in the sun,
+And that sweet incense rise?"
+For that sweet incense rose and never fail'd,
+And, while day sank or mounted higher,
+The light aerial gallery, golden-rail'd,
+Burnt like a fringe of fire.
+Likewise the deep-set windows, stain'd and traced,
+Would seem slow-flaming crimson fires
+From shadow'd grots of arches interlaced,
+And tipt with frost-like spires.
+Full of long-sounding corridors it was,
+That over-vaulted grateful gloom,
+Thro' which the livelong day my soul did pass,
+Well-pleased, from room to room.
+Full of great rooms and small the palace stood,
+All various, each a perfect whole
+From living Nature, fit for every mood
+And change of my still soul.
+For some were hung with arras green and blue,
+Showing a gaudy summer-morn,
+Where with puff'd cheek the belted hunter blew
+His wreathed bugle-horn.
+One seemed all dark and red—a tract of sand,
+And some one pacing there alone,
+Who paced for ever in a glimmering land,
+Lit with a low large moon.
+One show'd an iron coast and angry waves.
+You seemed to hear them climb and fall
+And roar rock-thwarted under bellowing caves,
+Beneath the windy wall.
+And one, a full-fed river winding slow
+By herds upon an endless plain,
+The ragged rims of thunder brooding low,
+With shadow-streaks of rain.
+And one, the reapers at their sultry toil.
+In front they bound the sheaves. Behind
+Were realms of upland, prodigal in oil,
+And hoary to the wind.
+And one a foreground black with stones and slags,
+Beyond, a line of heights, and higher
+All barr'd with long white cloud the scornful crags,
+And highest, snow and fire.
+And one, an English home—gray twilight pour'd
+On dewey pastures, dewey trees,
+Softer than sleep—all things in order stored,
+A haunt of ancient Peace.
+Nor these alone, but every landscape fair,
+As fit for every mood of mind,
+Or gay, or grave, or sweet, or stern, was there,
+Not less than truth design'd.
+*    *    *    *Or the maid-mother by a crucifix.
+In tracts of pasture sunny-warm.
+Beneath branch-work of costly sardonyx
+Sat smiling, babe in arm.
+Or in a clear-wall'd city on the sea,
+Near gilded organ-pipes, her hair
+with white roses, slept Saint Cecily;
+An angel look'd at her.
+Or thronging all one porch of Paradise
+A group of Houris bow'd to see
+The dying Islamite, with hands and eyes
+That said, We wait for thee.
+Or mythic Uther's deeply-wounded son
+In some fair space of sloping greens
+Lay, dozing in the vale of Avalon,
+And watch'd by weeping queens.
+Or hollowing one hand against his ear,
+To list a foot-fall, ere he saw
+The wood-nymph, stay'd the Tuscan king to hear
+Of wisdom and of law.
+Or over hills with peaky tops engrail'd,
+And many a tract of palm and rice,
+The throne of Indian Cama slowly sail'd
+A summer fann'd with spice.
+Or sweet Europa's mantle blew unclasp'd,
+From off her shoulder backward borne:
+From one hand droop'd a crocus: one hand grasp'd
+The mild bull's golden horn.
+Or else flush'd Ganymede, his rosy thigh
+Half-buried in the Eagle's down,
+Sole as a flying star shot thro' the sky
+Above the pillar'd town.
+Nor these alone: but every legend fair
+Which the supreme Caucasian mind
+Carved out of Nature for itself was there'
+Not less than life design'd.
+*    *    *    *Then in the towers I placed great bells that swung,
+Moved of themselves, with silver sound;
+And with choice paintings of wise men I hung
+The royal dais round.
+For there was Milton like a seraph strong,
+Beside him Shakespeare bland and mild;
+And there the world-worn Dante grasp'd his song,
+And somewhat grimly smiled.
+And there the Ionian father of the rest;
+A million wrinkles carved his skin;
+A hundred winters snow'd upon his breast,
+From cheek and throat and chin.
+Above, the fair hall-ceiling stately-set
+Many an arch high up did lift,
+And angels rising and descending met
+With interchange of gift.
+Below was all mosaic choicely plann'd
+With cycles of the human tale
+Of this wide world, the times of every land
+So wrought they will not fail.
+The people here, a beast of burden slow,
+Toil'd onward, prick'd with goads and stings;
+Here play'd, a tiger, rolling to and fro
+The heads and crowns of kings;
+Here rose, an athlete, strong to break or bind
+All force in bonds that might endure,
+And here once more like some sick man declined,
+And trusted any cure.
+But over these she trod: and those great bells
+Began to chime. She took her throne:
+She sat betwixt the shining Oriels.
+To sing her songs alone.
+And thro' the topmost oriels' coloured flame
+Two godlike faces gazed below;
+Plato the wise, and large-brow'd Verulam,
+The first of those who know.
+And all those names that in their motion were
+Full-welling fountain-heads of change,
+Betwixt the slender shafts were blazon'd fair
+In diverse raiment strange:
+Thro' which the lights' rose, amber, emerald, blue,
+Flush'd in her temples and her eyes,
+And from her lips, as morn from Memnon, drew
+Rivers of melodies.
+No nightingale delighteth to prolong
+Her low preamble all alone,
+More than my soul to hear her echo'd song
+Throb thro' the ribbed stone.
+Singing and murmuring in her feastful mirth,
+Joying to feel herself alive.
+Lord over Nature, Lord of the visible earth.
+Lord of the senses five;
+Communing with herself: "All these are mine,
+And let the world have peace or wars,
+'Tis one to me." She—when young night divine
+Crown'd dying day with stars,
+Making sweet close of his delicious toils—
+Lit light in wreaths and anadems,
+And pure quintessences of precious oils
+In hollow'd moons of gems,
+To mimic heaven; and clapt her hands and cried,
+"I marvel if my still delight
+In this great house so royal-rich, and wide,
+Be flatter'd to the height.
+"From shape to shape at first within the womb
+The brain is modell'd," she began,
+"And thro' all phases of all thought I come
+Into the perfect man.
+"All Nature widens upward. Evermore
+The simpler essence lower lies:
+More complex is more perfect, owning more
+Discourse, more widely wise."
+Then of the moral instinct would she prate,
+And of the rising from the dead,
+As hers by right of full-accomplish'd Fate;
+And at the last she said:
+"I take possession of man's mind and deed.
+I live in all things great and small.
+I sit apart holding no forms of creeds,
+But contemplating all."
+*    *    *    *Full oft the riddle of the painful earth
+Flash'd thro' her as she sat alone,
+Yet not the less held she her solemn mirth,
+And intellectual throne.
+Of full-sphered contemplation. So three years
+She throve, but on the fourth she fell.
+Like Herod, when the shout was in his ears,
+Struck thro' with pangs of hell.
+Lest she should fail and perish utterly,
+God, before whom ever lie bare
+The abysmal deeps of Personality,
+Plagued her with sore despair.
+When she would think, where'er she turn'd her sight,
+The airy hand confusion wrought,
+Wrote, "Mene, mene," and divided quite
+The kingdom of her thought.
+Deep dread and loathing of her solitude
+Fell on her, from which mood was born
+Scorn of herself; again, from out that mood
+Laughter at her self-scorn.
+"What! is not this my place of strength," she said,
+"My spacious mansion built for me,
+Whereof the strong foundation-stones were laid
+Since my first memory?"
+But in dark corners of her palace stood
+Uncertain shapes, and unawares
+On white-eyed phantasms weeping tears of blood,
+And horrible nightmares,
+And hollow shades enclosing hearts of flame,
+And, with dim fretted foreheads all,
+On corpses three-months-old at noon she came,
+That stood against the wall.
+A spot of dull stagnation, without light
+Or power of movement, seem'd my soul,
+Mid onward-sloping motions infinite
+Making for one sure goal.
+A still salt pool, lock'd in with bars of sand;
+Left on the shore; that hears all night
+The plunging seas draw backward from the land
+Their moon-led waters white.
+A star that with the choral starry dance
+Join'd not, but stood, and standing saw
+The hollow orb of moving Circumstance
+Roll'd round by one fix'd law.
+Back on herself her serpent pride had curl'd.
+"No voice," she shriek'd in that lone hall,
+"No voice breaks thro' the stillness of this world:
+One deep, deep silence all!"
+She, mouldering with the dull earth's mouldering sod,
+Inwrapt tenfold in slothful shame,
+Lay there exiled from eternal God,
+Lost to her place and name;
+And death and life she hated equally,
+And nothing saw, for her despair,
+But dreadful time, dreadful eternity,
+No comfort anywhere;
+Remaining utterly confused with fears,
+And ever worse with growing time,
+And ever unrelieved by dismal tears,
+And all alone in crime:
+Shut up as in a crumbling tomb, girt round
+With blackness as a solid wall,
+Far off she seem'd to hear the dully sound
+Of human footsteps fall.
+As in strange lands a traveller walking slow,
+In doubt and great perplexity,
+A little before moon-rise hears the low
+Moan of an unknown sea;
+And knows not if it be thunder or a sound
+Of rocks thrown down, or one deep cry
+Of great wild beasts; then thinketh, "I have found
+A new land, but I die."
+She howl'd aloud, "I am on fire within.
+There comes no murmur of reply.
+What is it that will take away my sin,
+And save me lest I die?"
+So when four years were wholly finished,
+She threw her royal robes away.
+"Make me a cottage in the vale," she said,
+"Where I may mourn and pray.
+"Yet pull not down my palace towers, that are
+So lightly, beautifully built:
+Perchance I may return with others there
+When I have purged my guilt."

--- a/scripts/ingest-wikisource-tennyson-depth.mjs
+++ b/scripts/ingest-wikisource-tennyson-depth.mjs
@@ -1,0 +1,219 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import yaml from "../site/node_modules/js-yaml/dist/js-yaml.mjs";
+
+const COLLECTION_TITLE = "Poems (Tennyson, 1843)";
+const COLLECTION_SOURCE_URL = "https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)";
+
+const POEMS = [
+  {
+    author: "Alfred Lord Tennyson",
+    author_slug: "alfred-tennyson",
+    century: 19,
+    slug: "mariana-in-the-south",
+    title: "Mariana in the South",
+    published_year: 1843,
+    source_url: "https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_1/Mariana_in_the_South",
+    page_title: "Poems (Tennyson, 1843)/Volume 1/Mariana in the South",
+    start_line: "With one black shadow at its feet,",
+    end_line: 'To live forgotten, and love forlorn."',
+  },
+  {
+    author: "Alfred Lord Tennyson",
+    author_slug: "alfred-tennyson",
+    century: 19,
+    slug: "the-palace-of-art",
+    title: "The Palace of Art",
+    published_year: 1843,
+    source_url: "https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_1/The_Palace_of_Art",
+    page_title: "Poems (Tennyson, 1843)/Volume 1/The Palace of Art",
+    start_line: "I built my soul a lordly pleasure-house,",
+    end_line: 'When I have purged my guilt."',
+  },
+  {
+    author: "Alfred Lord Tennyson",
+    author_slug: "alfred-tennyson",
+    century: 19,
+    slug: "morte-darthur",
+    title: "Morte d’Arthur",
+    published_year: 1842,
+    source_url: "https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_2/Morte_d%27Arthur",
+    page_title: "Poems (Tennyson, 1843)/Volume 2/Morte d'Arthur",
+    start_line: "So all day long the noise of battle roll'd",
+    end_line: "The clear church-bells ring in the Christmas morn.",
+  },
+  {
+    author: "Alfred Lord Tennyson",
+    author_slug: "alfred-tennyson",
+    century: 19,
+    slug: "locksley-hall",
+    title: "Locksley Hall",
+    published_year: 1842,
+    source_url: "https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_2/Locksley_Hall",
+    page_title: "Poems (Tennyson, 1843)/Volume 2/Locksley Hall",
+    start_line: "Comrades, leave me here a little, while as yet 'tis early morn:",
+    end_line: "For the mighty wind arises, roaring seaward, and I go.",
+  },
+  {
+    author: "Alfred Lord Tennyson",
+    author_slug: "alfred-tennyson",
+    century: 19,
+    slug: "lady-clare",
+    title: "Lady Clare",
+    published_year: 1842,
+    source_url: "https://en.wikisource.org/wiki/Poems_(Tennyson,_1843)/Volume_2/Lady_Clare",
+    page_title: "Poems (Tennyson, 1843)/Volume 2/Lady Clare",
+    start_line: "Lord Ronald courted Lady Clare,",
+    end_line: 'And you shall still be Lady Clare."',
+  },
+];
+
+function decodeHtml(value) {
+  return value
+    .replace(/&#32;/g, " ")
+    .replace(/&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&mdash;/g, "—")
+    .replace(/&ndash;/g, "–")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&#160;/g, " ")
+    .replace(/&#91;/g, "[")
+    .replace(/&#93;/g, "]")
+    .replace(/&#95;/g, "_")
+    .replace(/&#8203;/g, "")
+    .replace(/&#8212;/g, "—")
+    .replace(/&#8217;/g, "’")
+    .replace(/&#8220;/g, "“")
+    .replace(/&#8221;/g, "”")
+    .replace(/&#8230;/g, "…")
+    .replace(/&#198;/g, "Æ")
+    .replace(/&#230;/g, "æ")
+    .replace(/&#339;/g, "œ")
+    .replace(/&#42;/g, "*");
+}
+
+function cleanRenderedText(html) {
+  let body = html.slice(html.indexOf('<div class="prp-pages-output"'));
+  const referencesIndex = body.indexOf('<div class="mw-references-wrap');
+  if (referencesIndex !== -1) body = body.slice(0, referencesIndex);
+
+  body = body.replace(/<style[\s\S]*?<\/style>/g, "");
+  body = body.replace(/<link[^>]*>/g, "");
+  body = body.replace(/<sup[^>]*>.*?<\/sup>/gs, "");
+  body = body.replace(/<span[^>]*class="pagenum[\s\S]*?<\/span><\/span>/g, "");
+  body = body.replace(/<span[^>]*class="wst-gap[^"]*"[^>]*><\/span>/g, "    ");
+  body = body.replace(/<br\s*\/?>\n?/g, "\n");
+  body = body.replace(/<\/p>\s*<p>/g, "\n\n");
+  body = body.replace(/<[^>]+>/g, "");
+
+  return decodeHtml(body)
+    .replace(/\u00a0/g, " ")
+    .replace(/\n[ \t]+/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function normalizeMatch(value) {
+  return value
+    .replace(/[’‘]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractPoem(text, startLine, endLine) {
+  const lines = text.split("\n").map((line) => line.trimEnd());
+  const start = lines.findIndex((line) => normalizeMatch(line) === normalizeMatch(startLine));
+  if (start === -1) {
+    throw new Error(`Start line not found: ${startLine}`);
+  }
+
+  const end = lines.findIndex(
+    (line, index) => index >= start && normalizeMatch(line) === normalizeMatch(endLine),
+  );
+  if (end === -1) {
+    throw new Error(`End line not found: ${endLine}`);
+  }
+
+  return lines
+    .slice(start, end + 1)
+    .map((line) => line.replace(/^\*\s+\*\s+\*\s+\*(.*)$/u, "$1").trimEnd())
+    .map((line) => line.replace("*    *    *    *Four courts I made, East, West and South and North,", "Four courts I made, East, West and South and North,"))
+    .map((line) => line.replace("*    *    *    *Full of long-sounding corridors it was,", "Full of long-sounding corridors it was,"))
+    .map((line) => (line === "over-vaulted grateful gloom," ? "That over-vaulted grateful gloom," : line))
+    .filter((line) => line.trim() !== "")
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchPoemText(pageTitle, startLine, endLine) {
+  const url =
+    "https://en.wikisource.org/w/api.php?action=parse&format=json&formatversion=2&prop=text&page=" +
+    encodeURIComponent(pageTitle);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Wikisource page ${pageTitle} (${response.status})`);
+  }
+
+  const json = await response.json();
+  if (!json.parse?.text) {
+    throw new Error(`Wikisource parse failed for ${pageTitle}`);
+  }
+
+  return extractPoem(cleanRenderedText(json.parse.text), startLine, endLine);
+}
+
+function buildMeta(poem) {
+  return yaml.dump(
+    {
+      id: `${poem.author_slug}/${poem.slug}`,
+      slug: poem.slug,
+      author: poem.author,
+      author_slug: poem.author_slug,
+      title: poem.title,
+      century: poem.century,
+      text_path: `poems/${poem.author_slug}/${poem.slug}.txt`,
+      text_in_repo: true,
+      source_label: "Wikisource",
+      source_url: poem.source_url,
+      public_domain_rationale:
+        `Public domain in the United States: first published ${poem.published_year} ` +
+        `(pre-1929); text via English Wikisource.`,
+      collection_title: COLLECTION_TITLE,
+      collection_source_url: COLLECTION_SOURCE_URL,
+    },
+    { lineWidth: 1000 },
+  );
+}
+
+async function main() {
+  let created = 0;
+
+  for (const poem of POEMS) {
+    const poemsDir = path.join("poems", poem.author_slug);
+    const metaDir = path.join("meta", poem.author_slug);
+    await fs.mkdir(poemsDir, { recursive: true });
+    await fs.mkdir(metaDir, { recursive: true });
+
+    const textPath = path.join(poemsDir, `${poem.slug}.txt`);
+    const metaPath = path.join(metaDir, `${poem.slug}.yml`);
+
+    const text = await fetchPoemText(poem.page_title, poem.start_line, poem.end_line);
+    await fs.writeFile(textPath, `${text}\n`);
+    await fs.writeFile(metaPath, buildMeta(poem));
+    created += 1;
+    console.log(`${poem.author}: created ${poem.slug}`);
+  }
+
+  console.log(`Total created: ${created}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add 5 more canonical Alfred Lord Tennyson poems from English Wikisource
- add matching metadata sidecars
- add a repeatable Tennyson Wikisource ingest script

## Testing
- cd site && npm run build